### PR TITLE
style: unify payout method dropdown styling

### DIFF
--- a/lib/screens/profile/coach_profile.dart
+++ b/lib/screens/profile/coach_profile.dart
@@ -288,6 +288,7 @@ class CoachProfilePageState extends State<CoachProfilePage> {
 
   @override
   Widget build(BuildContext context) {
+    final textColor = Theme.of(context).colorScheme.onSurface;
     return coachProfileResponseModel.coachTitle != null
         ? Scaffold(
             key: scaffoldKey,
@@ -1824,8 +1825,7 @@ class CoachProfilePageState extends State<CoachProfilePage> {
                             decoration: BoxDecoration(
                               border: Border.all(color: Theme.of(context).colorScheme.primaryContainer),
                               borderRadius: BorderRadius.circular(15),
-                              color: Theme.of(context).colorScheme.onBackground,
-
+                              color: Theme.of(context).colorScheme.surface,
                             ),
                             child: Padding(
                               padding: const EdgeInsets.only(left: 10, right: 10),
@@ -1833,7 +1833,7 @@ class CoachProfilePageState extends State<CoachProfilePage> {
                                 isExpanded: true,
                                 icon: Icon(Icons.keyboard_arrow_down_rounded,
                                     color: Theme.of(context).colorScheme.primary),
-                                dropdownColor: Theme.of(context).colorScheme.onBackground,
+                                dropdownColor: Theme.of(context).colorScheme.surface,
                                 underline: const SizedBox(),
                                 borderRadius: BorderRadius.circular(15),
                                 hint: CustomTextView(
@@ -1844,9 +1844,7 @@ class CoachProfilePageState extends State<CoachProfilePage> {
                                       .copyWith(
                                           fontSize: 16.0,
                                           fontWeight: FontWeight.w400,
-                                          color: Theme.of(context)
-                                              .colorScheme
-                                              .primary),
+                                          color: textColor),
                                 ),
                                 value: selectedPayoutMethod,
                                 items: payoutMethods.map((method) {
@@ -1860,9 +1858,7 @@ class CoachProfilePageState extends State<CoachProfilePage> {
                                           .copyWith(
                                               fontSize: 16.0,
                                               fontWeight: FontWeight.w400,
-                                              color: Theme.of(context)
-                                                  .colorScheme
-                                                  .primary),
+                                              color: textColor),
                                     ),
                                   );
                                 }).toList(),

--- a/lib/screens/profile/facility_profile.dart
+++ b/lib/screens/profile/facility_profile.dart
@@ -168,6 +168,7 @@ class FacilityProfilePageState extends State<FacilityProfilePage> {
 
   @override
   Widget build(BuildContext context) {
+    final textColor = Theme.of(context).colorScheme.onSurface;
     return facilityProfileResponseModel.facilityName != null
         ? Scaffold(
             key: scaffoldKey,
@@ -1721,8 +1722,7 @@ class FacilityProfilePageState extends State<FacilityProfilePage> {
                             decoration: BoxDecoration(
                               border: Border.all(color: Theme.of(context).colorScheme.primaryContainer),
                               borderRadius: BorderRadius.circular(15),
-                              color: Theme.of(context).colorScheme.onBackground,
-
+                              color: Theme.of(context).colorScheme.surface,
                             ),
                             child: Padding(
                               padding: const EdgeInsets.only(left: 10, right: 10),
@@ -1730,7 +1730,7 @@ class FacilityProfilePageState extends State<FacilityProfilePage> {
                                 isExpanded: true,
                                 icon: Icon(Icons.keyboard_arrow_down_rounded,
                                     color: Theme.of(context).colorScheme.primary),
-                                dropdownColor: Theme.of(context).colorScheme.onBackground,
+                                dropdownColor: Theme.of(context).colorScheme.surface,
                                 underline: const SizedBox(),
                                 borderRadius: BorderRadius.circular(15),
                                 hint: CustomTextView(
@@ -1741,9 +1741,7 @@ class FacilityProfilePageState extends State<FacilityProfilePage> {
                                       .copyWith(
                                           fontSize: 16.0,
                                           fontWeight: FontWeight.w400,
-                                          color: Theme.of(context)
-                                              .colorScheme
-                                              .primary),
+                                          color: textColor),
                                 ),
                                 value: selectedPayoutMethod,
                                 items: payoutMethods.map((method) {
@@ -1757,9 +1755,7 @@ class FacilityProfilePageState extends State<FacilityProfilePage> {
                                           .copyWith(
                                               fontSize: 16.0,
                                               fontWeight: FontWeight.w400,
-                                              color: Theme.of(context)
-                                                  .colorScheme
-                                                  .primary),
+                                              color: textColor),
                                     ),
                                   );
                                 }).toList(),

--- a/lib/screens/service_provider/coach/coach_add_page_two.dart
+++ b/lib/screens/service_provider/coach/coach_add_page_two.dart
@@ -436,7 +436,10 @@ class CoachAddPageTwoState extends State<CoachAddPageTwo> {
                               textStyle: Theme.of(context)
                                   .textTheme
                                   .titleSmall!
-                                  .copyWith(fontSize: 16.0, fontWeight: FontWeight.w400, color: Theme.of(context).colorScheme.primary),
+                                  .copyWith(
+                                      fontSize: 16.0,
+                                      fontWeight: FontWeight.w400,
+                                      color: textColor),
                             ),
                             value: selectedPayoutMethod,
                             items: payoutMethods.map((method) {
@@ -447,7 +450,10 @@ class CoachAddPageTwoState extends State<CoachAddPageTwo> {
                                   textStyle: Theme.of(context)
                                       .textTheme
                                       .titleSmall!
-                                      .copyWith(fontSize: 16.0, fontWeight: FontWeight.w400, color: Theme.of(context).colorScheme.primary),
+                                      .copyWith(
+                                          fontSize: 16.0,
+                                          fontWeight: FontWeight.w400,
+                                          color: textColor),
                                 ),
                               );
                             }).toList(),

--- a/lib/screens/service_provider/facility/facility_add_page_two.dart
+++ b/lib/screens/service_provider/facility/facility_add_page_two.dart
@@ -135,8 +135,7 @@ class _FacilityAddPageTwoState extends State<FacilityAddPageTwo> {
 
   @override
   Widget build(BuildContext context) {
-    final textColor =
-        Theme.of(context).brightness == Brightness.dark ? Colors.white : Colors.black;
+    final textColor = Theme.of(context).colorScheme.onSurface;
     return Scaffold(
       body: SafeArea(
         child: Container(


### PR DESCRIPTION
## Summary
- ensure payout dropdowns use on-surface text colors
- align profile payout dropdown colors with registration forms

## Testing
- `dart format lib/screens/service_provider/coach/coach_add_page_two.dart lib/screens/service_provider/facility/facility_add_page_two.dart lib/screens/profile/coach_profile.dart lib/screens/profile/facility_profile.dart` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b97e6c62588332b7e82abe37ee728a