### PR TITLE
refactor: align profile screens with theme

### DIFF
--- a/lib/screens/profile/add_trainind_address_page.dart
+++ b/lib/screens/profile/add_trainind_address_page.dart
@@ -17,6 +17,7 @@ import 'package:oqdo_mobile_app/utils/validator.dart';
 import 'package:pin_code_text_field/pin_code_text_field.dart';
 import 'package:progress_dialog_null_safe/progress_dialog_null_safe.dart';
 import 'package:provider/provider.dart';
+import 'package:oqdo_mobile_app/utils/colorsUtils.dart';
 
 import '../../model/coach_profile_response.dart';
 import '../../model/get_all_activity_and_sub_activity_response.dart';
@@ -256,7 +257,7 @@ class AddTrainingAddressPageState extends State<AddTrainingAddressPage> {
                         highlightColor: Theme.of(context).colorScheme.secondaryContainer,
                         defaultBorderColor: Theme.of(context).colorScheme.secondaryContainer,
                         hasTextBorderColor: Theme.of(context).colorScheme.secondaryContainer,
-                        errorBorderColor: Colors.red,
+                        errorBorderColor: ColorsUtils.redColor,
                         maxLength: 6,
                         hasError: false,
                         maskCharacter: "*",
@@ -265,14 +266,20 @@ class AddTrainingAddressPageState extends State<AddTrainingAddressPage> {
                         onDone: (text) async {},
                         wrapAlignment: WrapAlignment.spaceEvenly,
                         pinBoxDecoration: ProvidedPinBoxDecoration.underlinedPinBoxDecoration,
-                        pinTextStyle: const TextStyle(fontSize: 25.0, color: Colors.black),
+                        pinTextStyle: TextStyle(
+                            fontSize: 25.0,
+                            color: Theme.of(context).colorScheme.onBackground),
                         pinTextAnimatedSwitcherTransition: ProvidedPinBoxTextAnimation.scalingTransition,
                         pinBoxColor: Theme.of(context).colorScheme.secondaryContainer,
                         pinTextAnimatedSwitcherDuration: const Duration(milliseconds: 300),
                         //                    highlightAnimation: true,
                         //highlightPinBoxColor: Colors.red,
-                        highlightAnimationBeginColor: Colors.black,
-                        highlightAnimationEndColor: Colors.white12,
+                        highlightAnimationBeginColor:
+                            Theme.of(context).colorScheme.onBackground,
+                        highlightAnimationEndColor: Theme.of(context)
+                            .colorScheme
+                            .onBackground
+                            .withOpacity(0.07),
                         keyboardType: TextInputType.number,
                       ),
                     ),

--- a/lib/screens/profile/coach_profile.dart
+++ b/lib/screens/profile/coach_profile.dart
@@ -22,7 +22,6 @@ import 'package:oqdo_mobile_app/oqdo_application.dart';
 import 'package:oqdo_mobile_app/screens/buddies/features/buddies/domain/chat_provider.dart';
 import 'package:oqdo_mobile_app/screens/common_widget/view_image_screen.dart';
 import 'package:oqdo_mobile_app/screens/profile/intent/refer_earn_intent.dart';
-import 'package:oqdo_mobile_app/theme/oqdo_theme_data.dart';
 import 'package:oqdo_mobile_app/utils/close_account_popup.dart';
 import 'package:oqdo_mobile_app/utils/colorsUtils.dart';
 import 'package:oqdo_mobile_app/utils/custom_text_view.dart';
