### PR TITLE
feat: add theme switching support

### DIFF
--- a/lib/oqdo_application.dart
+++ b/lib/oqdo_application.dart
@@ -7,6 +7,7 @@ import 'package:oqdo_mobile_app/screens/login/splash_screen.dart';
 import 'package:oqdo_mobile_app/theme/oqdo_theme_data.dart';
 import 'package:oqdo_mobile_app/utils/constants.dart';
 import 'package:oqdo_mobile_app/utils/shared_preferences_manager.dart';
+import 'package:oqdo_mobile_app/providers/theme_provider.dart';
 import 'package:oqdo_mobile_app/viewmodels/ProfileViewModel.dart';
 import 'package:oqdo_mobile_app/viewmodels/location_selection_viewmodel.dart';
 import 'package:oqdo_mobile_app/viewmodels/notification_provider.dart';
@@ -55,46 +56,55 @@ class OQDOApplication extends StatefulWidget {
 
 class _OQDOApplicationState extends State<OQDOApplication> {
   String? isLogin = '0';
+  late ThemeProvider _themeProvider;
 
   @override
   void initState() {
     super.initState();
-    // getData(context);
+    _themeProvider = ThemeProvider();
+    _themeProvider.loadTheme();
   }
 
   @override
   Widget build(BuildContext context) {
     return MultiProvider(
       providers: [
+        ChangeNotifierProvider<ThemeProvider>.value(value: _themeProvider),
         ChangeNotifierProvider<ChatProvider>(create: (_) => ChatProvider()),
         ChangeNotifierProvider<ProfileViewModel>(create: (_) => ProfileViewModel()),
         ChangeNotifierProvider<NotificationProvider>(create: (_) => NotificationProvider()),
         ChangeNotifierProvider<LocationSelectionViewModel>(create: (_) => LocationSelectionViewModel()),
       ],
-      child: MaterialApp(
-          builder: (context, widget) => MediaQuery(
-                data: MediaQuery.of(context).copyWith(textScaler: const TextScaler.linear(1.0)),
-                child: ResponsiveWrapper.builder(
-                  BouncingScrollWrapper.builder(context, widget!),
-                  maxWidth: 1200,
-                  minWidth: 450,
-                  defaultScale: true,
-                  breakpoints: [
-                    const ResponsiveBreakpoint.resize(450, name: MOBILE),
-                    const ResponsiveBreakpoint.autoScale(800, name: TABLET),
-                    const ResponsiveBreakpoint.autoScale(1000, name: TABLET),
-                    const ResponsiveBreakpoint.resize(1200, name: DESKTOP),
-                    const ResponsiveBreakpoint.autoScale(2460, name: "4K"),
-                  ],
-                ),
-              ),
-          onGenerateRoute: RouteGenerator.generateRoute,
-          title: Constants.APP_NAME,
-          home: const Splash(),
-          navigatorKey: navigatorKey,
-          scaffoldMessengerKey: rootScaffoldMessangerKey,
-          debugShowCheckedModeBanner: false,
-          theme: OQDOThemeData.lightThemeData),
+      child: Consumer<ThemeProvider>(
+        builder: (context, themeProvider, child) {
+          return MaterialApp(
+              builder: (context, widget) => MediaQuery(
+                    data: MediaQuery.of(context).copyWith(textScaler: const TextScaler.linear(1.0)),
+                    child: ResponsiveWrapper.builder(
+                      BouncingScrollWrapper.builder(context, widget!),
+                      maxWidth: 1200,
+                      minWidth: 450,
+                      defaultScale: true,
+                      breakpoints: [
+                        const ResponsiveBreakpoint.resize(450, name: MOBILE),
+                        const ResponsiveBreakpoint.autoScale(800, name: TABLET),
+                        const ResponsiveBreakpoint.autoScale(1000, name: TABLET),
+                        const ResponsiveBreakpoint.resize(1200, name: DESKTOP),
+                        const ResponsiveBreakpoint.autoScale(2460, name: "4K"),
+                      ],
+                    ),
+                  ),
+              onGenerateRoute: RouteGenerator.generateRoute,
+              title: Constants.APP_NAME,
+              home: const Splash(),
+              navigatorKey: navigatorKey,
+              scaffoldMessengerKey: rootScaffoldMessangerKey,
+              debugShowCheckedModeBanner: false,
+              theme: OQDOThemeData.lightThemeData,
+              darkTheme: OQDOThemeData.darkThemeData,
+              themeMode: themeProvider.themeMode);
+        },
+      ),
     );
   }
 }

--- a/lib/providers/theme_provider.dart
+++ b/lib/providers/theme_provider.dart
@@ -1,0 +1,59 @@
+import 'package:flutter/material.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+enum ThemeType { light, dark, system }
+
+class ThemeProvider extends ChangeNotifier {
+  ThemeProvider._internal();
+  static final ThemeProvider _instance = ThemeProvider._internal();
+  factory ThemeProvider() => _instance;
+
+  static const String _themeKey = 'theme_mode';
+
+  ThemeType _themeType = ThemeType.system;
+
+  ThemeType get themeType => _themeType;
+
+  ThemeMode get themeMode {
+    switch (_themeType) {
+      case ThemeType.light:
+        return ThemeMode.light;
+      case ThemeType.dark:
+        return ThemeMode.dark;
+      case ThemeType.system:
+        return ThemeMode.system;
+    }
+  }
+
+  bool get isDarkMode {
+    if (_themeType == ThemeType.system) {
+      return WidgetsBinding.instance.platformDispatcher.platformBrightness == Brightness.dark;
+    }
+    return _themeType == ThemeType.dark;
+  }
+
+  Future<void> loadTheme() async {
+    final prefs = await SharedPreferences.getInstance();
+    final themeIndex = prefs.getInt(_themeKey) ?? ThemeType.system.index;
+    _themeType = ThemeType.values[themeIndex];
+    notifyListeners();
+  }
+
+  Future<void> setTheme(ThemeType themeType) async {
+    _themeType = themeType;
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setInt(_themeKey, themeType.index);
+    notifyListeners();
+  }
+
+  Future<void> toggleTheme() async {
+    if (_themeType == ThemeType.light) {
+      await setTheme(ThemeType.dark);
+    } else if (_themeType == ThemeType.dark) {
+      await setTheme(ThemeType.light);
+    } else {
+      final brightness = WidgetsBinding.instance.platformDispatcher.platformBrightness;
+      await setTheme(brightness == Brightness.dark ? ThemeType.light : ThemeType.dark);
+    }
+  }
+}

--- a/lib/theme/oqdo_theme_data.dart
+++ b/lib/theme/oqdo_theme_data.dart
@@ -11,6 +11,7 @@ class OQDOThemeData {
   static ThemeData lightThemeData = themeData(lightColorScheme, _lightFocusColor);
   static ThemeData darkThemeData = themeData(darkColorScheme, _darkFocusColor);
 
+  // Existing light theme colors
   static const Color blackColor = Colors.black;
   static const Color whiteColor = Colors.white;
   static const Color backgroundColor = Colors.white;
@@ -30,18 +31,65 @@ class OQDOThemeData {
   static const Color wellnessListing = Color(0xFFF7ECEC);
   static const Color sportsListing = Color(0xFFEBF4ED);
 
+  // Dark theme equivalents
+  static const Color darkBackgroundColor = Color(0xFF121212);
+  static const Color darkSurfaceColor = Color(0xFF1E1E1E);
+  static const Color darkGreyColor = Color(0xFFE0E0E0);
+  static const Color darkOtherTextColor = Color(0xFFB0B0B0);
+  static const Color darkFilterDividerColor = Color(0xFF404040);
+  static const Color darkChipColor = Color(0xFF404040);
+
+  static const Color darkHobbiesListing = Color(0xFF2A3B3E);
+  static const Color darkWellnessListing = Color(0xFF3E2A2A);
+  static const Color darkSportsListing = Color(0xFF2A3E2F);
+
   static ThemeData themeData(ColorScheme colorScheme, Color focusColor) {
     return ThemeData(
       useMaterial3: false,
       colorScheme: colorScheme,
       textTheme: _textTheme,
-      primaryColor: const Color(0xFF030303),
-      appBarTheme: AppBarTheme(backgroundColor: colorScheme.background, elevation: 0, iconTheme: IconThemeData(color: colorScheme.primary)),
-      iconTheme: IconThemeData(color: colorScheme.onPrimary),
+      primaryColor: colorScheme.primary,
+      appBarTheme: AppBarTheme(
+        backgroundColor: colorScheme.surface,
+        elevation: 0,
+        iconTheme: IconThemeData(color: colorScheme.onSurface),
+        titleTextStyle: _textTheme.titleLarge?.copyWith(
+          color: colorScheme.onSurface,
+          fontWeight: FontWeight.w600,
+        ),
+      ),
+      iconTheme: IconThemeData(color: colorScheme.onSurface),
       canvasColor: colorScheme.background,
       scaffoldBackgroundColor: colorScheme.background,
       highlightColor: Colors.transparent,
       focusColor: focusColor,
+      cardTheme: CardTheme(
+        color: colorScheme.surface,
+        elevation: 2,
+        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
+      ),
+      elevatedButtonTheme: ElevatedButtonThemeData(
+        style: ElevatedButton.styleFrom(
+          backgroundColor: colorScheme.primary,
+          foregroundColor: colorScheme.onPrimary,
+        ),
+      ),
+      inputDecorationTheme: InputDecorationTheme(
+        filled: true,
+        fillColor: colorScheme.surface,
+        border: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(8),
+          borderSide: BorderSide(color: colorScheme.outline),
+        ),
+        enabledBorder: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(8),
+          borderSide: BorderSide(color: colorScheme.outline),
+        ),
+        focusedBorder: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(8),
+          borderSide: BorderSide(color: colorScheme.primary),
+        ),
+      ),
     );
   }
 
