### PR TITLE
Add theme support to coach screens

### DIFF
--- a/lib/screens/service_provider/coach/coach_activities_selection_screen.dart
+++ b/lib/screens/service_provider/coach/coach_activities_selection_screen.dart
@@ -42,8 +42,7 @@ class _CoachActivitiesSelectionScreenState extends State<CoachActivitiesSelectio
 
   @override
   Widget build(BuildContext context) {
-    final textColor =
-        Theme.of(context).brightness == Brightness.dark ? Colors.white : Colors.black;
+    final textColor = Theme.of(context).colorScheme.onSurface;
     return WillPopScope(
       onWillPop: () async {
         Navigator.of(context).pop(context);
@@ -94,13 +93,15 @@ class _CoachActivitiesSelectionScreenState extends State<CoachActivitiesSelectio
             height: 70.0,
             child: ElevatedButton(
               style: ButtonStyle(
-                foregroundColor: MaterialStateProperty.all<Color>(const Color(0xFFCECECE)),
-                backgroundColor: MaterialStateProperty.all<Color>(const Color(0xFFCECECE)),
+                foregroundColor: MaterialStateProperty.all<Color>(
+                    Theme.of(context).colorScheme.surfaceVariant),
+                backgroundColor: MaterialStateProperty.all<Color>(
+                    Theme.of(context).colorScheme.surfaceVariant),
                 shape: MaterialStateProperty.all<RoundedRectangleBorder>(
-                  const RoundedRectangleBorder(
+                  RoundedRectangleBorder(
                     borderRadius: BorderRadius.zero,
                     side: BorderSide(
-                      color: Color(0xFFCECECE),
+                      color: Theme.of(context).colorScheme.surfaceVariant,
                     ),
                   ),
                 ),
@@ -128,7 +129,7 @@ class _CoachActivitiesSelectionScreenState extends State<CoachActivitiesSelectio
                 textStyle: Theme.of(context)
                     .textTheme
                     .titleMedium!
-                    .copyWith(fontWeight: FontWeight.w400, fontSize: 16.0, decoration: TextDecoration.underline, color: OQDOThemeData.blackColor),
+                    .copyWith(fontWeight: FontWeight.w400, fontSize: 16.0, decoration: TextDecoration.underline, color: textColor),
               ),
             ),
           ),
@@ -138,13 +139,15 @@ class _CoachActivitiesSelectionScreenState extends State<CoachActivitiesSelectio
             height: 70.0,
             child: ElevatedButton(
               style: ButtonStyle(
-                foregroundColor: MaterialStateProperty.all<Color>(const Color(0xFF006590)),
-                backgroundColor: MaterialStateProperty.all<Color>(const Color(0xFF006590)),
+                foregroundColor: MaterialStateProperty.all<Color>(
+                    Theme.of(context).colorScheme.primary),
+                backgroundColor: MaterialStateProperty.all<Color>(
+                    Theme.of(context).colorScheme.primary),
                 shape: MaterialStateProperty.all<RoundedRectangleBorder>(
-                  const RoundedRectangleBorder(
+                  RoundedRectangleBorder(
                     borderRadius: BorderRadius.zero,
                     side: BorderSide(
-                      color: Color(0xFF006590),
+                      color: Theme.of(context).colorScheme.primary,
                     ),
                   ),
                 ),
@@ -280,7 +283,7 @@ class _CoachActivitiesSelectionScreenState extends State<CoachActivitiesSelectio
             ),
           ),
           Container(
-            color: const Color.fromRGBO(227, 227, 227, 1.0),
+            color: Theme.of(context).colorScheme.outline,
             width: 1,
             height: double.infinity,
           ),

--- a/lib/screens/service_provider/coach/coach_add_page.dart
+++ b/lib/screens/service_provider/coach/coach_add_page.dart
@@ -97,8 +97,7 @@ class CoachAddPageState extends State<CoachAddPage> {
 
   @override
   Widget build(BuildContext context) {
-    final textColor =
-        Theme.of(context).brightness == Brightness.dark ? Colors.white : Colors.black;
+    final textColor = Theme.of(context).colorScheme.onSurface;
     return Scaffold(
       body: SafeArea(
         child: Container(

--- a/lib/screens/service_provider/coach/coach_add_page_one.dart
+++ b/lib/screens/service_provider/coach/coach_add_page_one.dart
@@ -94,8 +94,7 @@ class CoachAddPageOneState extends State<CoachAddPageOne> {
 
   @override
   Widget build(BuildContext context) {
-    final textColor =
-        Theme.of(context).brightness == Brightness.dark ? Colors.white : Colors.black;
+    final textColor = Theme.of(context).colorScheme.onSurface;
     // var ph = MediaQuery.of(context).size.height;
     // TODO: implement build
     return Scaffold(
@@ -241,8 +240,8 @@ class CoachAddPageOneState extends State<CoachAddPageOne> {
                       hideCharacter: false,
                       highlight: true,
                       highlightColor: Theme.of(context).colorScheme.secondaryContainer,
-                      defaultBorderColor: const Color.fromRGBO(0, 101, 144, 0.53),
-                      hasTextBorderColor: const Color.fromRGBO(0, 101, 144, 0.53),
+                      defaultBorderColor: Theme.of(context).colorScheme.primary.withOpacity(0.53),
+                      hasTextBorderColor: Theme.of(context).colorScheme.primary.withOpacity(0.53),
                       errorBorderColor: Colors.red,
                       maxLength: 6,
                       hasError: false,
@@ -252,13 +251,13 @@ class CoachAddPageOneState extends State<CoachAddPageOne> {
                       onDone: (text) async {},
                       wrapAlignment: WrapAlignment.spaceEvenly,
                       pinBoxDecoration: ProvidedPinBoxDecoration.underlinedPinBoxDecoration,
-                      pinTextStyle: const TextStyle(fontSize: 25.0, color: Colors.black),
+                      pinTextStyle: TextStyle(fontSize: 25.0, color: textColor),
                       pinTextAnimatedSwitcherTransition: ProvidedPinBoxTextAnimation.scalingTransition,
                       pinBoxColor: Theme.of(context).colorScheme.secondaryContainer,
                       pinTextAnimatedSwitcherDuration: const Duration(milliseconds: 300),
                       //                    highlightAnimation: true,
                       //highlightPinBoxColor: Colors.red,
-                      highlightAnimationBeginColor: Colors.black,
+                      highlightAnimationBeginColor: textColor,
                       highlightAnimationEndColor: Colors.white12,
                       keyboardType: TextInputType.number,
                     ),
@@ -397,7 +396,7 @@ class CoachAddPageOneState extends State<CoachAddPageOne> {
                       textsize: 16,
                       fontWeight: FontWeight.w600,
                       letterspacing: 0.7,
-                      buttoncolor: OQDOThemeData.backgroundColor,
+                      buttoncolor: Theme.of(context).colorScheme.surface,
                       buttonbordercolor: Theme.of(context).colorScheme.secondaryContainer,
                       buttonheight: 60,
                       buttonwidth: width,
@@ -542,7 +541,7 @@ class CoachAddPageOneState extends State<CoachAddPageOne> {
     var mCroppedFile = await ImageCropper().cropImage(sourcePath: pickedFile.path, compressFormat: ImageCompressFormat.jpg, compressQuality: 100, uiSettings: [
       AndroidUiSettings(
           toolbarTitle: 'Cropper',
-          toolbarColor: OQDOThemeData.buttonColor,
+          toolbarColor: Theme.of(context).colorScheme.primary,
           toolbarWidgetColor: Colors.white,
           initAspectRatio: CropAspectRatioPreset.square,
           lockAspectRatio: false),

--- a/lib/screens/service_provider/coach/coach_add_page_two.dart
+++ b/lib/screens/service_provider/coach/coach_add_page_two.dart
@@ -128,8 +128,10 @@ class CoachAddPageTwoState extends State<CoachAddPageTwo> {
 
   @override
   Widget build(BuildContext context) {
-    final textColor =
-        Theme.of(context).brightness == Brightness.dark ? Colors.white : Colors.black;
+    final textColor = Theme.of(context).colorScheme.onSurface;
+    final secondaryTextColor = Theme.of(context).brightness == Brightness.dark
+        ? OQDOThemeData.darkOtherTextColor
+        : OQDOThemeData.otherTextColor;
     return Scaffold(
       body: SafeArea(
         child: Container(
@@ -164,13 +166,13 @@ class CoachAddPageTwoState extends State<CoachAddPageTwo> {
                         textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(
                               fontSize: 22.0,
                               fontWeight: FontWeight.w600,
-                              color: const Color(0xFF006590),
+                              color: Theme.of(context).colorScheme.primary,
                             ),
                       ),
                     ),
-                    const Divider(
+                    Divider(
                       thickness: 3,
-                      color: Color.fromRGBO(0, 101, 144, 0.78),
+                      color: Theme.of(context).colorScheme.primary.withOpacity(0.78),
                     ),
                     const SizedBox(
                       height: 30,
@@ -241,7 +243,7 @@ class CoachAddPageTwoState extends State<CoachAddPageTwo> {
                                                 textStyle: Theme.of(context)
                                                     .textTheme
                                                     .titleMedium!
-                                                    .copyWith(fontSize: 16.0, fontWeight: FontWeight.w400, color: OQDOThemeData.blackColor),
+                                                    .copyWith(fontSize: 16.0, fontWeight: FontWeight.w400, color: textColor),
                                               ),
                                             ),
                                             Expanded(
@@ -266,7 +268,7 @@ class CoachAddPageTwoState extends State<CoachAddPageTwo> {
                         : CustomTextView(
                             label: '(Select the activities you would like to add)',
                             textStyle:
-                                Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 15.0, fontWeight: FontWeight.w400, color: OQDOThemeData.blackColor),
+                                Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 15.0, fontWeight: FontWeight.w400, color: textColor),
                           ),
                     const SizedBox(
                       height: 30,
@@ -275,7 +277,7 @@ class CoachAddPageTwoState extends State<CoachAddPageTwo> {
                       label: 'If the sub activity you are interested in is not in our list',
                       maxLine: 2,
                       textOverFlow: TextOverflow.ellipsis,
-                      textStyle: const TextStyle(fontSize: 16, color: Colors.black, fontWeight: FontWeight.w500),
+                      textStyle: TextStyle(fontSize: 16, color: textColor, fontWeight: FontWeight.w500),
                     ),
                     const SizedBox(
                       height: 15,
@@ -298,8 +300,10 @@ class CoachAddPageTwoState extends State<CoachAddPageTwo> {
                     ),
                     CustomTextView(
                       label: 'Upload Certification Photo(s)',
-                      textStyle:
-                          Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 17.0, color: OQDOThemeData.otherTextColor, fontWeight: FontWeight.w400),
+                      textStyle: Theme.of(context)
+                          .textTheme
+                          .titleMedium!
+                          .copyWith(fontSize: 17.0, color: secondaryTextColor, fontWeight: FontWeight.w400),
                     ),
                     const SizedBox(
                       height: 8.0,
@@ -416,14 +420,15 @@ class CoachAddPageTwoState extends State<CoachAddPageTwo> {
                       decoration: BoxDecoration(
                         border: Border.all(color: Theme.of(context).colorScheme.primaryContainer),
                         borderRadius: BorderRadius.circular(15),
-                        color: OQDOThemeData.backgroundColor,
+                        color: Theme.of(context).colorScheme.surface,
                       ),
                       child: Padding(
                         padding: const EdgeInsets.only(left: 10, right: 10),
                         child: DropdownButton<dynamic>(
                             isExpanded: true,
-                            icon: const Icon(Icons.keyboard_arrow_down_rounded, color: OQDOThemeData.dividerColor),
-                            dropdownColor: Theme.of(context).colorScheme.onBackground,
+                            icon: Icon(Icons.keyboard_arrow_down_rounded,
+                                color: Theme.of(context).colorScheme.primary),
+                            dropdownColor: Theme.of(context).colorScheme.surface,
                             underline: const SizedBox(),
                             borderRadius: BorderRadius.circular(15),
                             hint: CustomTextView(
@@ -431,7 +436,7 @@ class CoachAddPageTwoState extends State<CoachAddPageTwo> {
                               textStyle: Theme.of(context)
                                   .textTheme
                                   .titleSmall!
-                                  .copyWith(fontSize: 16.0, fontWeight: FontWeight.w400, color: OQDOThemeData.dividerColor),
+                                  .copyWith(fontSize: 16.0, fontWeight: FontWeight.w400, color: Theme.of(context).colorScheme.primary),
                             ),
                             value: selectedPayoutMethod,
                             items: payoutMethods.map((method) {
@@ -442,7 +447,7 @@ class CoachAddPageTwoState extends State<CoachAddPageTwo> {
                                   textStyle: Theme.of(context)
                                       .textTheme
                                       .titleSmall!
-                                      .copyWith(fontSize: 16.0, fontWeight: FontWeight.w400, color: OQDOThemeData.dividerColor),
+                                      .copyWith(fontSize: 16.0, fontWeight: FontWeight.w400, color: Theme.of(context).colorScheme.primary),
                                 ),
                               );
                             }).toList(),
@@ -736,7 +741,7 @@ class CoachAddPageTwoState extends State<CoachAddPageTwo> {
                               style: Theme.of(context)
                                   .textTheme
                                   .titleLarge!
-                                  .copyWith(fontSize: 17.0, fontWeight: FontWeight.w400, color: OQDOThemeData.otherTextColor),
+                                  .copyWith(fontSize: 17.0, fontWeight: FontWeight.w400, color: secondaryTextColor),
                               children: [
                                 TextSpan(
                                   recognizer: TapGestureRecognizer()
@@ -763,7 +768,7 @@ class CoachAddPageTwoState extends State<CoachAddPageTwo> {
                                   style: Theme.of(context)
                                       .textTheme
                                       .titleLarge!
-                                      .copyWith(fontSize: 17.0, fontWeight: FontWeight.w400, color: OQDOThemeData.otherTextColor),
+                                      .copyWith(fontSize: 17.0, fontWeight: FontWeight.w400, color: secondaryTextColor),
                                 ),
                                 TextSpan(
                                   recognizer: TapGestureRecognizer()
@@ -790,7 +795,7 @@ class CoachAddPageTwoState extends State<CoachAddPageTwo> {
                                   style: Theme.of(context)
                                       .textTheme
                                       .titleLarge!
-                                      .copyWith(fontSize: 17.0, fontWeight: FontWeight.w400, color: OQDOThemeData.otherTextColor),
+                                      .copyWith(fontSize: 17.0, fontWeight: FontWeight.w400, color: secondaryTextColor),
                                 ),
                                 TextSpan(
                                   recognizer: TapGestureRecognizer()
@@ -817,7 +822,7 @@ class CoachAddPageTwoState extends State<CoachAddPageTwo> {
                                   style: Theme.of(context)
                                       .textTheme
                                       .titleLarge!
-                                      .copyWith(fontSize: 17.0, fontWeight: FontWeight.w400, color: OQDOThemeData.otherTextColor),
+                                      .copyWith(fontSize: 17.0, fontWeight: FontWeight.w400, color: secondaryTextColor),
                                 ),
                               ],
                             ),
@@ -950,15 +955,20 @@ class CoachAddPageTwoState extends State<CoachAddPageTwo> {
   chipsWidget(SelectedFilterValues item) {
     return Container(
       decoration: BoxDecoration(
-        color: OQDOThemeData.whiteColor,
-        border: Border.all(color: OQDOThemeData.blackColor),
+        color: Theme.of(context).colorScheme.surface,
+        border: Border.all(color: Theme.of(context).colorScheme.onSurface),
         borderRadius: const BorderRadius.all(
           Radius.circular(20),
         ),
       ),
       padding: const EdgeInsets.fromLTRB(24, 10, 24, 10),
       child: CustomTextView(
-        textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(color: OQDOThemeData.chipColor, fontSize: 13.0, fontWeight: FontWeight.w400),
+        textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(
+            color: Theme.of(context).brightness == Brightness.dark
+                ? OQDOThemeData.darkChipColor
+                : OQDOThemeData.chipColor,
+            fontSize: 13.0,
+            fontWeight: FontWeight.w400),
         label: item.activityName,
       ),
     );
@@ -1423,22 +1433,22 @@ class CoachAddPageTwoState extends State<CoachAddPageTwo> {
                   child: AlertDialog(
                     title: CustomTextView(
                       label: 'Account- Pending Approval',
-                      textStyle: Theme.of(context).textTheme.titleLarge!.copyWith(fontSize: 18.0, fontWeight: FontWeight.bold, color: OQDOThemeData.blackColor),
+                      textStyle: Theme.of(context).textTheme.titleLarge!.copyWith(fontSize: 18.0, fontWeight: FontWeight.bold, color: textColor),
                     ),
                     content: CustomTextView(
                       label:
                           'Your account is presently under review. Upon completion of the approval process, you will receive an email. If you have any questions, please visit our website to contact us.',
                       maxLine: 6,
-                      textStyle: Theme.of(context).textTheme.titleLarge!.copyWith(fontSize: 15.0, fontWeight: FontWeight.w400, color: OQDOThemeData.blackColor),
+                      textStyle: Theme.of(context).textTheme.titleLarge!.copyWith(fontSize: 15.0, fontWeight: FontWeight.w400, color: textColor),
                     ),
                     actions: <Widget>[
                       TextButton(
                         onPressed: () async {
                           await Navigator.pushNamedAndRemoveUntil(context, Constants.LOGIN, (r) => false);
                         },
-                        child: const Text(
+                        child: Text(
                           'Ok',
-                          style: TextStyle(fontSize: 20, fontWeight: FontWeight.bold, color: OQDOThemeData.blackColor),
+                          style: TextStyle(fontSize: 20, fontWeight: FontWeight.bold, color: textColor),
                         ),
                       ),
                     ],

--- a/lib/screens/service_provider/coach/coach_otp_page.dart
+++ b/lib/screens/service_provider/coach/coach_otp_page.dart
@@ -59,8 +59,9 @@ class _CoachOTPPageState extends State<CoachOTPPage> {
 
   @override
   Widget build(BuildContext context) {
-    final textColor =
-        Theme.of(context).brightness == Brightness.dark ? Colors.white : Colors.black;
+    final textColor = Theme.of(context).colorScheme.onSurface;
+    final secondaryTextColor =
+        Theme.of(context).colorScheme.onSurface.withOpacity(0.6);
     phone.text = widget.commonPassingArgs.mobileNo!;
     return Scaffold(
       backgroundColor: Theme.of(context).colorScheme.surface,
@@ -101,21 +102,21 @@ class _CoachOTPPageState extends State<CoachOTPPage> {
                     textStyle: Theme.of(context)
                         .textTheme
                         .titleMedium!
-                        .copyWith(color: const Color.fromRGBO(129, 129, 129, 1), fontWeight: FontWeight.w400, fontSize: 17.0),
+                        .copyWith(color: secondaryTextColor, fontWeight: FontWeight.w400, fontSize: 17.0),
                   ),
                 ),
                 CustomEditText(
                   controller: phone,
                   isReadOnly: true,
                   autoFocus: false,
-                  decoration: const InputDecoration(
-                    focusedBorder: UnderlineInputBorder(
-                      borderSide: BorderSide(color: Color.fromRGBO(0, 101, 144, 0.53)),
+                    decoration: InputDecoration(
+                      focusedBorder: UnderlineInputBorder(
+                        borderSide: BorderSide(color: Theme.of(context).colorScheme.primary.withOpacity(0.53)),
+                      ),
+                      enabledBorder: UnderlineInputBorder(
+                        borderSide: BorderSide(color: Theme.of(context).colorScheme.primary.withOpacity(0.53)),
+                      ),
                     ),
-                    enabledBorder: UnderlineInputBorder(
-                      borderSide: BorderSide(color: Color.fromRGBO(0, 101, 144, 0.53)),
-                    ),
-                  ),
                 ),
                 const SizedBox(
                   height: 30,
@@ -128,7 +129,7 @@ class _CoachOTPPageState extends State<CoachOTPPage> {
                     textStyle: Theme.of(context)
                         .textTheme
                         .bodyLarge!
-                        .copyWith(color: const Color.fromRGBO(129, 129, 129, 1), fontWeight: FontWeight.w400, fontSize: 17.0),
+                        .copyWith(color: secondaryTextColor, fontWeight: FontWeight.w400, fontSize: 17.0),
                   ),
                 ),
                 PinCodeTextField(
@@ -139,9 +140,9 @@ class _CoachOTPPageState extends State<CoachOTPPage> {
                   controller: otp,
                   hideCharacter: false,
                   highlight: true,
-                  highlightColor: const Color.fromRGBO(0, 101, 144, 1),
-                  defaultBorderColor: const Color.fromRGBO(0, 101, 144, 1),
-                  hasTextBorderColor: const Color.fromRGBO(0, 101, 144, 1),
+                  highlightColor: Theme.of(context).colorScheme.primary,
+                  defaultBorderColor: Theme.of(context).colorScheme.primary,
+                  hasTextBorderColor: Theme.of(context).colorScheme.primary,
                   errorBorderColor: Colors.red,
                   maxLength: 6,
                   hasError: false,
@@ -150,13 +151,13 @@ class _CoachOTPPageState extends State<CoachOTPPage> {
                   onDone: (text) async {},
                   wrapAlignment: WrapAlignment.spaceEvenly,
                   pinBoxDecoration: ProvidedPinBoxDecoration.underlinedPinBoxDecoration,
-                  pinTextStyle: const TextStyle(fontSize: 25.0, color: Colors.black),
+                  pinTextStyle: TextStyle(fontSize: 25.0, color: textColor),
                   pinTextAnimatedSwitcherTransition: ProvidedPinBoxTextAnimation.scalingTransition,
                   pinBoxColor: Theme.of(context).colorScheme.primary,
                   pinTextAnimatedSwitcherDuration: const Duration(milliseconds: 300),
                   //                    highlightAnimation: true,
                   //highlightPinBoxColor: Colors.red,
-                  highlightAnimationBeginColor: Colors.black,
+                  highlightAnimationBeginColor: textColor,
                   highlightAnimationEndColor: Colors.white12,
                   keyboardType: TextInputType.number,
                 ),
@@ -189,7 +190,7 @@ class _CoachOTPPageState extends State<CoachOTPPage> {
                       textStyle: Theme.of(context)
                           .textTheme
                           .bodyLarge!
-                          .copyWith(color: const Color.fromRGBO(129, 129, 129, 1), fontWeight: FontWeight.w400, fontSize: 18.0),
+                          .copyWith(color: secondaryTextColor, fontWeight: FontWeight.w400, fontSize: 18.0),
                     ),
                     GestureDetector(
                       onTap: () {
@@ -202,7 +203,7 @@ class _CoachOTPPageState extends State<CoachOTPPage> {
                         textStyle: Theme.of(context)
                             .textTheme
                             .bodyLarge!
-                            .copyWith(color: const Color.fromRGBO(0, 101, 144, 1), fontWeight: FontWeight.w400, fontSize: 18.0),
+                            .copyWith(color: Theme.of(context).colorScheme.primary, fontWeight: FontWeight.w400, fontSize: 18.0),
                       ),
                     ),
                   ],


### PR DESCRIPTION
## Summary
- replace hardcoded colors in coach screens with values from `colorScheme`
- ensure dropdowns, inputs, buttons and chips adapt to light and dark themes

## Testing
- `dart format lib/screens/service_provider/coach/coach_add_page.dart lib/screens/service_provider/coach/coach_add_page_one.dart lib/screens/service_provider/coach/coach_add_page_two.dart lib/screens/service_provider/coach/coach_activities_selection_screen.dart lib/screens/service_provider/coach/coach_otp_page.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b93ed0284083329b2f30044076e895