@@ -278,7 +277,7 @@ class CoachProfilePageState extends State<CoachProfilePage> {
               child: Container(
                 width: width,
                 height: height,
-                color: OQDOThemeData.whiteColor,
+                color: ColorsUtils.white,
                 child: SingleChildScrollView(
                   child: Form(
                     key: formKey,
@@ -489,6 +488,10 @@ class CoachProfilePageState extends State<CoachProfilePage> {
                                       child: Image.asset(
                                         "assets/images/ic_edit.png",
                                         fit: BoxFit.scaleDown,
+                                        color: Theme.of(context).brightness ==
+                                                Brightness.dark
+                                            ? Colors.white
+                                            : Colors.black,
                                         height: 22,
                                       ),
                                     ),
@@ -569,6 +572,10 @@ class CoachProfilePageState extends State<CoachProfilePage> {
                                       child: Image.asset(
                                         "assets/images/ic_edit.png",
                                         fit: BoxFit.scaleDown,
+                                        color: Theme.of(context).brightness ==
+                                                Brightness.dark
+                                            ? Colors.white
+                                            : Colors.black,
                                         height: 22,
                                       ),
                                     ),
@@ -827,6 +834,10 @@ class CoachProfilePageState extends State<CoachProfilePage> {
                                       child: Image.asset(
                                         "assets/images/ic_edit.png",
                                         fit: BoxFit.scaleDown,
+                                        color: Theme.of(context).brightness ==
+                                                Brightness.dark
+                                            ? Colors.white
+                                            : Colors.black,
                                         height: 22,
                                       ),
                                     ),
@@ -857,11 +868,12 @@ class CoachProfilePageState extends State<CoachProfilePage> {
                               FilteringTextInputFormatter.allow(RegExp(r'^[a-zA-Z0-9]+')),
                             ],
                             style: Theme.of(context).textTheme.bodyMedium!.copyWith(fontSize: 16, color: Theme.of(context).colorScheme.primary),
-                            decoration: const InputDecoration(
+                            decoration: InputDecoration(
                               isDense: true,
-                              errorStyle: TextStyle(color: Colors.red),
-                              contentPadding: EdgeInsets.symmetric(horizontal: 0, vertical: 4),
-                              border: UnderlineInputBorder(),
+                              errorStyle: TextStyle(color: ColorsUtils.redColor),
+                              contentPadding:
+                                  const EdgeInsets.symmetric(horizontal: 0, vertical: 4),
+                              border: const UnderlineInputBorder(),
                             ),
                           ),
 
@@ -889,11 +901,12 @@ class CoachProfilePageState extends State<CoachProfilePage> {
                             textInputAction: TextInputAction.next,
                             maxLines: 1,
                             style: Theme.of(context).textTheme.bodyMedium!.copyWith(fontSize: 16, color: Theme.of(context).colorScheme.primary),
-                            decoration: const InputDecoration(
+                            decoration: InputDecoration(
                               isDense: true,
-                              errorStyle: TextStyle(color: Colors.red),
-                              contentPadding: EdgeInsets.symmetric(horizontal: 0, vertical: 4),
-                              border: UnderlineInputBorder(),
+                              errorStyle: TextStyle(color: ColorsUtils.redColor),
+                              contentPadding:
+                                  const EdgeInsets.symmetric(horizontal: 0, vertical: 4),
+                              border: const UnderlineInputBorder(),
                             ),
                           ),
                           const SizedBox(
@@ -918,11 +931,12 @@ class CoachProfilePageState extends State<CoachProfilePage> {
                             textInputAction: TextInputAction.next,
                             maxLines: 1,
                             style: Theme.of(context).textTheme.bodyMedium!.copyWith(fontSize: 16, color: Theme.of(context).colorScheme.primary),
-                            decoration: const InputDecoration(
+                            decoration: InputDecoration(
                               isDense: true,
-                              errorStyle: TextStyle(color: Colors.red),
-                              contentPadding: EdgeInsets.symmetric(horizontal: 0, vertical: 4),
-                              border: UnderlineInputBorder(),
+                              errorStyle: TextStyle(color: ColorsUtils.redColor),
+                              contentPadding:
+                                  const EdgeInsets.symmetric(horizontal: 0, vertical: 4),
+                              border: const UnderlineInputBorder(),
                             ),
                           ),
                           //experience
@@ -946,12 +960,13 @@ class CoachProfilePageState extends State<CoachProfilePage> {
                             validator: Validator.notEmpty,
                             maxLength: 2,
                             style: Theme.of(context).textTheme.bodyMedium!.copyWith(fontSize: 16, color: Theme.of(context).colorScheme.primary),
-                            decoration: const InputDecoration(
+                            decoration: InputDecoration(
                               isDense: true,
                               counterText: '',
-                              errorStyle: TextStyle(color: Colors.red),
-                              contentPadding: EdgeInsets.symmetric(horizontal: 0, vertical: 4),
-                              border: UnderlineInputBorder(),
+                              errorStyle: TextStyle(color: ColorsUtils.redColor),
+                              contentPadding:
+                                  const EdgeInsets.symmetric(horizontal: 0, vertical: 4),
+                              border: const UnderlineInputBorder(),
                             ),
                           ),
                           //description.
@@ -993,7 +1008,10 @@ class CoachProfilePageState extends State<CoachProfilePage> {
                             textStyle: Theme.of(context)
                                 .textTheme
                                 .titleMedium!
-                                .copyWith(fontSize: 17.0, color: OQDOThemeData.otherTextColor, fontWeight: FontWeight.w400),
+                                .copyWith(
+                                    fontSize: 17.0,
+                                    color: ColorsUtils.greyText,
+                                    fontWeight: FontWeight.w400),
                           ),
                           const SizedBox(
                             height: 10.0,
@@ -1217,7 +1235,10 @@ class CoachProfilePageState extends State<CoachProfilePage> {
                                                   textStyle: Theme.of(context)
                                                       .textTheme
                                                       .titleMedium!
-                                                      .copyWith(color: const Color(0xFF2B2B2B), fontWeight: FontWeight.w400, fontSize: 18.0),
+                                                      .copyWith(
+                                                          color: ColorsUtils.chipText,
+                                                          fontWeight: FontWeight.w400,
+                                                          fontSize: 18.0),
                                                 ),
                                                 const SizedBox(
                                                   height: 10.0,
@@ -1308,7 +1329,12 @@ class CoachProfilePageState extends State<CoachProfilePage> {
                                       textStyle: Theme.of(context)
                                           .textTheme
                                           .titleMedium!
-                                          .copyWith(fontSize: 15.0, fontWeight: FontWeight.w400, color: OQDOThemeData.blackColor),
+                                          .copyWith(
+                                              fontSize: 15.0,
+                                              fontWeight: FontWeight.w400,
+                                              color: Theme.of(context)
+                                                  .colorScheme
+                                                  .onBackground),
                                     ),
                           const SizedBox(
                             height: 26,
@@ -1382,8 +1408,12 @@ class CoachProfilePageState extends State<CoachProfilePage> {
                                           child: Image.asset(
                                             "assets/images/ic_edit.png",
                                             fit: BoxFit.fitWidth,
+                                            color: Theme.of(context).brightness ==
+                                                    Brightness.dark
+                                                ? Colors.white
+                                                : Colors.black,
                                             height: 30,
-                                            width: 30,
+        width: 30,
                                           ),
                                         ),
                                       ),
@@ -1499,6 +1529,10 @@ class CoachProfilePageState extends State<CoachProfilePage> {
                                       child: Image.asset(
                                         "assets/images/ic_edit.png",
                                         fit: BoxFit.scaleDown,
+                                        color: Theme.of(context).brightness ==
+                                                Brightness.dark
+                                            ? Colors.white
+                                            : Colors.black,
                                         height: 22,
                                       ),
                                     ),
@@ -1719,7 +1753,12 @@ class CoachProfilePageState extends State<CoachProfilePage> {
                           ),
                           CustomTextView(
                             label: 'Current Effective Date: ${currentEffectiveDate.isEmpty ? 'N/A' : currentEffectiveDate}',
-                            textStyle: const TextStyle(fontSize: 16, fontWeight: FontWeight.w500, color: Colors.black),
+                            textStyle: TextStyle(
+                                fontSize: 16,
+                                fontWeight: FontWeight.w500,
+                                color: Theme.of(context)
+                                    .colorScheme
+                                    .onBackground),
                           ),
                           const SizedBox(
                             height: 26,
@@ -1803,6 +1842,10 @@ class CoachProfilePageState extends State<CoachProfilePage> {
                                       child: Image.asset(
                                         "assets/images/ic_edit.png",
                                         fit: BoxFit.scaleDown,
+                                        color: Theme.of(context).brightness ==
+                                                Brightness.dark
+                                            ? Colors.white
+                                            : Colors.black,
                                         height: 22,
                                       ),
                                     ),
@@ -1816,13 +1859,14 @@ class CoachProfilePageState extends State<CoachProfilePage> {
                             decoration: BoxDecoration(
                               border: Border.all(color: Theme.of(context).colorScheme.primaryContainer),
                               borderRadius: BorderRadius.circular(15),
-                              color: OQDOThemeData.backgroundColor,
+                              color: ColorsUtils.white,
                             ),
                             child: Padding(
                               padding: const EdgeInsets.only(left: 10, right: 10),
                               child: DropdownButton<dynamic>(
                                 isExpanded: true,
-                                icon: const Icon(Icons.keyboard_arrow_down_rounded, color: OQDOThemeData.dividerColor),
+                                icon: Icon(Icons.keyboard_arrow_down_rounded,
+                                    color: Theme.of(context).colorScheme.primary),
                                 dropdownColor: Theme.of(context).colorScheme.onBackground,
                                 underline: const SizedBox(),
                                 borderRadius: BorderRadius.circular(15),
@@ -1831,7 +1875,12 @@ class CoachProfilePageState extends State<CoachProfilePage> {
                                   textStyle: Theme.of(context)
                                       .textTheme
                                       .titleSmall!
-                                      .copyWith(fontSize: 16.0, fontWeight: FontWeight.w400, color: OQDOThemeData.dividerColor),
+                                      .copyWith(
+                                          fontSize: 16.0,
+                                          fontWeight: FontWeight.w400,
+                                          color: Theme.of(context)
+                                              .colorScheme
+                                              .primary),
                                 ),
                                 value: selectedPayoutMethod,
                                 items: payoutMethods.map((method) {
@@ -1842,7 +1891,12 @@ class CoachProfilePageState extends State<CoachProfilePage> {
                                       textStyle: Theme.of(context)
                                           .textTheme
                                           .titleSmall!
-                                          .copyWith(fontSize: 16.0, fontWeight: FontWeight.w400, color: OQDOThemeData.dividerColor),
+                                          .copyWith(
+                                              fontSize: 16.0,
+                                              fontWeight: FontWeight.w400,
+                                              color: Theme.of(context)
+                                                  .colorScheme
+                                                  .primary),
                                     ),
                                   );
                                 }).toList(),
@@ -1918,7 +1972,12 @@ class CoachProfilePageState extends State<CoachProfilePage> {
                                             counterText: '',
                                             contentPadding: const EdgeInsets.symmetric(horizontal: 0, vertical: 4),
                                             border: const UnderlineInputBorder(),
-                                            errorStyle: Theme.of(context).textTheme.bodyMedium!.copyWith(fontSize: 12, color: Colors.red)),
+                                            errorStyle: Theme.of(context)
+                                                .textTheme
+                                                .bodyMedium!
+                                                .copyWith(
+                                                    fontSize: 12,
+                                                    color: ColorsUtils.redColor)),
                                       ),
                                       const SizedBox(
                                         height: 16,
@@ -1956,7 +2015,12 @@ class CoachProfilePageState extends State<CoachProfilePage> {
                                             counterText: '',
                                             contentPadding: const EdgeInsets.symmetric(horizontal: 0, vertical: 4),
                                             border: const UnderlineInputBorder(),
-                                            errorStyle: Theme.of(context).textTheme.bodyMedium!.copyWith(fontSize: 12, color: Colors.red)),
+                                            errorStyle: Theme.of(context)
+                                                .textTheme
+                                                .bodyMedium!
+                                                .copyWith(
+                                                    fontSize: 12,
+                                                    color: ColorsUtils.redColor)),
                                       ),
                                     ],
                                   ),
@@ -2005,7 +2069,12 @@ class CoachProfilePageState extends State<CoachProfilePage> {
                                             counterText: '',
                                             contentPadding: const EdgeInsets.symmetric(horizontal: 0, vertical: 4),
                                             border: const UnderlineInputBorder(),
-                                            errorStyle: Theme.of(context).textTheme.bodyMedium!.copyWith(fontSize: 12, color: Colors.red)),
+                                            errorStyle: Theme.of(context)
+                                                .textTheme
+                                                .bodyMedium!
+                                                .copyWith(
+                                                    fontSize: 12,
+                                                    color: ColorsUtils.redColor)),
                                       ),
                                     ],
                                   ),
@@ -2051,7 +2120,12 @@ class CoachProfilePageState extends State<CoachProfilePage> {
                                             counterText: '',
                                             contentPadding: const EdgeInsets.symmetric(horizontal: 0, vertical: 4),
                                             border: const UnderlineInputBorder(),
-                                            errorStyle: Theme.of(context).textTheme.bodyMedium!.copyWith(fontSize: 12, color: Colors.red)),
+                                            errorStyle: Theme.of(context)
+                                                .textTheme
+                                                .bodyMedium!
+                                                .copyWith(
+                                                    fontSize: 12,
+                                                    color: ColorsUtils.redColor)),
                                       ),
                                       const SizedBox(
                                         height: 16,
@@ -2087,7 +2161,12 @@ class CoachProfilePageState extends State<CoachProfilePage> {
                                             counterText: '',
                                             contentPadding: const EdgeInsets.symmetric(horizontal: 0, vertical: 4),
                                             border: const UnderlineInputBorder(),
-                                            errorStyle: Theme.of(context).textTheme.bodyMedium!.copyWith(fontSize: 12, color: Colors.red)),
+                                            errorStyle: Theme.of(context)
+                                                .textTheme
+                                                .bodyMedium!
+                                                .copyWith(
+                                                    fontSize: 12,
+                                                    color: ColorsUtils.redColor)),
                                       ),
                                       const SizedBox(
                                         height: 16,
@@ -2126,7 +2205,12 @@ class CoachProfilePageState extends State<CoachProfilePage> {
                                             counterText: '',
                                             contentPadding: const EdgeInsets.symmetric(horizontal: 0, vertical: 4),
                                             border: const UnderlineInputBorder(),
-                                            errorStyle: Theme.of(context).textTheme.bodyMedium!.copyWith(fontSize: 12, color: Colors.red)),
+                                            errorStyle: Theme.of(context)
+                                                .textTheme
+                                                .bodyMedium!
+                                                .copyWith(
+                                                    fontSize: 12,
+                                                    color: ColorsUtils.redColor)),
                                       ),
                                       const SizedBox(
                                         height: 16,
@@ -2164,7 +2248,12 @@ class CoachProfilePageState extends State<CoachProfilePage> {
                                             counterText: '',
                                             contentPadding: const EdgeInsets.symmetric(horizontal: 0, vertical: 4),
                                             border: const UnderlineInputBorder(),
-                                            errorStyle: Theme.of(context).textTheme.bodyMedium!.copyWith(fontSize: 12, color: Colors.red)),
+                                            errorStyle: Theme.of(context)
+                                                .textTheme
+                                                .bodyMedium!
+                                                .copyWith(
+                                                    fontSize: 12,
+                                                    color: ColorsUtils.redColor)),
                                       ),
                                     ],
                                   ),