@@ -50,38 +98,40 @@ class OQDOThemeData {
     primaryContainer: Color(0xFF117378),
     secondary: Color(0xFFEFF3F3),
     secondaryContainer: Color(0xFF006590),
-    background: Color(0xFFE6EBEB),
+    background: Color(0xFFFFFFFF),
     surface: Color(0xFFFAFBFB),
-    shadow: Color(0xff818181),
-    onBackground: Colors.white,
-    error: _lightFillColor,
-    onError: _lightFillColor,
-    onPrimary: _lightFillColor,
+    surfaceVariant: Color(0xFFF8F8F8),
+    shadow: Color(0xFF818181),
+    outline: Color(0xFFE0E0E0),
+    onBackground: Color(0xFF1C1B1F),
+    onSurface: Color(0xFF1C1B1F),
+    onPrimary: Color(0xFFFFFFFF),
     onSecondary: Color(0xFF322942),
-    onSurface: Color(0xFF241E30),
+    error: Color(0xFFB3261E),
+    onError: Color(0xFFFFFFFF),
     brightness: Brightness.light,
-    surfaceVariant: Color(0xffF8F8F8),
   );
 
   static const ColorScheme darkColorScheme = ColorScheme(
-    primary: Color(0xFF006590),
-    primaryContainer: Color(0xFF1CDEC9),
-    secondary: Color(0xFF4D1F7C),
-    secondaryContainer: Color(0xFF451B6F),
-    background: Color(0xFF241E30),
-    surface: Color(0xFF1F1929),
-    shadow: Color(0xff818181),
-    onBackground: Color(0x0DFFFFFF),
-    // White with 0.05 opacity
-    error: _darkFillColor,
-    onError: _darkFillColor,
-    onPrimary: _darkFillColor,
-    onSecondary: _darkFillColor,
-    onSurface: _darkFillColor,
+    primary: Color(0xFF4FC3F7),
+    primaryContainer: Color(0xFF00658F),
+    secondary: Color(0xFF2A2A2A),
+    secondaryContainer: Color(0xFF4FC3F7),
+    background: Color(0xFF121212),
+    surface: Color(0xFF1E1E1E),
+    surfaceVariant: Color(0xFF2A2A2A),
+    shadow: Color(0xFF000000),
+    outline: Color(0xFF404040),
+    onBackground: Color(0xFFE6E1E5),
+    onSurface: Color(0xFFE6E1E5),
+    onPrimary: Color(0xFF003547),
+    onSecondary: Color(0xFFE6E1E5),
+    error: Color(0xFFF2B8B5),
+    onError: Color(0xFF601410),
     brightness: Brightness.dark,
-    surfaceVariant: Color(0xffF8F8F8),
   );
 
