### PR TITLE
Style bottom bar for themes and adjust notification icon colors

### DIFF
--- a/lib/components/bottom_navigation_bar.dart
+++ b/lib/components/bottom_navigation_bar.dart
@@ -51,14 +51,13 @@ class _Mybottom_nav_barState extends State<Mybottomnavbar> {
 
   @override
   Widget build(BuildContext context) {
-    // TODO: implement build
     return BottomNavigationBar(
-        unselectedItemColor: Theme.of(context).colorScheme.shadow,
+        unselectedItemColor: Theme.of(context).colorScheme.onSurface,
         selectedItemColor: Theme.of(context).colorScheme.primary,
         type: BottomNavigationBarType.fixed,
-        backgroundColor: Theme.of(context).colorScheme.onBackground,
+        backgroundColor: Theme.of(context).colorScheme.background,
         unselectedLabelStyle: TextStyle(
-            color: Theme.of(context).colorScheme.shadow,
+            color: Theme.of(context).colorScheme.onSurface,
             fontWeight: FontWeight.w500,
             fontSize: 12),
         selectedLabelStyle: TextStyle(

--- a/lib/screens/bazaar/bazaar_home/bazaar_home_screen.dart
+++ b/lib/screens/bazaar/bazaar_home/bazaar_home_screen.dart
@@ -78,10 +78,16 @@ class _BazaarHomeScreenState extends State<BazaarHomeScreen> {
         body: isPageSet ? page : ChangeNotifierProvider(create: (context) => SellViewmodel(), child: const BuyScreen()),
         bottomNavigationBar: BottomNavigationBar(
           elevation: 8,
-          backgroundColor: Color(0xFFFFFFFF),
-          unselectedLabelStyle: TextStyle(color: Theme.of(context).colorScheme.shadow, fontWeight: FontWeight.w500, fontSize: 12),
-          selectedLabelStyle: TextStyle(color: Theme.of(context).colorScheme.primary, fontWeight: FontWeight.w500, fontSize: 12),
-          unselectedItemColor: Theme.of(context).colorScheme.shadow,
+          backgroundColor: Theme.of(context).colorScheme.background,
+          unselectedLabelStyle: TextStyle(
+              color: Theme.of(context).colorScheme.onSurface,
+              fontWeight: FontWeight.w500,
+              fontSize: 12),
+          selectedLabelStyle: TextStyle(
+              color: Theme.of(context).colorScheme.primary,
+              fontWeight: FontWeight.w500,
+              fontSize: 12),
+          unselectedItemColor: Theme.of(context).colorScheme.onSurface,
           selectedItemColor: Theme.of(context).colorScheme.primary,
           type: BottomNavigationBarType.fixed,
           currentIndex: index,

--- a/lib/screens/dashboard/dashboard_page.dart
+++ b/lib/screens/dashboard/dashboard_page.dart
@@ -585,7 +585,9 @@ class DashboardPagesState extends State<DashboardPages> with SingleTickerProvide
                   Center(
                     child: Image.asset(
                       'assets/images/notify_icon.png',
-                      color: Theme.of(context).colorScheme.onSurface,
+                      color: Theme.of(context).brightness == Brightness.dark
+                          ? Colors.white
+                          : Colors.black,
                       width: 30,
                       height: 30,
                     ),
@@ -1598,12 +1600,18 @@ class DashboardPagesState extends State<DashboardPages> with SingleTickerProvide
               },
             )),
         bottomNavigationBar: BottomNavigationBar(
-          unselectedItemColor: Theme.of(context).colorScheme.shadow,
+          unselectedItemColor: Theme.of(context).colorScheme.onSurface,
           selectedItemColor: Theme.of(context).colorScheme.primary,
           type: BottomNavigationBarType.fixed,
-          backgroundColor: Theme.of(context).colorScheme.onBackground,
-          unselectedLabelStyle: TextStyle(color: Theme.of(context).colorScheme.shadow, fontWeight: FontWeight.w500, fontSize: 12),
-          selectedLabelStyle: TextStyle(color: Theme.of(context).colorScheme.primary, fontWeight: FontWeight.w500, fontSize: 12),
+          backgroundColor: Theme.of(context).colorScheme.background,
+          unselectedLabelStyle: TextStyle(
+              color: Theme.of(context).colorScheme.onSurface,
+              fontWeight: FontWeight.w500,
+              fontSize: 12),
+          selectedLabelStyle: TextStyle(
+              color: Theme.of(context).colorScheme.primary,
+              fontWeight: FontWeight.w500,
+              fontSize: 12),
           items: [
             const BottomNavigationBarItem(
               icon: ImageIcon(

--- a/lib/screens/setup/add_facility_vacation_page.dart
+++ b/lib/screens/setup/add_facility_vacation_page.dart
@@ -66,7 +66,9 @@ class _AddFacilityVacationPageState extends State<AddFacilityVacationPage> {
             onPressed: () {},
             icon: ImageIcon(
               const AssetImage("assets/images/notify_icon.png"),
-              color: Theme.of(context).colorScheme.onSurface,
+              color: Theme.of(context).brightness == Brightness.dark
+                  ? Colors.white
+                  : Colors.black,
             ),
           ),
           IconButton(


### PR DESCRIPTION
## Summary
- ensure bottom navigation bar colors adapt to light and dark themes
- show white notification icon on dark theme and black on light theme

## Testing
- `dart format lib/screens/dashboard/dashboard_page.dart lib/screens/bazaar/bazaar_home/bazaar_home_screen.dart` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b81b5b84488332b4b4deb2e57884d0