### PR TITLE
Style text fields for theme-aware underline

### DIFF
--- a/lib/screens/profile/learner_profile.dart
+++ b/lib/screens/profile/learner_profile.dart
@@ -169,10 +169,14 @@ class LearnerProfilePageState extends State<LearnerProfilePage> {
                                           errorBuilder: (context, error, trace) {
                                             return ClipRRect(
                                               borderRadius: BorderRadius.circular(10.0),
-                                              child: const SizedBox(
+                                              child: SizedBox(
                                                 height: 70,
                                                 width: 70,
-                                                child: Icon(Icons.account_circle_rounded, size: 70),
+                                                child: Icon(
+                                                  Icons.account_circle_rounded,
+                                                  size: 70,
+                                                  color: Theme.of(context).colorScheme.onBackground,
+                                                ),
                                               ),
                                             );
                                           },
@@ -345,11 +349,29 @@ class LearnerProfilePageState extends State<LearnerProfilePage> {
                           inputFormatters: [
                             FilteringTextInputFormatter.allow(RegExp(r'^[a-zA-Z0-9 ]+')),
                           ],
-                          style: Theme.of(context).textTheme.bodyMedium!.copyWith(fontSize: 16, color: Theme.of(context).colorScheme.primary),
-                          decoration: const InputDecoration(
+                          style: Theme.of(context).textTheme.bodyMedium!.copyWith(
+                              fontSize: 16, color: Theme.of(context).colorScheme.primary),
+                          decoration: InputDecoration(
                             isDense: true,
-                            contentPadding: EdgeInsets.symmetric(horizontal: 0, vertical: 4),
-                            border: UnderlineInputBorder(),
+                            filled: false,
+                            contentPadding:
+                                const EdgeInsets.symmetric(horizontal: 0, vertical: 4),
+                            border: const UnderlineInputBorder(),
+                            enabledBorder: UnderlineInputBorder(
+                              borderSide: BorderSide(
+                                  color: Theme.of(context).colorScheme.onSurface),
+                            ),
+                            focusedBorder: UnderlineInputBorder(
+                              borderSide:
+                                  BorderSide(color: Theme.of(context).colorScheme.primary),
+                            ),
+                            disabledBorder: UnderlineInputBorder(
+                              borderSide: BorderSide(
+                                  color: Theme.of(context)
+                                      .colorScheme
+                                      .onSurface
+                                      .withOpacity(0.5)),
+                            ),
                           ),
                         ),
                         const SizedBox(
@@ -372,11 +394,29 @@ class LearnerProfilePageState extends State<LearnerProfilePage> {
                           inputFormatters: [
                             FilteringTextInputFormatter.allow(RegExp(r'^[a-zA-Z0-9 ]+')),
                           ],
-                          style: Theme.of(context).textTheme.bodyMedium!.copyWith(fontSize: 16, color: Theme.of(context).colorScheme.primary),
-                          decoration: const InputDecoration(
+                          style: Theme.of(context).textTheme.bodyMedium!.copyWith(
+                              fontSize: 16, color: Theme.of(context).colorScheme.primary),
+                          decoration: InputDecoration(
                             isDense: true,
-                            contentPadding: EdgeInsets.symmetric(horizontal: 0, vertical: 4),
-                            border: UnderlineInputBorder(),
+                            filled: false,
+                            contentPadding:
+                                const EdgeInsets.symmetric(horizontal: 0, vertical: 4),
+                            border: const UnderlineInputBorder(),
+                            enabledBorder: UnderlineInputBorder(
+                              borderSide: BorderSide(
+                                  color: Theme.of(context).colorScheme.onSurface),
+                            ),
+                            focusedBorder: UnderlineInputBorder(
+                              borderSide:
+                                  BorderSide(color: Theme.of(context).colorScheme.primary),
+                            ),
+                            disabledBorder: UnderlineInputBorder(
+                              borderSide: BorderSide(
+                                  color: Theme.of(context)
+                                      .colorScheme
+                                      .onSurface
+                                      .withOpacity(0.5)),
+                            ),
                           ),
                         ),
                         const SizedBox(
@@ -398,15 +438,34 @@ class LearnerProfilePageState extends State<LearnerProfilePage> {
                           maxLines: 1,
                           style: Theme.of(context).textTheme.bodyMedium!.copyWith(
                                 fontSize: 16,
-                                color: Theme.of(context).colorScheme.primary.withOpacity(0.5),
+                                color: Theme.of(context)
+                                    .colorScheme
+                                    .primary
+                                    .withOpacity(0.5),
                               ),
                           decoration: InputDecoration(
                             isDense: true,
-                            contentPadding: const EdgeInsets.symmetric(horizontal: 0, vertical: 4),
-                            border: UnderlineInputBorder(
+                            filled: false,
+                            contentPadding: const EdgeInsets.symmetric(
+                                horizontal: 0, vertical: 4),
+                            border: const UnderlineInputBorder(),
+                            enabledBorder: UnderlineInputBorder(
                               borderSide: BorderSide(
-                                color: ColorsUtils.subTitle.withOpacity(0.5),
-                              ),
+                                  color: Theme.of(context)
+                                      .colorScheme
+                                      .onSurface
+                                      .withOpacity(0.5)),
+                            ),
+                            focusedBorder: UnderlineInputBorder(
+                              borderSide:
+                                  BorderSide(color: Theme.of(context).colorScheme.primary),
+                            ),
+                            disabledBorder: UnderlineInputBorder(
+                              borderSide: BorderSide(
+                                  color: Theme.of(context)
+                                      .colorScheme
+                                      .onSurface
+                                      .withOpacity(0.5)),
                             ),
                           ),
                         ),
@@ -438,16 +497,35 @@ class LearnerProfilePageState extends State<LearnerProfilePage> {
                           ],
                           style: Theme.of(context).textTheme.bodyMedium!.copyWith(
                                 fontSize: 16,
-                                color: Theme.of(context).colorScheme.primary.withOpacity(0.5),
+                                color: Theme.of(context)
+                                    .colorScheme
+                                    .primary
+                                    .withOpacity(0.5),
                               ),
                           decoration: InputDecoration(
                             isDense: true,
+                            filled: false,
                             counterText: '',
-                            contentPadding: const EdgeInsets.symmetric(horizontal: 0, vertical: 4),
-                            border: UnderlineInputBorder(
+                            contentPadding: const EdgeInsets.symmetric(
+                                horizontal: 0, vertical: 4),
+                            border: const UnderlineInputBorder(),
+                            enabledBorder: UnderlineInputBorder(
                               borderSide: BorderSide(
-                                color: ColorsUtils.subTitle.withOpacity(0.5),
-                              ),
+                                  color: Theme.of(context)
+                                      .colorScheme
+                                      .onSurface
+                                      .withOpacity(0.5)),
+                            ),
+                            focusedBorder: UnderlineInputBorder(
+                              borderSide:
+                                  BorderSide(color: Theme.of(context).colorScheme.primary),
+                            ),
+                            disabledBorder: UnderlineInputBorder(
+                              borderSide: BorderSide(
+                                  color: Theme.of(context)
+                                      .colorScheme
+                                      .onSurface
+                                      .withOpacity(0.5)),
                             ),
                           ),
                         ),
@@ -525,12 +603,30 @@ class LearnerProfilePageState extends State<LearnerProfilePage> {
                             FilteringTextInputFormatter.digitsOnly,
                           ],
                           maxLength: 6,
-                          style: Theme.of(context).textTheme.bodyMedium!.copyWith(fontSize: 16, color: Theme.of(context).colorScheme.primary),
-                          decoration: const InputDecoration(
+                          style: Theme.of(context).textTheme.bodyMedium!.copyWith(
+                              fontSize: 16, color: Theme.of(context).colorScheme.primary),
+                          decoration: InputDecoration(
                             isDense: true,
+                            filled: false,
                             counterText: '',
-                            contentPadding: EdgeInsets.symmetric(horizontal: 0, vertical: 4),
-                            border: UnderlineInputBorder(),
+                            contentPadding:
+                                const EdgeInsets.symmetric(horizontal: 0, vertical: 4),
+                            border: const UnderlineInputBorder(),
+                            enabledBorder: UnderlineInputBorder(
+                              borderSide: BorderSide(
+                                  color: Theme.of(context).colorScheme.onSurface),
+                            ),
+                            focusedBorder: UnderlineInputBorder(
+                              borderSide:
+                                  BorderSide(color: Theme.of(context).colorScheme.primary),
+                            ),
+                            disabledBorder: UnderlineInputBorder(
+                              borderSide: BorderSide(
+                                  color: Theme.of(context)
+                                      .colorScheme
+                                      .onSurface
+                                      .withOpacity(0.5)),
+                            ),
                           ),
                         ),
                         const SizedBox(
@@ -636,11 +732,29 @@ class LearnerProfilePageState extends State<LearnerProfilePage> {
                           inputFormatters: [
                             FilteringTextInputFormatter.allow(RegExp(r'^[a-zA-Z0-9]+')),
                           ],
-                          style: Theme.of(context).textTheme.bodyMedium!.copyWith(fontSize: 16, color: Theme.of(context).colorScheme.primary),
-                          decoration: const InputDecoration(
+                          style: Theme.of(context).textTheme.bodyMedium!.copyWith(
+                              fontSize: 16, color: Theme.of(context).colorScheme.primary),
+                          decoration: InputDecoration(
                             isDense: true,
-                            contentPadding: EdgeInsets.symmetric(horizontal: 0, vertical: 4),
-                            border: UnderlineInputBorder(),
+                            filled: false,
+                            contentPadding:
+                                const EdgeInsets.symmetric(horizontal: 0, vertical: 4),
+                            border: const UnderlineInputBorder(),
+                            enabledBorder: UnderlineInputBorder(
+                              borderSide: BorderSide(
+                                  color: Theme.of(context).colorScheme.onSurface),
+                            ),
+                            focusedBorder: UnderlineInputBorder(
+                              borderSide:
+                                  BorderSide(color: Theme.of(context).colorScheme.primary),
+                            ),
+                            disabledBorder: UnderlineInputBorder(
+                              borderSide: BorderSide(
+                                  color: Theme.of(context)
+                                      .colorScheme
+                                      .onSurface
+                                      .withOpacity(0.5)),
+                            ),
                           ),
                         ),
 
@@ -869,12 +983,30 @@ class LearnerProfilePageState extends State<LearnerProfilePage> {
                           minLines: 1,
                           maxLines: 3,
                           controller: descriptionController,
-                          style: Theme.of(context).textTheme.bodyMedium!.copyWith(fontSize: 16, color: Theme.of(context).colorScheme.primary),
-                          decoration: const InputDecoration(
+                          style: Theme.of(context).textTheme.bodyMedium!.copyWith(
+                              fontSize: 16, color: Theme.of(context).colorScheme.primary),
+                          decoration: InputDecoration(
                             isDense: true,
+                            filled: false,
                             counterText: '',
-                            contentPadding: EdgeInsets.symmetric(horizontal: 0, vertical: 4),
-                            border: UnderlineInputBorder(),
+                            contentPadding:
+                                const EdgeInsets.symmetric(horizontal: 0, vertical: 4),
+                            border: const UnderlineInputBorder(),
+                            enabledBorder: UnderlineInputBorder(
+                              borderSide: BorderSide(
+                                  color: Theme.of(context).colorScheme.onSurface),
+                            ),
+                            focusedBorder: UnderlineInputBorder(
+                              borderSide:
+                                  BorderSide(color: Theme.of(context).colorScheme.primary),
+                            ),
+                            disabledBorder: UnderlineInputBorder(
+                              borderSide: BorderSide(
+                                  color: Theme.of(context)
+                                      .colorScheme
+                                      .onSurface
+                                      .withOpacity(0.5)),
+                            ),
                           ),
                         ),
 
@@ -1040,7 +1172,7 @@ class LearnerProfilePageState extends State<LearnerProfilePage> {
                                             children: [
                                               Icon(
                                                 Icons.cancel,
-                                                color: ColorsUtils.redColor,
+                                                color: Theme.of(context).colorScheme.error,
                                                 size: 100.0,
                                               ),
                                               const SizedBox(height: 10.0),
@@ -1126,26 +1258,28 @@ class LearnerProfilePageState extends State<LearnerProfilePage> {
                                 onTap: () {
                                   openCloseAccountDialog();
                                 },
-                                child: Container(
-                                  width: double.infinity,
-                                  decoration: BoxDecoration(
-                                    borderRadius: BorderRadius.circular(20.0), // Adjust radius as needed
-                                    color: ColorsUtils.closeAccountColor,
-                                  ),
-                                  child: const Center(
-                                    child: Padding(
-                                      padding: EdgeInsets.all(16.0),
-                                      child: Text(
-                                        "Close Account",
-                                        style: TextStyle(
-                                          fontWeight: FontWeight.bold,
-                                          color: Colors.white,
-                                          fontSize: 18.0, // Adjust font size as needed
-                                        ),
+                              child: Container(
+                                width: double.infinity,
+                                decoration: BoxDecoration(
+                                  borderRadius: BorderRadius.circular(20.0),
+                                  color: ColorsUtils.closeAccountColor,
+                                ),
+                                child: Center(
+                                  child: Padding(
+                                    padding: const EdgeInsets.all(16.0),
+                                    child: Text(
+                                      "Close Account",
+                                      style: TextStyle(
+                                        fontWeight: FontWeight.bold,
+                                        color: Theme.of(context)
+                                            .colorScheme
+                                            .onPrimary,
+                                        fontSize: 18.0,
                                       ),
                                     ),
                                   ),
                                 ),
+                              ),
                               )
                             : Center(
                                 child: Text(
@@ -1595,7 +1729,10 @@ class LearnerProfilePageState extends State<LearnerProfilePage> {
             child: Wrap(
               children: <Widget>[
                 ListTile(
-                    leading: const Icon(Icons.photo_library),
+                    leading: Icon(
+                      Icons.photo_library,
+                      color: Theme.of(context).colorScheme.onBackground,
+                    ),
                     title: const Text(
                       'Photo Library',
                       style: TextStyle(
@@ -1618,7 +1755,10 @@ class LearnerProfilePageState extends State<LearnerProfilePage> {
                       }
                     }),
                 ListTile(
-                    leading: const Icon(Icons.photo_camera),
+                    leading: Icon(
+                      Icons.photo_camera,
+                      color: Theme.of(context).colorScheme.onBackground,
+                    ),
                     title: const Text(
                       'Camera',
                       style: TextStyle(
@@ -1693,7 +1833,7 @@ class LearnerProfilePageState extends State<LearnerProfilePage> {
       AndroidUiSettings(
           toolbarTitle: 'Cropper',
           toolbarColor: OQDOThemeData.buttonColor,
-          toolbarWidgetColor: Colors.white,
+          toolbarWidgetColor: Theme.of(context).colorScheme.onPrimary,
           initAspectRatio: CropAspectRatioPreset.square,
           lockAspectRatio: false),
       IOSUiSettings(


### PR DESCRIPTION
## Summary
- adjust learner profile text fields to use theme-aware underline borders
- use theme colors for crop toolbar and close-account button
- style learner profile icons with theme-aware colors

## Testing
- `flutter analyze` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b9708f2d9c8332a8474f15dd166b68