### PR TITLE
feat: use dynamic text color for facility pages

### DIFF
--- a/lib/screens/service_provider/facility/facility_add_page.dart
+++ b/lib/screens/service_provider/facility/facility_add_page.dart
@@ -94,6 +94,8 @@ class FacilityAddPageState extends State<FacilityAddPage> {
 
   @override
   Widget build(BuildContext context) {
+    final textColor =
+        Theme.of(context).brightness == Brightness.dark ? Colors.white : Colors.black;
     return Scaffold(
       body: SafeArea(
         child: Container(
@@ -128,7 +130,7 @@ class FacilityAddPageState extends State<FacilityAddPage> {
                         textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(
                               fontSize: 22.0,
                               fontWeight: FontWeight.w600,
-                              color: Theme.of(context).colorScheme.primary,
+                              color: textColor,
                             ),
                       ),
                     ),
@@ -163,8 +165,8 @@ class FacilityAddPageState extends State<FacilityAddPage> {
                         textStyle: Theme.of(context)
                             .textTheme
                             .titleMedium!
-                            .copyWith(color: Theme.of(context).colorScheme.shadow, fontWeight: FontWeight.w600, fontSize: 17.0),
-                        color: Theme.of(context).colorScheme.primaryContainer,
+                            .copyWith(color: textColor, fontWeight: FontWeight.w600, fontSize: 17.0),
+                        color: textColor,
                       ),
                     ),
                     const SizedBox(
@@ -189,7 +191,7 @@ class FacilityAddPageState extends State<FacilityAddPage> {
                               textStyle: Theme.of(context)
                                   .textTheme
                                   .titleSmall!
-                                  .copyWith(fontSize: 16.0, fontWeight: FontWeight.w400, color: Theme.of(context).colorScheme.primary),
+                                  .copyWith(fontSize: 16.0, fontWeight: FontWeight.w400, color: textColor),
                             ),
                             value: choosedlocation,
                             items: location!.map((country) {
@@ -200,7 +202,7 @@ class FacilityAddPageState extends State<FacilityAddPage> {
                                   textStyle: Theme.of(context)
                                       .textTheme
                                       .titleSmall!
-                                      .copyWith(fontSize: 16.0, fontWeight: FontWeight.w400, color: Theme.of(context).colorScheme.primary),
+                                      .copyWith(fontSize: 16.0, fontWeight: FontWeight.w400, color: textColor),
                                 ),
                               );
                             }).toList(),
@@ -470,7 +472,7 @@ class FacilityAddPageState extends State<FacilityAddPage> {
                     ),
                     MyButton(
                       text: "Continue",
-                      textcolor: Theme.of(context).colorScheme.onBackground,
+                      textcolor: textColor,
                       textsize: 16,
                       fontWeight: FontWeight.w600,
                       letterspacing: 0.7,

--- a/lib/screens/service_provider/facility/facility_add_page_one.dart
+++ b/lib/screens/service_provider/facility/facility_add_page_one.dart
@@ -111,6 +111,8 @@ class _FacilityAddPageOneState extends State<FacilityAddPageOne> {
     //   _progressDialog = ProgressDialog(context, type: ProgressDialogType.normal, isDismissible: false);
     //   _progressDialog.style(message: "Please wait..");
     // });
+    final textColor =
+        Theme.of(context).brightness == Brightness.dark ? Colors.white : Colors.black;
     return Scaffold(
       body: SafeArea(
         child: Container(
@@ -145,7 +147,7 @@ class _FacilityAddPageOneState extends State<FacilityAddPageOne> {
                         textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(
                               fontSize: 22.0,
                               fontWeight: FontWeight.w600,
-                              color: Theme.of(context).colorScheme.primary,
+                              color: textColor,
                             ),
                       ),
                     ),
@@ -180,7 +182,7 @@ class _FacilityAddPageOneState extends State<FacilityAddPageOne> {
                         textStyle: Theme.of(context)
                             .textTheme
                             .titleMedium!
-                            .copyWith(color: Theme.of(context).colorScheme.surface, fontWeight: FontWeight.w400, fontSize: 17.0),
+                            .copyWith(color: textColor, fontWeight: FontWeight.w400, fontSize: 17.0),
                       ),
                     ),
                     const SizedBox(
@@ -205,7 +207,7 @@ class _FacilityAddPageOneState extends State<FacilityAddPageOne> {
                               textStyle: Theme.of(context)
                                   .textTheme
                                   .titleSmall!
-                                  .copyWith(fontSize: 16.0, fontWeight: FontWeight.w400, color: Theme.of(context).colorScheme.primary),
+                                  .copyWith(fontSize: 16.0, fontWeight: FontWeight.w400, color: textColor),
                             ),
                             value: choosedlocation,
                             items: location!.map((country) {
@@ -216,7 +218,7 @@ class _FacilityAddPageOneState extends State<FacilityAddPageOne> {
                                   textStyle: Theme.of(context)
                                       .textTheme
                                       .titleSmall!
-                                      .copyWith(fontSize: 16.0, fontWeight: FontWeight.w400, color: Theme.of(context).colorScheme.primary),
+                                      .copyWith(fontSize: 16.0, fontWeight: FontWeight.w400, color: textColor),
                                 ),
                               );
                             }).toList(),
@@ -242,7 +244,7 @@ class _FacilityAddPageOneState extends State<FacilityAddPageOne> {
                         textStyle: Theme.of(context)
                             .textTheme
                             .bodyLarge!
-                            .copyWith(color: Theme.of(context).colorScheme.shadow, fontWeight: FontWeight.w400, fontSize: 16.0),
+                            .copyWith(color: textColor, fontWeight: FontWeight.w400, fontSize: 16.0),
                       ),
                     ),
                     PinCodeTextField(
@@ -265,7 +267,7 @@ class _FacilityAddPageOneState extends State<FacilityAddPageOne> {
                       onDone: (text) async {},
                       wrapAlignment: WrapAlignment.spaceEvenly,
                       pinBoxDecoration: ProvidedPinBoxDecoration.underlinedPinBoxDecoration,
-                      pinTextStyle: TextStyle(fontSize: 25.0, color: Theme.of(context).colorScheme.onBackground),
+                      pinTextStyle: TextStyle(fontSize: 25.0, color: textColor),
                       pinTextAnimatedSwitcherTransition: ProvidedPinBoxTextAnimation.scalingTransition,
                       pinBoxColor: Theme.of(context).colorScheme.secondaryContainer,
                       pinTextAnimatedSwitcherDuration: const Duration(milliseconds: 300),
@@ -295,7 +297,7 @@ class _FacilityAddPageOneState extends State<FacilityAddPageOne> {
                     CustomTextView(
                       label: 'Upload Profile Photo',
                       textStyle:
-                          Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 17.0, color: Theme.of(context).colorScheme.shadow, fontWeight: FontWeight.w400),
+                          Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 17.0, color: textColor, fontWeight: FontWeight.w400),
                     ),
                     const SizedBox(
                       height: 10.0,
@@ -347,7 +349,7 @@ class _FacilityAddPageOneState extends State<FacilityAddPageOne> {
                                   textStyle: Theme.of(context)
                                       .textTheme
                                       .titleLarge!
-                                      .copyWith(color: Theme.of(context).colorScheme.primary, fontSize: 16.0, fontWeight: FontWeight.w600),
+                                      .copyWith(color: textColor, fontSize: 16.0, fontWeight: FontWeight.w600),
                                 ),
                               )
                             : Container(),
@@ -367,7 +369,7 @@ class _FacilityAddPageOneState extends State<FacilityAddPageOne> {
                             textStyle: Theme.of(context)
                                 .textTheme
                                 .bodyLarge!
-                                .copyWith(color: Theme.of(context).colorScheme.shadow, fontWeight: FontWeight.w400, fontSize: 17.0),
+                                .copyWith(color: textColor, fontWeight: FontWeight.w400, fontSize: 17.0),
                           ),
                         ),
                         GestureDetector(
@@ -399,7 +401,7 @@ class _FacilityAddPageOneState extends State<FacilityAddPageOne> {
                                                 textStyle: Theme.of(context)
                                                     .textTheme
                                                     .titleMedium!
-                                                    .copyWith(color: Theme.of(context).colorScheme.onBackground, fontWeight: FontWeight.w400, fontSize: 16.0),
+                                                    .copyWith(color: textColor, fontWeight: FontWeight.w400, fontSize: 16.0),
                                               ),
                                               GestureDetector(
                                                   onTap: () {
@@ -458,7 +460,7 @@ class _FacilityAddPageOneState extends State<FacilityAddPageOne> {
                                           ),
                                           MyButton(
                                             text: "Submit",
-                                            textcolor: Theme.of(context).colorScheme.onBackground,
+                                            textcolor: textColor,
                                             textsize: 16,
                                             fontWeight: FontWeight.w600,
                                             letterspacing: 0.7,
@@ -531,7 +533,7 @@ class _FacilityAddPageOneState extends State<FacilityAddPageOne> {
                                             CustomTextView(
                                               label: contactDetailsList[index].Name,
                                               textStyle: Theme.of(context).textTheme.bodyLarge!.copyWith(
-                                                    color: Theme.of(context).colorScheme.onBackground,
+                                                    color: textColor,
                                                     fontWeight: FontWeight.w500,
                                                     fontSize: 15.0,
                                                   ),
@@ -544,7 +546,7 @@ class _FacilityAddPageOneState extends State<FacilityAddPageOne> {
                                                 textStyle: Theme.of(context)
                                                     .textTheme
                                                     .bodyLarge!
-                                                    .copyWith(color: Theme.of(context).colorScheme.primary, fontWeight: FontWeight.w400, fontSize: 17.0)),
+                                                    .copyWith(color: textColor, fontWeight: FontWeight.w400, fontSize: 17.0)),
                                             const SizedBox(
                                               height: 5.0,
                                             ),
@@ -573,7 +575,7 @@ class _FacilityAddPageOneState extends State<FacilityAddPageOne> {
                                               textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(
                                                     fontSize: 14.0,
                                                     fontWeight: FontWeight.w300,
-                                                    color: Theme.of(context).colorScheme.onBackground.withOpacity(0.5),
+                                                    color: textColor.withOpacity(0.5),
                                                   ),
                                             ),
                                           ],
@@ -581,7 +583,7 @@ class _FacilityAddPageOneState extends State<FacilityAddPageOne> {
                                       )
                                     ],
                                   ),
-                                   Divider(
+                                  Divider(
                                     height: 2,
                                     color: Theme.of(context).colorScheme.outline,
                                   )
@@ -609,7 +611,7 @@ class _FacilityAddPageOneState extends State<FacilityAddPageOne> {
                     ),
                     MyButtonWithoutBackground(
                         text: "Next",
-                        textcolor: Theme.of(context).colorScheme.secondaryContainer,
+                        textcolor: textColor,
                         textsize: 16,
                         fontWeight: FontWeight.w600,
                         letterspacing: 0.7,
@@ -972,7 +974,7 @@ class _FacilityAddPageOneState extends State<FacilityAddPageOne> {
                     CustomTextView(
                       label: 'Contact Details',
                       textStyle:
-                          Theme.of(context).textTheme.titleMedium!.copyWith(color: Theme.of(context).colorScheme.onBackground, fontWeight: FontWeight.w400, fontSize: 16.0),
+                          Theme.of(context).textTheme.titleMedium!.copyWith(color: textColor, fontWeight: FontWeight.w400, fontSize: 16.0),
                     ),
                     GestureDetector(
                         onTap: () {
@@ -1023,7 +1025,7 @@ class _FacilityAddPageOneState extends State<FacilityAddPageOne> {
                 ),
                 MyButton(
                   text: "Submit",
-                  textcolor: Theme.of(context).colorScheme.onBackground,
+                  textcolor: textColor,
                   textsize: 16,
                   fontWeight: FontWeight.w600,
                   letterspacing: 0.7,

--- a/lib/screens/service_provider/facility/facility_add_page_two.dart
+++ b/lib/screens/service_provider/facility/facility_add_page_two.dart
@@ -135,6 +135,8 @@ class _FacilityAddPageTwoState extends State<FacilityAddPageTwo> {
 
   @override
   Widget build(BuildContext context) {
+    final textColor =
+        Theme.of(context).brightness == Brightness.dark ? Colors.white : Colors.black;
     return Scaffold(
       body: SafeArea(
         child: Container(
@@ -169,7 +171,7 @@ class _FacilityAddPageTwoState extends State<FacilityAddPageTwo> {
                         textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(
                               fontSize: 22.0,
                               fontWeight: FontWeight.w600,
-                              color: Theme.of(context).colorScheme.primary,
+                              color: textColor,
                             ),
                       ),
                     ),
@@ -217,7 +219,7 @@ class _FacilityAddPageTwoState extends State<FacilityAddPageTwo> {
                           CustomTextView(
                             label: 'Activities',
                             textStyle:
-                                Theme.of(context).textTheme.bodyLarge!.copyWith(color: Theme.of(context).colorScheme.shadow, fontSize: 17.0, fontWeight: FontWeight.w400),
+                                Theme.of(context).textTheme.bodyLarge!.copyWith(color: textColor, fontSize: 17.0, fontWeight: FontWeight.w400),
                           ),
                           Image.asset(
                             'assets/images/ic_left_nav_arrow.png',
@@ -253,7 +255,7 @@ class _FacilityAddPageTwoState extends State<FacilityAddPageTwo> {
                                                 textStyle: Theme.of(context)
                                                     .textTheme
                                                     .titleMedium!
-                                                    .copyWith(fontSize: 16.0, fontWeight: FontWeight.w400, color: Theme.of(context).colorScheme.onBackground),
+                                                    .copyWith(fontSize: 16.0, fontWeight: FontWeight.w400, color: textColor),
                                               ),
                                             ),
                                             Expanded(
@@ -278,7 +280,7 @@ class _FacilityAddPageTwoState extends State<FacilityAddPageTwo> {
                         : CustomTextView(
                             label: '(Select your interests)',
                             textStyle:
-                                Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 15.0, fontWeight: FontWeight.w400, color: Theme.of(context).colorScheme.onBackground),
+                                Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 15.0, fontWeight: FontWeight.w400, color: textColor),
                           ),
                     const SizedBox(
                       height: 30,
@@ -287,7 +289,7 @@ class _FacilityAddPageTwoState extends State<FacilityAddPageTwo> {
                       label: 'If the sub activity you are interested in is not in our list',
                       maxLine: 2,
                       textOverFlow: TextOverflow.ellipsis,
-                      textStyle: TextStyle(fontSize: 16, color: Theme.of(context).colorScheme.onBackground, fontWeight: FontWeight.w500),
+                      textStyle: TextStyle(fontSize: 16, color: textColor, fontWeight: FontWeight.w500),
                     ),
                     const SizedBox(
                       height: 15,
@@ -311,7 +313,7 @@ class _FacilityAddPageTwoState extends State<FacilityAddPageTwo> {
                     CustomTextView(
                       label: 'Upload Certification Photo(s)',
                       textStyle:
-                          Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 17.0, color: Theme.of(context).colorScheme.shadow, fontWeight: FontWeight.w400),
+                          Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 17.0, color: textColor, fontWeight: FontWeight.w400),
                     ),
                     const SizedBox(
                       height: 10.0,
@@ -440,7 +442,7 @@ class _FacilityAddPageTwoState extends State<FacilityAddPageTwo> {
                               textStyle: Theme.of(context)
                                   .textTheme
                                   .titleSmall!
-                                  .copyWith(fontSize: 16.0, fontWeight: FontWeight.w400, color: Theme.of(context).colorScheme.primary),
+                                  .copyWith(fontSize: 16.0, fontWeight: FontWeight.w400, color: textColor),
                             ),
                             value: selectedPayoutMethod,
                             items: payoutMethods.map((method) {
@@ -451,7 +453,7 @@ class _FacilityAddPageTwoState extends State<FacilityAddPageTwo> {
                                   textStyle: Theme.of(context)
                                       .textTheme
                                       .titleSmall!
-                                      .copyWith(fontSize: 16.0, fontWeight: FontWeight.w400, color: Theme.of(context).colorScheme.primary),
+                                      .copyWith(fontSize: 16.0, fontWeight: FontWeight.w400, color: textColor),
                                 ),
                               );
                             }).toList(),
@@ -746,7 +748,7 @@ class _FacilityAddPageTwoState extends State<FacilityAddPageTwo> {
                               style: Theme.of(context)
                                   .textTheme
                                   .titleLarge!
-                                  .copyWith(fontSize: 17.0, fontWeight: FontWeight.w400, color: Theme.of(context).colorScheme.shadow),
+                                  .copyWith(fontSize: 17.0, fontWeight: FontWeight.w400, color: textColor),
                               children: [
                                 TextSpan(
                                   recognizer: TapGestureRecognizer()
@@ -764,7 +766,7 @@ class _FacilityAddPageTwoState extends State<FacilityAddPageTwo> {
                                   style: TextStyle(
                                       fontWeight: FontWeight.w400,
                                       fontSize: 17.0,
-                                      color: Theme.of(context).colorScheme.primaryContainer,
+                                      color: textColor,
                                       decoration: TextDecoration.underline,
                                       decorationThickness: 2),
                                 ),
@@ -773,7 +775,7 @@ class _FacilityAddPageTwoState extends State<FacilityAddPageTwo> {
                                   style: Theme.of(context)
                                       .textTheme
                                       .titleLarge!
-                                      .copyWith(fontSize: 17.0, fontWeight: FontWeight.w400, color: Theme.of(context).colorScheme.shadow),
+                                      .copyWith(fontSize: 17.0, fontWeight: FontWeight.w400, color: textColor),
                                 ),
                                 TextSpan(
                                   recognizer: TapGestureRecognizer()
@@ -791,7 +793,7 @@ class _FacilityAddPageTwoState extends State<FacilityAddPageTwo> {
                                   style: TextStyle(
                                       fontWeight: FontWeight.w400,
                                       fontSize: 17.0,
-                                      color: Theme.of(context).colorScheme.primaryContainer,
+                                      color: textColor,
                                       decoration: TextDecoration.underline,
                                       decorationThickness: 2),
                                 ),
@@ -800,7 +802,7 @@ class _FacilityAddPageTwoState extends State<FacilityAddPageTwo> {
                                   style: Theme.of(context)
                                       .textTheme
                                       .titleLarge!
-                                      .copyWith(fontSize: 17.0, fontWeight: FontWeight.w400, color: Theme.of(context).colorScheme.shadow),
+                                      .copyWith(fontSize: 17.0, fontWeight: FontWeight.w400, color: textColor),
                                 ),
                                 TextSpan(
                                   recognizer: TapGestureRecognizer()
@@ -818,7 +820,7 @@ class _FacilityAddPageTwoState extends State<FacilityAddPageTwo> {
                                   style: Theme.of(context).textTheme.titleLarge!.copyWith(
                                       fontSize: 17.0,
                                       fontWeight: FontWeight.w400,
-                                      color: Theme.of(context).colorScheme.primaryContainer,
+                                      color: textColor,
                                       decoration: TextDecoration.underline,
                                       decorationThickness: 2),
                                 ),
@@ -827,7 +829,7 @@ class _FacilityAddPageTwoState extends State<FacilityAddPageTwo> {
                                   style: Theme.of(context)
                                       .textTheme
                                       .titleLarge!
-                                      .copyWith(fontSize: 17.0, fontWeight: FontWeight.w400, color: Theme.of(context).colorScheme.shadow),
+                                      .copyWith(fontSize: 17.0, fontWeight: FontWeight.w400, color: textColor),
                                 ),
                               ],
                             ),
@@ -840,7 +842,7 @@ class _FacilityAddPageTwoState extends State<FacilityAddPageTwo> {
                     ),
                     MyButton(
                         text: "Register",
-                        textcolor: Theme.of(context).colorScheme.onBackground,
+                    textcolor: textColor,
                         textsize: 16,
                         fontWeight: FontWeight.w600,
                         letterspacing: 0.7,
@@ -967,7 +969,7 @@ class _FacilityAddPageTwoState extends State<FacilityAddPageTwo> {
       ),
       padding: const EdgeInsets.fromLTRB(24, 10, 24, 10),
       child: CustomTextView(
-          textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(color: Theme.of(context).colorScheme.shadow, fontSize: 13.0, fontWeight: FontWeight.w400),
+        textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(color: textColor, fontSize: 13.0, fontWeight: FontWeight.w400),
           label: item.activityName),
     );
   }
@@ -1485,14 +1487,14 @@ class _FacilityAddPageTwoState extends State<FacilityAddPageTwo> {
                       title: CustomTextView(
                         label: 'Account- Pending Approval',
                         textStyle:
-                            Theme.of(context).textTheme.titleLarge!.copyWith(fontSize: 18.0, fontWeight: FontWeight.bold, color: Theme.of(context).colorScheme.onBackground),
+                            Theme.of(context).textTheme.titleLarge!.copyWith(fontSize: 18.0, fontWeight: FontWeight.bold, color: textColor),
                       ),
                       content: CustomTextView(
                         label:
                             'Your account is presently under review. Upon completion of the approval process, you will receive an email. If you have any questions, please visit our website to contact us.',
                         maxLine: 6,
                         textStyle:
-                            Theme.of(context).textTheme.titleLarge!.copyWith(fontSize: 15.0, fontWeight: FontWeight.w400, color: Theme.of(context).colorScheme.onBackground),
+                            Theme.of(context).textTheme.titleLarge!.copyWith(fontSize: 15.0, fontWeight: FontWeight.w400, color: textColor),
                       ),
                       actions: <Widget>[
                         TextButton(
@@ -1501,7 +1503,7 @@ class _FacilityAddPageTwoState extends State<FacilityAddPageTwo> {
                           },
                           child:  Text(
                             'Ok',
-                            style: TextStyle(fontSize: 20, fontWeight: FontWeight.bold, color: Theme.of(context).colorScheme.onBackground),
+                            style: TextStyle(fontSize: 20, fontWeight: FontWeight.bold, color: textColor),
                           ),
                         ),
                       ],

--- a/lib/screens/service_provider/facility/facility_otp_page.dart
+++ b/lib/screens/service_provider/facility/facility_otp_page.dart
@@ -61,6 +61,8 @@ class _FacilityOTPPageState extends State<FacilityOTPPage> {
   @override
   Widget build(BuildContext context) {
     var ph = MediaQuery.of(context).size.height;
+    final textColor =
+        Theme.of(context).brightness == Brightness.dark ? Colors.white : Colors.black;
     phone.text = _commonPassingArgs.mobileNo!;
     return Scaffold(
       backgroundColor: Theme.of(context).colorScheme.background,
@@ -89,7 +91,7 @@ class _FacilityOTPPageState extends State<FacilityOTPPage> {
                   label: 'An OTP is sent to your number via SMS.',
                   type: styleSubTitle,
                   textStyle: Theme.of(context).textTheme.titleSmall!.copyWith(
-                        color: Theme.of(context).colorScheme.primary,
+                        color: textColor,
                         fontSize: 17.0,
                         fontWeight: FontWeight.w600,
                       ),
@@ -105,7 +107,7 @@ class _FacilityOTPPageState extends State<FacilityOTPPage> {
                         .textTheme
                         .titleMedium!
                         .copyWith(
-                          color: Theme.of(context).colorScheme.onBackground,
+                          color: textColor,
                           fontWeight: FontWeight.w400,
                           fontSize: 17.0,
                         ),
@@ -136,7 +138,7 @@ class _FacilityOTPPageState extends State<FacilityOTPPage> {
                         .textTheme
                         .bodyLarge!
                         .copyWith(
-                          color: Theme.of(context).colorScheme.onBackground,
+                          color: textColor,
                           fontWeight: FontWeight.w400,
                           fontSize: 17.0,
                         ),
@@ -163,7 +165,7 @@ class _FacilityOTPPageState extends State<FacilityOTPPage> {
                   pinBoxDecoration: ProvidedPinBoxDecoration.underlinedPinBoxDecoration,
                   pinTextStyle: TextStyle(
                     fontSize: 25.0,
-                    color: Theme.of(context).colorScheme.onBackground,
+                    color: textColor,
                   ),
                   pinTextAnimatedSwitcherTransition: ProvidedPinBoxTextAnimation.scalingTransition,
                   pinBoxColor: Theme.of(context).colorScheme.primary,
@@ -179,7 +181,7 @@ class _FacilityOTPPageState extends State<FacilityOTPPage> {
                 ),
                 MyButton(
                     text: "Verify",
-                    textcolor: Theme.of(context).colorScheme.onBackground,
+                    textcolor: textColor,
                     textsize: 16.0,
                     fontWeight: FontWeight.w600,
                     letterspacing: 0.7,
@@ -201,7 +203,7 @@ class _FacilityOTPPageState extends State<FacilityOTPPage> {
                       label: 'Didn’t receive an OTP? ',
                       type: styleSubTitle,
                       textStyle: Theme.of(context).textTheme.bodyLarge!.copyWith(
-                            color: Theme.of(context).colorScheme.onBackground,
+                            color: textColor,
                             fontWeight: FontWeight.w400,
                             fontSize: 18.0,
                           ),
@@ -215,7 +217,7 @@ class _FacilityOTPPageState extends State<FacilityOTPPage> {
                         label: 'Resend OTP',
                         type: styleSubTitle,
                         textStyle: Theme.of(context).textTheme.bodyLarge!.copyWith(
-                              color: Theme.of(context).colorScheme.primary,
+                              color: textColor,
                               fontWeight: FontWeight.w400,
                               fontSize: 18.0,
                             ),


### PR DESCRIPTION
## Summary
- compute a reusable textColor based on theme brightness
- apply textColor to headings, labels, and buttons across facility screens

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b928c2f8e88332b5fcf49d6d048527