### PR TITLE
Use theme surface for dropdown color

### DIFF
--- a/lib/screens/service_provider/facility/facility_add_page_two.dart
+++ b/lib/screens/service_provider/facility/facility_add_page_two.dart
@@ -434,7 +434,7 @@ class _FacilityAddPageTwoState extends State<FacilityAddPageTwo> {
                         child: DropdownButton<dynamic>(
                             isExpanded: true,
                             icon:  Icon(Icons.keyboard_arrow_down_rounded, color: Theme.of(context).colorScheme.primary),
-                            dropdownColor: Theme.of(context).colorScheme.onBackground,
+                            dropdownColor: Theme.of(context).colorScheme.surface,
                             underline: const SizedBox(),
                             borderRadius: BorderRadius.circular(15),
                             hint: CustomTextView(


### PR DESCRIPTION
## Summary
- Ensure FacilityAddPageTwo dropdown uses theme surface color for better dark/light theme support

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b93442bc408332b663a1569b739cbd