@@ -2193,9 +2282,9 @@ class CoachProfilePageState extends State<CoachProfilePage> {
                                             content: Column(
                                               mainAxisSize: MainAxisSize.min,
                                               children: [
-                                                const Icon(
+                                                Icon(
                                                   Icons.cancel,
-                                                  color: Colors.red,
+                                                  color: ColorsUtils.redColor,
                                                   size: 100.0,
                                                 ),
                                                 const SizedBox(height: 10.0),
@@ -2227,7 +2316,7 @@ class CoachProfilePageState extends State<CoachProfilePage> {
                               width: double.infinity,
                               decoration: BoxDecoration(
                                 borderRadius: BorderRadius.circular(20.0), // Adjust radius as needed
-                                color: const Color(0xFF006590),
+                                color: ColorsUtils.referEarnColor,
                               ),
                               child: Padding(
                                 padding: const EdgeInsets.all(16.0),
@@ -2247,13 +2336,13 @@ class CoachProfilePageState extends State<CoachProfilePage> {
                                           const SizedBox(
                                             width: 10,
                                           ),
-                                          const Align(
+                                          Align(
                                             alignment: Alignment.center,
                                             child: Text(
                                               "Refer and Earn",
                                               style: TextStyle(
                                                 fontWeight: FontWeight.bold,
-                                                color: Colors.white,
+                                                color: ColorsUtils.white,
                                                 fontSize: 20.0, // Adjust font size as needed
                                               ),
                                             ),
@@ -2285,16 +2374,16 @@ class CoachProfilePageState extends State<CoachProfilePage> {
                                     width: double.infinity,
                                     decoration: BoxDecoration(
                                       borderRadius: BorderRadius.circular(20.0), // Adjust radius as needed
-                                      color: const Color(0xFFFC5555),
+                                      color: ColorsUtils.closeAccountColor,
                                     ),
-                                    child: const Center(
+                                    child: Center(
                                       child: Padding(
-                                        padding: EdgeInsets.all(16.0),
+                                        padding: const EdgeInsets.all(16.0),
                                         child: Text(
                                           "Close Account",
                                           style: TextStyle(
                                             fontWeight: FontWeight.bold,
-                                            color: Colors.white,
+                                            color: ColorsUtils.white,
                                             fontSize: 18.0, // Adjust font size as needed
                                           ),
                                         ),
@@ -2302,10 +2391,13 @@ class CoachProfilePageState extends State<CoachProfilePage> {
                                     ),
                                   ),
                                 )
-                              : const Center(
+                              : Center(
                                   child: Text(
                                     'Account Closure Request in Process',
-                                    style: TextStyle(color: Colors.red, fontWeight: FontWeight.bold, fontSize: 18),
+                                    style: TextStyle(
+                                        color: ColorsUtils.redColor,
+                                        fontWeight: FontWeight.bold,
+                                        fontSize: 18),
                                   ),
                                 ),
                           const SizedBox(
@@ -2513,8 +2605,8 @@ class CoachProfilePageState extends State<CoachProfilePage> {
     var mCroppedFile = await ImageCropper().cropImage(sourcePath: pickedFile.path, compressFormat: ImageCompressFormat.jpg, compressQuality: 100, uiSettings: [
       AndroidUiSettings(
           toolbarTitle: 'Cropper',
-          toolbarColor: OQDOThemeData.buttonColor,
-          toolbarWidgetColor: Colors.white,
+          toolbarColor: Theme.of(context).colorScheme.primary,
+          toolbarWidgetColor: Theme.of(context).colorScheme.onPrimary,
           initAspectRatio: CropAspectRatioPreset.square,
           lockAspectRatio: false),
       IOSUiSettings(
@@ -3066,13 +3158,25 @@ class CoachProfilePageState extends State<CoachProfilePage> {
               padding: const EdgeInsets.fromLTRB(0, 10, 0, 10),
               child: CustomTextView(
                 label: 'Training Address',
-                textStyle: Theme.of(context).textTheme.titleSmall!.copyWith(color: OQDOThemeData.blackColor, fontSize: 14, fontWeight: FontWeight.w600),
+                textStyle: Theme.of(context)
+                    .textTheme
+                    .titleSmall!
+                    .copyWith(
+                        color: Theme.of(context).colorScheme.onBackground,
+                        fontSize: 14,
+                        fontWeight: FontWeight.w600),
               ),
             ),
             content: CustomTextView(
               label: 'Are you sure you want to delete Training Address?',
               maxLine: 2,
-              textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(color: OQDOThemeData.blackColor, fontSize: 18, fontWeight: FontWeight.w400),
+              textStyle: Theme.of(context)
+                  .textTheme
+                  .titleMedium!
+                  .copyWith(
+                      color: Theme.of(context).colorScheme.onBackground,
+                      fontSize: 18,
+                      fontWeight: FontWeight.w400),
             ),
             actions: [
               CupertinoDialogAction(
@@ -3263,11 +3367,11 @@ class CoachProfilePageState extends State<CoachProfilePage> {
           data: ThemeData.dark().copyWith(
             colorScheme: ColorScheme.light(
               primary: Theme.of(context).colorScheme.primary,
-              onPrimary: Colors.white,
-              surface: Colors.white,
-              onSurface: Colors.black,
+              onPrimary: Theme.of(context).colorScheme.onPrimary,
+              surface: Theme.of(context).colorScheme.surface,
+              onSurface: Theme.of(context).colorScheme.onSurface,
             ),
-            dialogBackgroundColor: Colors.white,
+            dialogBackgroundColor: Theme.of(context).colorScheme.surface,
           ),
           child: child!,
         );
@@ -3326,9 +3430,12 @@ class CoachProfilePageState extends State<CoachProfilePage> {
                               isCloseAccount = true;
                             });
                           },
-                          child: const Text(
+                          child: Text(
                             'Close',
-                            style: TextStyle(color: Colors.black, fontWeight: FontWeight.bold, fontSize: 18),
+                            style: TextStyle(
+                                color: Theme.of(context).colorScheme.onBackground,
+                                fontWeight: FontWeight.bold,
+                                fontSize: 18),
                           ),
                         ),
                       ],

--- a/lib/screens/profile/coach_training_address_page.dart
+++ b/lib/screens/profile/coach_training_address_page.dart
@@ -16,6 +16,7 @@ import 'package:oqdo_mobile_app/utils/validator.dart';
 import 'package:pin_code_text_field/pin_code_text_field.dart';
 import 'package:progress_dialog_null_safe/progress_dialog_null_safe.dart';
 import 'package:provider/provider.dart';
+import 'package:oqdo_mobile_app/utils/colorsUtils.dart';
 
 import '../../model/coach_profile_response.dart';
 import '../../model/coach_training_address.dart';
@@ -246,7 +247,7 @@ class CoachTrainingAddressPageState extends State<CoachTrainingAddressPage> {
                         highlightColor: Theme.of(context).colorScheme.secondaryContainer,
                         defaultBorderColor: Theme.of(context).colorScheme.secondaryContainer,
                         hasTextBorderColor: Theme.of(context).colorScheme.secondaryContainer,
-                        errorBorderColor: Colors.red,
+                        errorBorderColor: ColorsUtils.redColor,
                         maxLength: 6,
                         hasError: false,
                         maskCharacter: "*",
@@ -255,14 +256,20 @@ class CoachTrainingAddressPageState extends State<CoachTrainingAddressPage> {
                         onDone: (text) async {},
                         wrapAlignment: WrapAlignment.spaceEvenly,
                         pinBoxDecoration: ProvidedPinBoxDecoration.underlinedPinBoxDecoration,
-                        pinTextStyle: const TextStyle(fontSize: 25.0, color: Colors.black),
+                        pinTextStyle: TextStyle(
+                            fontSize: 25.0,
+                            color: Theme.of(context).colorScheme.onBackground),
                         pinTextAnimatedSwitcherTransition: ProvidedPinBoxTextAnimation.scalingTransition,
                         pinBoxColor: Theme.of(context).colorScheme.secondaryContainer,
                         pinTextAnimatedSwitcherDuration: const Duration(milliseconds: 300),
                         //                    highlightAnimation: true,
                         //highlightPinBoxColor: Colors.red,
-                        highlightAnimationBeginColor: Colors.black,
-                        highlightAnimationEndColor: Colors.white12,
+                        highlightAnimationBeginColor:
+                            Theme.of(context).colorScheme.onBackground,
+                        highlightAnimationEndColor: Theme.of(context)
+                            .colorScheme
+                            .onBackground
+                            .withOpacity(0.07),
                         keyboardType: TextInputType.number,
                       ),
                     ),

--- a/lib/screens/profile/end_user_edit_training_address.dart
+++ b/lib/screens/profile/end_user_edit_training_address.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:oqdo_mobile_app/components/custom_app_bar.dart';
+import 'package:oqdo_mobile_app/utils/colorsUtils.dart';
 
 class EndUserEditAddressScreen extends StatefulWidget {
   const EndUserEditAddressScreen({Key? key}) : super(key: key);
@@ -18,7 +19,7 @@ class _EndUserEditAddressScreenState extends State<EndUserEditAddressScreen> {
           Navigator.pop(context);
         },
       ),
-      backgroundColor: Theme.of(context).colorScheme.onBackground,
+      backgroundColor: ColorsUtils.white,
       body: SafeArea(
         child: Container(
           padding: const EdgeInsets.only(left: 15, right: 15, top: 20, bottom: 40),

--- a/lib/screens/profile/facility_profile.dart
+++ b/lib/screens/profile/facility_profile.dart
@@ -18,7 +18,6 @@ import 'package:oqdo_mobile_app/helper/helpers.dart';
 import 'package:oqdo_mobile_app/model/common_passing_args.dart';
 import 'package:oqdo_mobile_app/screens/buddies/features/buddies/domain/chat_provider.dart';
 import 'package:oqdo_mobile_app/screens/profile/intent/refer_earn_intent.dart';
-import 'package:oqdo_mobile_app/theme/oqdo_theme_data.dart';
 import 'package:oqdo_mobile_app/utils/close_account_popup.dart';
 import 'package:oqdo_mobile_app/utils/colorsUtils.dart';
 import 'package:oqdo_mobile_app/utils/custom_text_view.dart';
@@ -355,6 +354,10 @@ class FacilityProfilePageState extends State<FacilityProfilePage> {
                                       child: Image.asset(
                                         "assets/images/ic_edit.png",
                                         fit: BoxFit.scaleDown,
+                                        color: Theme.of(context).brightness ==
+                                                Brightness.dark
+                                            ? Colors.white
+                                            : Colors.black,
                                         height: 22,
                                       ),
                                     ),
@@ -438,6 +441,10 @@ class FacilityProfilePageState extends State<FacilityProfilePage> {
                                       child: Image.asset(
                                         "assets/images/ic_edit.png",
                                         fit: BoxFit.scaleDown,
+                                        color: Theme.of(context).brightness ==
+                                                Brightness.dark
+                                            ? Colors.white
+                                            : Colors.black,
                                         height: 22,
                                       ),
                                     )
@@ -705,7 +712,12 @@ class FacilityProfilePageState extends State<FacilityProfilePage> {
                                                         textStyle: Theme.of(context)
                                                             .textTheme
                                                             .titleMedium!
-                                                            .copyWith(color: OQDOThemeData.blackColor, fontWeight: FontWeight.w400, fontSize: 16.0),
+                                                            .copyWith(
+                                                                color: Theme.of(context)
+                                                                    .colorScheme
+                                                                    .onBackground,
+                                                                fontWeight: FontWeight.w400,
+                                                                fontSize: 16.0),
                                                       ),
                                                       GestureDetector(
                                                           onTap: () {
@@ -929,6 +941,10 @@ class FacilityProfilePageState extends State<FacilityProfilePage> {
                                       child: Image.asset(
                                         "assets/images/ic_edit.png",
                                         fit: BoxFit.scaleDown,
+                                        color: Theme.of(context).brightness ==
+                                                Brightness.dark
+                                            ? Colors.white
+                                            : Colors.black,
                                         height: 22,
                                       ),
                                     ),
@@ -1038,7 +1054,10 @@ class FacilityProfilePageState extends State<FacilityProfilePage> {
                             textStyle: Theme.of(context)
                                 .textTheme
                                 .titleMedium!
-                                .copyWith(fontSize: 17.0, color: OQDOThemeData.otherTextColor, fontWeight: FontWeight.w400),
+                                .copyWith(
+                                    fontSize: 17.0,
+                                    color: ColorsUtils.greyText,
+                                    fontWeight: FontWeight.w400),
                           ),
                           const SizedBox(
                             height: 10.0,
@@ -1332,7 +1351,12 @@ class FacilityProfilePageState extends State<FacilityProfilePage> {
                                       textStyle: Theme.of(context)
                                           .textTheme
                                           .titleMedium!
-                                          .copyWith(fontSize: 15.0, fontWeight: FontWeight.w400, color: OQDOThemeData.blackColor),
+                                          .copyWith(
+                                              fontSize: 15.0,
+                                              fontWeight: FontWeight.w400,
+                                              color: Theme.of(context)
+                                                  .colorScheme
+                                                  .onBackground),
                                     ),
                           const SizedBox(
                             height: 26,
@@ -1398,6 +1422,10 @@ class FacilityProfilePageState extends State<FacilityProfilePage> {
                                       child: Image.asset(
                                         "assets/images/ic_edit.png",
                                         fit: BoxFit.scaleDown,
+                                        color: Theme.of(context).brightness ==
+                                                Brightness.dark
+                                            ? Colors.white
+                                            : Colors.black,
                                         height: 22,
                                       ),
                                     ),
@@ -1699,6 +1727,10 @@ class FacilityProfilePageState extends State<FacilityProfilePage> {
                                       child: Image.asset(
                                         "assets/images/ic_edit.png",
                                         fit: BoxFit.scaleDown,
+                                        color: Theme.of(context).brightness ==
+                                                Brightness.dark
+                                            ? Colors.white
+                                            : Colors.black,
                                         height: 22,
                                       ),
                                     ),
@@ -1712,13 +1744,14 @@ class FacilityProfilePageState extends State<FacilityProfilePage> {
                             decoration: BoxDecoration(
                               border: Border.all(color: Theme.of(context).colorScheme.primaryContainer),
                               borderRadius: BorderRadius.circular(15),
-                              color: OQDOThemeData.backgroundColor,
+                              color: ColorsUtils.white,
                             ),
                             child: Padding(
                               padding: const EdgeInsets.only(left: 10, right: 10),
                               child: DropdownButton<dynamic>(
                                 isExpanded: true,
-                                icon: const Icon(Icons.keyboard_arrow_down_rounded, color: OQDOThemeData.dividerColor),
+                                icon: Icon(Icons.keyboard_arrow_down_rounded,
+                                    color: Theme.of(context).colorScheme.primary),
                                 dropdownColor: Theme.of(context).colorScheme.onBackground,
                                 underline: const SizedBox(),
                                 borderRadius: BorderRadius.circular(15),
@@ -1727,7 +1760,12 @@ class FacilityProfilePageState extends State<FacilityProfilePage> {
                                   textStyle: Theme.of(context)
                                       .textTheme
                                       .titleSmall!
-                                      .copyWith(fontSize: 16.0, fontWeight: FontWeight.w400, color: OQDOThemeData.dividerColor),
+                                      .copyWith(
+                                          fontSize: 16.0,
+                                          fontWeight: FontWeight.w400,
+                                          color: Theme.of(context)
+                                              .colorScheme
+                                              .primary),
                                 ),
                                 value: selectedPayoutMethod,
                                 items: payoutMethods.map((method) {
@@ -1738,7 +1776,12 @@ class FacilityProfilePageState extends State<FacilityProfilePage> {
                                       textStyle: Theme.of(context)
                                           .textTheme
                                           .titleSmall!
-                                          .copyWith(fontSize: 16.0, fontWeight: FontWeight.w400, color: OQDOThemeData.dividerColor),
+                                          .copyWith(
+                                              fontSize: 16.0,
+                                              fontWeight: FontWeight.w400,
+                                              color: Theme.of(context)
+                                                  .colorScheme
+                                                  .primary),
                                     ),
                                   );
                                 }).toList(),
@@ -2628,7 +2671,7 @@ class FacilityProfilePageState extends State<FacilityProfilePage> {
     var mCroppedFile = await ImageCropper().cropImage(sourcePath: pickedFile.path, compressFormat: ImageCompressFormat.jpg, compressQuality: 100, uiSettings: [
       AndroidUiSettings(
           toolbarTitle: 'Cropper',
-          toolbarColor: OQDOThemeData.buttonColor,
+          toolbarColor: Theme.of(context).colorScheme.primary,
           toolbarWidgetColor: Theme.of(context).colorScheme.onPrimary,
           initAspectRatio: CropAspectRatioPreset.square,
           lockAspectRatio: false),

--- a/lib/screens/profile/learner_profile.dart
+++ b/lib/screens/profile/learner_profile.dart
@@ -1844,7 +1844,7 @@ class LearnerProfilePageState extends State<LearnerProfilePage> {
     var mCroppedFile = await ImageCropper().cropImage(sourcePath: pickedFile.path, compressFormat: ImageCompressFormat.jpg, compressQuality: 100, uiSettings: [
       AndroidUiSettings(
           toolbarTitle: 'Cropper',
-          toolbarColor: OQDOThemeData.buttonColor,
+          toolbarColor: Theme.of(context).colorScheme.primary,
           toolbarWidgetColor: Theme.of(context).colorScheme.onPrimary,
           initAspectRatio: CropAspectRatioPreset.square,
           lockAspectRatio: false),

--- a/lib/screens/profile/refer_earn_screen.dart
+++ b/lib/screens/profile/refer_earn_screen.dart
@@ -4,7 +4,7 @@ import 'package:oqdo_mobile_app/utils/constants.dart';
 import 'package:share_plus/share_plus.dart';
 import 'package:oqdo_mobile_app/components/custom_app_bar.dart';
 import 'package:oqdo_mobile_app/screens/profile/intent/refer_earn_intent.dart';
-import 'package:oqdo_mobile_app/theme/oqdo_theme_data.dart';
+import 'package:oqdo_mobile_app/utils/colorsUtils.dart';
 
 class ReferEarnScreen extends StatefulWidget {
   final ReferEarnIntent intent;
@@ -59,7 +59,7 @@ Download the app here: https://oqdo.com/#download-app
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      backgroundColor: Colors.white,
+      backgroundColor: ColorsUtils.white,
       appBar: CustomAppBar(
         title: 'Refer and Earn',
         onBack: () {
@@ -82,11 +82,11 @@ Download the app here: https://oqdo.com/#download-app
               ),
               const SizedBox(height: 24),
               // Refer and Earn Title
-              const Text(
+              Text(
                 'Refer and Earn',
                 style: TextStyle(
                   fontSize: 24,
-                  color: Color(0xFF3A3A3A),
+                  color: ColorsUtils.subTitle,
                   fontWeight: FontWeight.w500,
                   fontFamily: 'Montserrat',
                 ),
@@ -101,16 +101,16 @@ Download the app here: https://oqdo.com/#download-app
               Container(
                 padding: const EdgeInsets.all(15),
                 decoration: BoxDecoration(
-                  color: const Color(0xFF006590).withOpacity(0.2),
+                  color: ColorsUtils.referEarnColor.withOpacity(0.2),
                   borderRadius: BorderRadius.circular(16),
                 ),
                 child: Row(
                   children: [
                     Text(
                       widget.intent.referCode ?? '',
-                      style: const TextStyle(
+                      style: TextStyle(
                         fontSize: 16,
-                        color: Color(0xFF006590),
+                        color: ColorsUtils.referEarnColor,
                         fontWeight: FontWeight.w600,
                       ),
                     ),
@@ -122,6 +122,9 @@ Download the app here: https://oqdo.com/#download-app
                         width: 30,
                         height: 30,
                         fit: BoxFit.cover,
+                        color: Theme.of(context).brightness == Brightness.dark
+                            ? Colors.white
+                            : Colors.black,
                       ),
                     ),
                     const SizedBox(width: 10),
@@ -132,6 +135,9 @@ Download the app here: https://oqdo.com/#download-app
                         width: 30,
                         height: 30,
                         fit: BoxFit.cover,
+                        color: Theme.of(context).brightness == Brightness.dark
+                            ? Colors.white
+                            : Colors.black,
                       ),
                     ),
                     const SizedBox(width: 10),
@@ -153,15 +159,15 @@ Download the app here: https://oqdo.com/#download-app
           Container(
             height: 24,
             width: 24,
-            decoration: const BoxDecoration(
-              color: OQDOThemeData.dividerColor,
+            decoration: BoxDecoration(
+              color: Theme.of(context).colorScheme.primary,
               shape: BoxShape.circle,
             ),
             child: Center(
               child: Text(
                 number.toString(),
-                style: const TextStyle(
-                  color: Colors.white,
+                style: TextStyle(
+                  color: ColorsUtils.white,
                   fontWeight: FontWeight.bold,
                 ),
               ),
@@ -170,7 +176,7 @@ Download the app here: https://oqdo.com/#download-app
           const SizedBox(width: 12),
           Text(
             text,
-            style: const TextStyle(fontSize: 16, fontFamily: 'Montserrat', color: OQDOThemeData.greyColor),
+            style: TextStyle(fontSize: 16, fontFamily: 'Montserrat', color: ColorsUtils.chipText),
           ),
         ],
       ),


### PR DESCRIPTION
## Summary
- use theme-driven colors in profile editing screens
- tint profile icons for dark and light modes
- modernize refer & earn visuals with dynamic colors

## Testing
- `dart format lib/screens/profile/add_trainind_address_page.dart lib/screens/profile/coach_training_address_page.dart lib/screens/profile/facility_profile.dart lib/screens/profile/coach_profile.dart lib/screens/profile/end_user_edit_training_address.dart lib/screens/profile/refer_earn_screen.dart lib/utils/colorsUtils.dart` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b976d6192c8332915e35c9cce4a86a