+  // Text theme remains the same
   static const _regular = FontWeight.w400;
   static const _medium = FontWeight.w500;
   static const _semiBold = FontWeight.w600;
@@ -89,34 +139,20 @@ class OQDOThemeData {
 
   static final TextTheme _textTheme = TextTheme(
     displayLarge: GoogleFonts.montserrat(fontWeight: _regular, fontSize: 57.0),
-    // Was headline1
     displayMedium: GoogleFonts.montserrat(fontWeight: _regular, fontSize: 45.0),
-    // Was headline2
     displaySmall: GoogleFonts.montserrat(fontWeight: _regular, fontSize: 36.0),
-    // Was headline3
     headlineLarge: GoogleFonts.montserrat(fontWeight: _regular, fontSize: 32.0),
-    // Was headline4
     headlineMedium: GoogleFonts.montserrat(fontWeight: _regular, fontSize: 28.0),
-    // Was headline5
     headlineSmall: GoogleFonts.montserrat(fontWeight: _regular, fontSize: 24.0),
-    // Was headline6
     titleLarge: GoogleFonts.montserrat(fontWeight: _regular, fontSize: 22.0),
-    // Was subtitle1
     titleMedium: GoogleFonts.montserrat(fontWeight: _regular, fontSize: 16.0),
-    // Was subtitle2
     titleSmall: GoogleFonts.montserrat(fontWeight: _regular, fontSize: 14.0),
-    // New in Flutter 3.22.2
     bodyLarge: GoogleFonts.montserrat(fontWeight: _regular, fontSize: 16.0),
-    // Was bodyText1
     bodyMedium: GoogleFonts.montserrat(fontWeight: _regular, fontSize: 14.0),
-    // Was bodyText2
     bodySmall: GoogleFonts.montserrat(fontWeight: _regular, fontSize: 12.0),
-    // Was caption
     labelLarge: GoogleFonts.montserrat(fontWeight: _regular, fontSize: 14.0),
-    // Was button
     labelMedium: GoogleFonts.montserrat(fontWeight: _regular, fontSize: 12.0),
-    // New in Flutter 3.22.2
-    labelSmall: GoogleFonts.montserrat(fontWeight: _regular, fontSize: 11.0), // Was overline
+    labelSmall: GoogleFonts.montserrat(fontWeight: _regular, fontSize: 11.0),
   );
 
   Color parseColor(String color) {

--- a/lib/utils/colorsUtils.dart
+++ b/lib/utils/colorsUtils.dart
@@ -1,27 +1,45 @@
 import 'package:flutter/material.dart';
-import 'package:oqdo_mobile_app/utils/utilities.dart';
+import 'package:oqdo_mobile_app/providers/theme_provider.dart';
 
 class ColorsUtils {
-  static Color greyButton = parseColor("#EFEFEF");
-  static Color greyCircle = parseColor("#E2E2E8");
-  static Color redColor = parseColor("#FF0000");
-  static Color redDeleteColor = parseColor("#EE2B2F");
-  static Color vacationList = parseColor("#80b2c7");
-  static Color greyText = parseColor("#818181");
-  static Color subTitle = parseColor("#3A3A3A");
-  static Color chipBackground = parseColor("#e1edf2");
-  static Color chipText = parseColor("#2B2B2B");
-  static Color edittextBackProfile = parseColor("#D9D9D9");
-  static Color white = parseColor("#FFFFFF");
-  static Color messageLeft = parseColor("#C7DDE7");
-  static Color messageRight = parseColor("#C7C7C7");
-  static Color greyTab = parseColor("#F8F8F8");
-  static Color greyAmount = parseColor("#656565");
-  static Color redAmount = parseColor("#FF0000");
-  static Color greenAmount = parseColor("#008000");
-  static Color pendingAmount = parseColor("#B59800");
-  static Color yellowStatus = parseColor("#E1B000");
+  static bool get _isDark => ThemeProvider().isDarkMode;
 
+  static Color get greyButton =>
+      _isDark ? const Color(0xFF333333) : const Color(0xFFEFEFEF);
+  static Color get greyCircle =>
+      _isDark ? const Color(0xFF404040) : const Color(0xFFE2E2E8);
+  static Color get redColor =>
+      _isDark ? const Color(0xFFFF6B6B) : const Color(0xFFFF0000);
+  static Color get redDeleteColor =>
+      _isDark ? const Color(0xFFFF5252) : const Color(0xFFEE2B2F);
+  static Color get vacationList =>
+      _isDark ? const Color(0xFF4A90A4) : const Color(0xFF80b2c7);
+  static Color get greyText =>
+      _isDark ? const Color(0xFFB0B0B0) : const Color(0xFF818181);
+  static Color get subTitle =>
+      _isDark ? const Color(0xFFD0D0D0) : const Color(0xFF3A3A3A);
+  static Color get chipBackground =>
+      _isDark ? const Color(0xFF2A3540) : const Color(0xFFE1EDF2);
+  static Color get chipText =>
+      _isDark ? const Color(0xFFD0D0D0) : const Color(0xFF2B2B2B);
+  static Color get edittextBackProfile =>
+      _isDark ? const Color(0xFF404040) : const Color(0xFFD9D9D9);
+  static Color get white =>
+      _isDark ? const Color(0xFF1E1E1E) : const Color(0xFFFFFFFF);
+  static Color get messageLeft =>
+      _isDark ? const Color(0xFF2A4A57) : const Color(0xFFC7DDE7);
+  static Color get messageRight =>
+      _isDark ? const Color(0xFF404040) : const Color(0xFFC7C7C7);
+  static Color get greyTab =>
+      _isDark ? const Color(0xFF2A2A2A) : const Color(0xFFF8F8F8);
+  static Color get greyAmount =>
+      _isDark ? const Color(0xFFB0B0B0) : const Color(0xFF656565);
+  static Color get redAmount =>
+      _isDark ? const Color(0xFFFF6B6B) : const Color(0xFFFF0000);
+  static Color get greenAmount =>
+      _isDark ? const Color(0xFF4CAF50) : const Color(0xFF008000);
+  static Color get pendingAmount =>
+      _isDark ? const Color(0xFFFFA726) : const Color(0xFFB59800);
+  static Color get yellowStatus =>
+      _isDark ? const Color(0xFFFFD54F) : const Color(0xFFE1B000);
 }
-
-

--- a/lib/widgets/theme_toggle_widgets.dart
+++ b/lib/widgets/theme_toggle_widgets.dart
@@ -1,0 +1,66 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import '../providers/theme_provider.dart';
+
+class ThemeToggleButton extends StatelessWidget {
+  const ThemeToggleButton({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Consumer<ThemeProvider>(
+      builder: (context, themeProvider, child) {
+        return IconButton(
+          icon: Icon(
+              themeProvider.isDarkMode ? Icons.light_mode : Icons.dark_mode),
+          onPressed: () => themeProvider.toggleTheme(),
+        );
+      },
+    );
+  }
+}
+
+class ThemeSettingsWidget extends StatelessWidget {
+  const ThemeSettingsWidget({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Consumer<ThemeProvider>(
+      builder: (context, themeProvider, child) {
+        return Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              'Theme Settings',
+              style: Theme.of(context).textTheme.titleLarge,
+            ),
+            const SizedBox(height: 16),
+            RadioListTile<ThemeType>(
+              title: const Text('Light Mode'),
+              subtitle: const Text('Use light theme'),
+              value: ThemeType.light,
+              groupValue: themeProvider.themeType,
+              onChanged: (value) =>
+                  value != null ? themeProvider.setTheme(value) : null,
+            ),
+            RadioListTile<ThemeType>(
+              title: const Text('Dark Mode'),
+              subtitle: const Text('Use dark theme'),
+              value: ThemeType.dark,
+              groupValue: themeProvider.themeType,
+              onChanged: (value) =>
+                  value != null ? themeProvider.setTheme(value) : null,
+            ),
+            RadioListTile<ThemeType>(
+              title: const Text('System Default'),
+              subtitle: const Text('Follow system theme'),
+              value: ThemeType.system,
+              groupValue: themeProvider.themeType,
+              onChanged: (value) =>
+                  value != null ? themeProvider.setTheme(value) : null,
+            ),
+          ],
+        );
+      },
+    );
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -46,7 +46,7 @@ dependencies:
   scrollable_positioned_list: ^0.3.4
   card_swiper: ^3.0.1
   http: ^1.2.0
-  provider: ^6.0.3
+  provider: ^6.1.1
   progress_dialog_null_safe: ^3.0.0
   permission_handler: ^11.3.0
   flutter_secure_storage: ^9.0.0

--- a/scripts/migration_analyzer.dart
+++ b/scripts/migration_analyzer.dart
@@ -1,0 +1,98 @@
+import 'dart:io';
+
+void main() async {
+  print('🔍 Analyzing Flutter project for theme migration...\n');
+
+  final libDir = Directory('lib');
+  if (!libDir.existsSync()) {
+    print('❌ lib directory not found. Run this from your Flutter project root.');
+    exit(1);
+  }
+
+  final analysisResults = <String, int>{
+    'ColorsUtils static calls': 0,
+    'OQDOThemeData static calls': 0,
+    'Colors.white usage': 0,
+    'Colors.black usage': 0,
+    'Hardcoded color hex': 0,
+    'Theme-aware calls': 0,
+  };
+
+  final filesToMigrate = <String>[];
+
+  await for (final file in libDir.list(recursive: true)) {
+    if (file.path.endsWith('.dart')) {
+      final content = await File(file.path).readAsString();
+
+      final colorsUtilsMatches = RegExp(r'ColorsUtils\.\w+').allMatches(content);
+      final oqdoThemeMatches = RegExp(r'OQDOThemeData\.\w+').allMatches(content);
+      final colorsWhiteMatches = RegExp(r'Colors\.white').allMatches(content);
+      final colorsBlackMatches = RegExp(r'Colors\.black').allMatches(content);
+      final hexColorMatches = RegExp(r'Color\(0x[0-9A-Fa-f]+\)').allMatches(content);
+      final themeAwareMatches = RegExp(r'Theme\.of\(context\)').allMatches(content);
+
+      final totalIssues = colorsUtilsMatches.length +
+          oqdoThemeMatches.length +
+          colorsWhiteMatches.length +
+          colorsBlackMatches.length +
+          hexColorMatches.length;
+
+      if (totalIssues > 0) {
+        filesToMigrate.add('${file.path}: $totalIssues issues');
+
+        analysisResults['ColorsUtils static calls'] =
+            (analysisResults['ColorsUtils static calls'] ?? 0) + colorsUtilsMatches.length;
+        analysisResults['OQDOThemeData static calls'] =
+            (analysisResults['OQDOThemeData static calls'] ?? 0) + oqdoThemeMatches.length;
+        analysisResults['Colors.white usage'] =
+            (analysisResults['Colors.white usage'] ?? 0) + colorsWhiteMatches.length;
+        analysisResults['Colors.black usage'] =
+            (analysisResults['Colors.black usage'] ?? 0) + colorsBlackMatches.length;
+        analysisResults['Hardcoded color hex'] =
+            (analysisResults['Hardcoded color hex'] ?? 0) + hexColorMatches.length;
+      }
+
+      analysisResults['Theme-aware calls'] =
+          (analysisResults['Theme-aware calls'] ?? 0) + themeAwareMatches.length;
+    }
+  }
+
+  print('📊 MIGRATION ANALYSIS RESULTS\n');
+  print('=' * 50);
+
+  analysisResults.forEach((key, value) {
+    final emoji = key == 'Theme-aware calls' ? '✅' : '⚠️';
+    print('$emoji $key: $value');
+  });
+
+  print('\n📁 FILES NEEDING MIGRATION (${filesToMigrate.length} total):');
+  print('=' * 50);
+
+  filesToMigrate.take(20).forEach(print);
+  if (filesToMigrate.length > 20) {
+    print('... and ${filesToMigrate.length - 20} more files');
+  }
+
+  final totalIssues = analysisResults.values
+          .where((value) => value > 0)
+          .fold(0, (a, b) => a + b) -
+      (analysisResults['Theme-aware calls'] ?? 0);
+
+  print('\n🎯 MIGRATION PRIORITY:');
+  print('=' * 50);
+  if (totalIssues > 500) {
+    print('🔴 HIGH - Consider gradual migration approach');
+  } else if (totalIssues > 200) {
+    print('🟡 MEDIUM - Can be done in phases');
+  } else {
+    print('🟢 LOW - Can be migrated quickly');
+  }
+
+  print('\n💡 RECOMMENDATIONS:');
+  print('=' * 50);
+  print('1. Start with ColorsUtils migration (automatic)');
+  print('2. Update OQDOThemeData calls (automatic)');
+  print('3. Review Colors.white/black usage (manual review needed)');
+  print('4. Test each screen after migration');
+  print('5. Consider using the provided migration script');
+}

--- a/scripts/migration_script.sh
+++ b/scripts/migration_script.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+echo "🚀 Starting OQDO Flutter theme migration..."
+echo "Creating backup of lib directory..."
+
+# Create backup
+cp -r lib lib_backup_$(date +%Y%m%d_%H%M%S)
+
+echo "📝 Migrating ColorsUtils calls..."
+find lib -name "*.dart" -type f -exec sed -i '' 's/ColorsUtils\.greyButton/ColorsUtils.of(context).greyButton/g' {} \;
+find lib -name "*.dart" -type f -exec sed -i '' 's/ColorsUtils\.greyCircle/ColorsUtils.of(context).greyCircle/g' {} \;
+find lib -name "*.dart" -type f -exec sed -i '' 's/ColorsUtils\.redColor/ColorsUtils.of(context).redColor/g' {} \;
+find lib -name "*.dart" -type f -exec sed -i '' 's/ColorsUtils\.redDeleteColor/ColorsUtils.of(context).redDeleteColor/g' {} \;
+find lib -name "*.dart" -type f -exec sed -i '' 's/ColorsUtils\.vacationList/ColorsUtils.of(context).vacationList/g' {} \;
+find lib -name "*.dart" -type f -exec sed -i '' 's/ColorsUtils\.greyText/ColorsUtils.of(context).greyText/g' {} \;
+find lib -name "*.dart" -type f -exec sed -i '' 's/ColorsUtils\.subTitle/ColorsUtils.of(context).subTitle/g' {} \;
+find lib -name "*.dart" -type f -exec sed -i '' 's/ColorsUtils\.chipBackground/ColorsUtils.of(context).chipBackground/g' {} \;
+find lib -name "*.dart" -type f -exec sed -i '' 's/ColorsUtils\.chipText/ColorsUtils.of(context).chipText/g' {} \;
+find lib -name "*.dart" -type f -exec sed -i '' 's/ColorsUtils\.edittextBackProfile/ColorsUtils.of(context).edittextBackProfile/g' {} \;
+find lib -name "*.dart" -type f -exec sed -i '' 's/ColorsUtils\.white/ColorsUtils.of(context).white/g' {} \;
+find lib -name "*.dart" -type f -exec sed -i '' 's/ColorsUtils\.messageLeft/ColorsUtils.of(context).messageLeft/g' {} \;
+find lib -name "*.dart" -type f -exec sed -i '' 's/ColorsUtils\.messageRight/ColorsUtils.of(context).messageRight/g' {} \;
+find lib -name "*.dart" -type f -exec sed -i '' 's/ColorsUtils\.greyTab/ColorsUtils.of(context).greyTab/g' {} \;
+find lib -name "*.dart" -type f -exec sed -i '' 's/ColorsUtils\.greyAmount/ColorsUtils.of(context).greyAmount/g' {} \;
+find lib -name "*.dart" -type f -exec sed -i '' 's/ColorsUtils\.redAmount/ColorsUtils.of(context).redAmount/g' {} \;
+find lib -name "*.dart" -type f -exec sed -i '' 's/ColorsUtils\.greenAmount/ColorsUtils.of(context).greenAmount/g' {} \;
+find lib -name "*.dart" -type f -exec sed -i '' 's/ColorsUtils\.pendingAmount/ColorsUtils.of(context).pendingAmount/g' {} \;
+find lib -name "*.dart" -type f -exec sed -i '' 's/ColorsUtils\.yellowStatus/ColorsUtils.of(context).yellowStatus/g' {} \;
+
+echo "🎨 Migrating OQDOThemeData calls..."
+find lib -name "*.dart" -type f -exec sed -i '' 's/OQDOThemeData\.whiteColor/Theme.of(context).colorScheme.background/g' {} \;
+find lib -name "*.dart" -type f -exec sed -i '' 's/OQDOThemeData\.blackColor/Theme.of(context).colorScheme.onBackground/g' {} \;
+find lib -name "*.dart" -type f -exec sed -i '' 's/OQDOThemeData\.greyColor/Theme.of(context).colorScheme.onSurface/g' {} \;
+find lib -name "*.dart" -type f -exec sed -i '' 's/OQDOThemeData\.backgroundColor/Theme.of(context).colorScheme.background/g' {} \;
+find lib -name "*.dart" -type f -exec sed -i '' 's/OQDOThemeData\.dividerColor/Theme.of(context).colorScheme.primary/g' {} \;
+find lib -name "*.dart" -type f -exec sed -i '' 's/OQDOThemeData\.otherTextColor/Theme.of(context).colorScheme.onSurface.withOpacity(0.6)/g' {} \;
+find lib -name "*.dart" -type f -exec sed -i '' 's/OQDOThemeData\.filterDividerColor/Theme.of(context).colorScheme.outline/g' {} \;
+
+echo "🏠 Migrating common color patterns..."
+find lib -name "*.dart" -type f -exec sed -i '' 's/color: Colors\.white/color: Theme.of(context).colorScheme.background/g' {} \;
+find lib -name "*.dart" -type f -exec sed -i '' 's/backgroundColor: Colors\.white/backgroundColor: Theme.of(context).colorScheme.background/g' {} \;
+
+echo "✅ Migration complete!"


### PR DESCRIPTION
## Summary
- add `ThemeProvider` and toggle widgets for runtime light/dark mode
- expand `OQDOThemeData` with separate light and dark `ColorScheme`s
- make `ColorsUtils` theme-aware via the new provider
- wire theme switching into `OQDOApplication`
- add migration scripts and update `provider` dependency

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b7ef6c1c2483328fa1b1c6d02c4986