### PR TITLE
feat: support theme colors in chat and buddies

### DIFF
--- a/lib/screens/buddies/features/buddies/presentaion/add_participants_screen.dart
+++ b/lib/screens/buddies/features/buddies/presentaion/add_participants_screen.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 
 import 'package:flutter/material.dart';
+import 'package:oqdo_mobile_app/utils/colorsUtils.dart';
 import 'package:oqdo_mobile_app/components/custom_app_bar.dart';
 import 'package:oqdo_mobile_app/oqdo_application.dart';
 import 'package:oqdo_mobile_app/screens/buddies/features/buddies/data/get_all_buddies_repository.dart';
@@ -89,7 +90,7 @@ class _AddParticipantsScreenState extends State<AddParticipantsScreen> {
           },
           child: const Icon(
             Icons.done_rounded,
-            color: Colors.white,
+            color: ColorsUtils.white,
           )),
       appBar: CustomAppBar(
           title: 'Add Participant',
@@ -100,7 +101,7 @@ class _AddParticipantsScreenState extends State<AddParticipantsScreen> {
         child: Container(
           width: MediaQuery.of(context).size.width,
           height: MediaQuery.of(context).size.height,
-          color: Colors.white,
+          color: ColorsUtils.white,
           child: Padding(
             padding: const EdgeInsets.symmetric(horizontal: 10.0),
             child: Column(
@@ -115,9 +116,9 @@ class _AddParticipantsScreenState extends State<AddParticipantsScreen> {
                     padding: const EdgeInsets.all(8),
                     width: MediaQuery.of(context).size.width,
                     decoration: BoxDecoration(
-                        color: const Color(0xFFF5F5F5),
+                        color: ColorsUtils.buddiesBackground,
                         border: Border.all(
-                          color: const Color(0xFFF5F5F5),
+                          color: ColorsUtils.buddiesBackground,
                         ),
                         borderRadius: const BorderRadius.all(Radius.circular(10))),
                     child: SizedBox(
@@ -304,7 +305,7 @@ class _AddParticipantsScreenState extends State<AddParticipantsScreen> {
             }
           });
         },
-        backgroundColor: Colors.white);
+        backgroundColor: ColorsUtils.white);
   }
 
   Widget singleBuddyView(AllBuddiesModel allBuddiesModel) {
@@ -334,14 +335,14 @@ class _AddParticipantsScreenState extends State<AddParticipantsScreen> {
               children: [
                 Container(
                   padding: const EdgeInsets.only(top: 10, bottom: 10, left: 4, right: 4),
-                  decoration: BoxDecoration(color: allBuddiesModel.isSelected ? OQDOThemeData.buttonColor : Colors.white),
+                  decoration: BoxDecoration(color: allBuddiesModel.isSelected ? OQDOThemeData.buttonColor : ColorsUtils.white),
                   child: CustomTextView(
                     label: '${allBuddiesModel.firstName} ${allBuddiesModel.lastName}',
                     maxLine: 3,
                     textOverFlow: TextOverflow.ellipsis,
                     type: styleSubTitle,
                     textStyle: Theme.of(context).textTheme.titleSmall!.copyWith(
-                        color: allBuddiesModel.isSelected ? Colors.white : Colors.black,
+                        color: allBuddiesModel.isSelected ? ColorsUtils.white : ColorsUtils.chipText,
                         fontSize: 15.0,
                         fontWeight: FontWeight.w500,
                         overflow: TextOverflow.ellipsis),

--- a/lib/screens/buddies/features/buddies/presentaion/buddies_profile.dart
+++ b/lib/screens/buddies/features/buddies/presentaion/buddies_profile.dart
@@ -64,7 +64,7 @@ class _BuddiesProfilePageState extends State<BuddiesProfilePage> {
           child: Container(
         width: MediaQuery.of(context).size.width,
         height: MediaQuery.of(context).size.height,
-        color: Colors.white,
+        color: ColorsUtils.white,
         child: SingleChildScrollView(
           physics: const BouncingScrollPhysics(),
           child: Column(
@@ -81,7 +81,7 @@ class _BuddiesProfilePageState extends State<BuddiesProfilePage> {
                     widget.allBuddiesModel!.profileImage!.isNotEmpty
                         ? CircleAvatar(
                             radius: 70,
-                            backgroundColor: const Color(0xffFFFFFF),
+                            backgroundColor: ColorsUtils.white,
                             backgroundImage: const AssetImage('assets/images/ic_profile_outer_ring.png'),
                             child: Center(
                               child: Container(
@@ -89,7 +89,7 @@ class _BuddiesProfilePageState extends State<BuddiesProfilePage> {
                                 width: 95,
                                 decoration: const BoxDecoration(
                                   shape: BoxShape.circle,
-                                  color: Color(0xffFFFFFF), // You can set your desired background color
+                                  color: ColorsUtils.white, // You can set your desired background color
                                 ),
                                 child: ClipOval(
                                   child: CachedNetworkImage(
@@ -108,7 +108,7 @@ class _BuddiesProfilePageState extends State<BuddiesProfilePage> {
                               ),
                               // child: CircleAvatar(
                               //   radius: 42,
-                              //   backgroundColor: const Color(0xffFFFFFF),
+                              //   backgroundColor: ColorsUtils.white,
                               //   backgroundImage: CachedNetworkImageProvider(widget.allBuddiesModel!.profileImage!),
                               // ),
                             ),
@@ -135,7 +135,7 @@ class _BuddiesProfilePageState extends State<BuddiesProfilePage> {
                             maxLine: 2,
                             textOverFlow: TextOverflow.ellipsis,
                             textStyle:
-                                Theme.of(context).textTheme.titleSmall!.copyWith(color: const Color(0xFF2B2B2B), fontSize: 16.0, fontWeight: FontWeight.w600),
+                                Theme.of(context).textTheme.titleSmall!.copyWith(color: ColorsUtils.chipText, fontSize: 16.0, fontWeight: FontWeight.w600),
                           ),
                           const SizedBox(
                             height: 8,
@@ -145,14 +145,14 @@ class _BuddiesProfilePageState extends State<BuddiesProfilePage> {
                               label: 'About: ',
                               type: styleSubTitle,
                               textStyle:
-                                  Theme.of(context).textTheme.titleSmall!.copyWith(color: const Color(0xFF2B2B2B), fontSize: 15.0, fontWeight: FontWeight.w600),
+                                  Theme.of(context).textTheme.titleSmall!.copyWith(color: ColorsUtils.chipText, fontSize: 15.0, fontWeight: FontWeight.w600),
                             ),
                           if (widget.allBuddiesModel!.status != "Friend" && widget.allBuddiesModel!.isProfilePrivate == false)
                             CustomTextView(
                               label: 'About: ',
                               type: styleSubTitle,
                               textStyle:
-                                  Theme.of(context).textTheme.titleSmall!.copyWith(color: const Color(0xFF2B2B2B), fontSize: 15.0, fontWeight: FontWeight.w600),
+                                  Theme.of(context).textTheme.titleSmall!.copyWith(color: ColorsUtils.chipText, fontSize: 15.0, fontWeight: FontWeight.w600),
                             ),
 
                           // widget.allBuddiesModel!.status == "Friend" || widget.allBuddiesModel!.isProfilePrivate!
@@ -161,7 +161,7 @@ class _BuddiesProfilePageState extends State<BuddiesProfilePage> {
                           //         label: 'About: ',
                           //         type: styleSubTitle,
                           //         textStyle: Theme.of(context).textTheme.titleSmall!.copyWith(
-                          //             color: const Color(0xFF2B2B2B), fontSize: 12.0, fontWeight: FontWeight.w600),
+                          //             color: ColorsUtils.chipText, fontSize: 12.0, fontWeight: FontWeight.w600),
                           //       ),
 
                           if (widget.allBuddiesModel!.status == "Friend")
@@ -181,7 +181,7 @@ class _BuddiesProfilePageState extends State<BuddiesProfilePage> {
                                 textStyle: Theme.of(context)
                                     .textTheme
                                     .titleSmall!
-                                    .copyWith(color: const Color(0xFF2B2B2B), fontSize: 11.0, fontWeight: FontWeight.w400),
+                                    .copyWith(color: ColorsUtils.chipText, fontSize: 11.0, fontWeight: FontWeight.w400),
                               ),
                             ),
                           if (widget.allBuddiesModel!.status != "Friend" && widget.allBuddiesModel!.isProfilePrivate == false)
@@ -193,7 +193,7 @@ class _BuddiesProfilePageState extends State<BuddiesProfilePage> {
                                 textStyle: Theme.of(context)
                                     .textTheme
                                     .titleSmall!
-                                    .copyWith(color: const Color(0xFF2B2B2B), fontSize: 11.0, fontWeight: FontWeight.w400),
+                                    .copyWith(color: ColorsUtils.chipText, fontSize: 11.0, fontWeight: FontWeight.w400),
                               ),
                             ),
                         ],
@@ -287,15 +287,15 @@ class _BuddiesProfilePageState extends State<BuddiesProfilePage> {
                                         bottomLeft: Radius.circular(10),
                                         bottomRight: Radius.circular(10),
                                         topRight: Radius.circular(10)),
-                                    border: Border.all(color: const Color(0xffF1F1F1)),
-                                    color: const Color(0xffF1F1F1).withOpacity(0.5)),
+                                    border: Border.all(color: ColorsUtils.buddiesCard),
+                                    color: ColorsUtils.buddiesCard.withOpacity(0.5)),
                                 child: Row(
                                   mainAxisAlignment: MainAxisAlignment.center,
                                   children: [
                                     const Icon(
                                       Icons.close,
                                       size: 20,
-                                      color: Colors.black,
+                                      color: ColorsUtils.chipText,
                                     ),
                                     const SizedBox(
                                       width: 10,
@@ -306,7 +306,7 @@ class _BuddiesProfilePageState extends State<BuddiesProfilePage> {
                                       textStyle: Theme.of(context)
                                           .textTheme
                                           .titleSmall!
-                                          .copyWith(color: const Color(0xFF2B2B2B), fontSize: 11.0, fontWeight: FontWeight.w500),
+                                          .copyWith(color: ColorsUtils.chipText, fontSize: 11.0, fontWeight: FontWeight.w500),
                                     ),
                                   ],
                                 ),
@@ -338,15 +338,15 @@ class _BuddiesProfilePageState extends State<BuddiesProfilePage> {
                                             bottomLeft: Radius.circular(10),
                                             bottomRight: Radius.circular(10),
                                             topRight: Radius.circular(10)),
-                                        border: Border.all(color: const Color(0xffF1F1F1)),
-                                        color: const Color(0xffF1F1F1).withOpacity(0.5)),
+                                        border: Border.all(color: ColorsUtils.buddiesCard),
+                                        color: ColorsUtils.buddiesCard.withOpacity(0.5)),
                                     child: Row(
                                       mainAxisAlignment: MainAxisAlignment.center,
                                       children: [
                                         const Icon(
                                           Icons.close,
                                           size: 20,
-                                          color: Colors.black,
+                                          color: ColorsUtils.chipText,
                                         ),
                                         const SizedBox(
                                           width: 10,
@@ -357,7 +357,7 @@ class _BuddiesProfilePageState extends State<BuddiesProfilePage> {
                                           textStyle: Theme.of(context)
                                               .textTheme
                                               .titleSmall!
-                                              .copyWith(color: const Color(0xFF2B2B2B), fontSize: 11.0, fontWeight: FontWeight.w500),
+                                              .copyWith(color: ColorsUtils.chipText, fontSize: 11.0, fontWeight: FontWeight.w500),
                                         ),
                                       ],
                                     ),
@@ -390,15 +390,15 @@ class _BuddiesProfilePageState extends State<BuddiesProfilePage> {
                                 height: 50,
                                 decoration: BoxDecoration(
                                     borderRadius: const BorderRadius.only(topLeft: Radius.circular(10), bottomLeft: Radius.circular(10)),
-                                    border: Border.all(color: const Color(0xffF1F1F1)),
-                                    color: const Color(0xffF1F1F1).withOpacity(0.5)),
+                                    border: Border.all(color: ColorsUtils.buddiesCard),
+                                    color: ColorsUtils.buddiesCard.withOpacity(0.5)),
                                 child: Row(
                                   mainAxisAlignment: MainAxisAlignment.center,
                                   children: [
                                     const Icon(
                                       Icons.close,
                                       size: 20,
-                                      color: Colors.black,
+                                      color: ColorsUtils.chipText,
                                     ),
                                     const SizedBox(
                                       width: 10,
@@ -409,7 +409,7 @@ class _BuddiesProfilePageState extends State<BuddiesProfilePage> {
                                       textStyle: Theme.of(context)
                                           .textTheme
                                           .titleSmall!
-                                          .copyWith(color: const Color(0xFF2B2B2B), fontSize: 11.0, fontWeight: FontWeight.w500),
+                                          .copyWith(color: ColorsUtils.chipText, fontSize: 11.0, fontWeight: FontWeight.w500),
                                     ),
                                   ],
                                 ),
@@ -428,15 +428,15 @@ class _BuddiesProfilePageState extends State<BuddiesProfilePage> {
                                 height: 50,
                                 decoration: BoxDecoration(
                                     borderRadius: const BorderRadius.only(topRight: Radius.circular(10), bottomRight: Radius.circular(10)),
-                                    border: Border.all(color: const Color(0xffF1F1F1)),
-                                    color: const Color(0xffF1F1F1).withOpacity(0.5)),
+                                    border: Border.all(color: ColorsUtils.buddiesCard),
+                                    color: ColorsUtils.buddiesCard.withOpacity(0.5)),
                                 child: Row(
                                   mainAxisAlignment: MainAxisAlignment.center,
                                   children: [
                                     const Icon(
                                       Icons.check,
                                       size: 20,
-                                      color: Color(0xff3C80A8),
+                                      color: ColorsUtils.profileBlue,
                                     ),
                                     const SizedBox(
                                       width: 10,
@@ -447,7 +447,7 @@ class _BuddiesProfilePageState extends State<BuddiesProfilePage> {
                                       textStyle: Theme.of(context)
                                           .textTheme
                                           .titleSmall!
-                                          .copyWith(color: const Color(0xFF3C80A8), fontSize: 11.0, fontWeight: FontWeight.w500),
+                                          .copyWith(color: ColorsUtils.profileBlue, fontSize: 11.0, fontWeight: FontWeight.w500),
                                     ),
                                   ],
                                 ),
@@ -478,7 +478,7 @@ class _BuddiesProfilePageState extends State<BuddiesProfilePage> {
                         label: 'Interests',
                         type: styleSubTitle,
                         textStyle:
-                            Theme.of(context).textTheme.titleMedium!.copyWith(color: const Color(0xFF2B2B2B), fontSize: 16.0, fontWeight: FontWeight.w600),
+                            Theme.of(context).textTheme.titleMedium!.copyWith(color: ColorsUtils.chipText, fontSize: 16.0, fontWeight: FontWeight.w600),
                       ),
                       const SizedBox(
                         height: 8,
@@ -500,7 +500,7 @@ class _BuddiesProfilePageState extends State<BuddiesProfilePage> {
                                           textStyle: Theme.of(context)
                                               .textTheme
                                               .titleMedium!
-                                              .copyWith(color: const Color(0xFF2B2B2B), fontWeight: FontWeight.w400, fontSize: 18.0),
+                                              .copyWith(color: ColorsUtils.chipText, fontWeight: FontWeight.w400, fontSize: 18.0),
                                         ),
                                         const SizedBox(
                                           height: 10.0,
@@ -557,7 +557,7 @@ class _BuddiesProfilePageState extends State<BuddiesProfilePage> {
                         label: 'Interests',
                         type: styleSubTitle,
                         textStyle:
-                            Theme.of(context).textTheme.titleMedium!.copyWith(color: const Color(0xFF2B2B2B), fontSize: 16.0, fontWeight: FontWeight.w600),
+                            Theme.of(context).textTheme.titleMedium!.copyWith(color: ColorsUtils.chipText, fontSize: 16.0, fontWeight: FontWeight.w600),
                       ),
                       const SizedBox(
                         height: 8,
@@ -579,7 +579,7 @@ class _BuddiesProfilePageState extends State<BuddiesProfilePage> {
                                           textStyle: Theme.of(context)
                                               .textTheme
                                               .titleMedium!
-                                              .copyWith(color: const Color(0xFF2B2B2B), fontWeight: FontWeight.w400, fontSize: 18.0),
+                                              .copyWith(color: ColorsUtils.chipText, fontWeight: FontWeight.w400, fontSize: 18.0),
                                         ),
                                         const SizedBox(
                                           height: 10.0,

--- a/lib/screens/buddies/features/buddies/presentaion/buddies_screen.dart
+++ b/lib/screens/buddies/features/buddies/presentaion/buddies_screen.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 
 import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
+import 'package:oqdo_mobile_app/utils/colorsUtils.dart';
 import 'package:oqdo_mobile_app/components/custom_app_bar.dart';
 import 'package:oqdo_mobile_app/oqdo_application.dart';
 import 'package:oqdo_mobile_app/screens/buddies/features/buddies/data/get_all_buddies_repository.dart';
@@ -84,7 +85,7 @@ class _BuddiesScreenState extends State<BuddiesScreen> {
               padding: const EdgeInsets.only(right: 10.0, top: 15, bottom: 15),
               child: CustomTextView(
                 label: 'Your Friends',
-                textStyle: Theme.of(context).textTheme.bodyMedium!.copyWith(fontSize: 18, color: const Color(0xFF006590), fontWeight: FontWeight.w500),
+                textStyle: Theme.of(context).textTheme.bodyMedium!.copyWith(fontSize: 18, color: ColorsUtils.accentBlue, fontWeight: FontWeight.w500),
                 textAlign: TextAlign.center,
               ),
             ),
@@ -97,7 +98,7 @@ class _BuddiesScreenState extends State<BuddiesScreen> {
           child: Container(
             width: MediaQuery.of(context).size.width,
             height: MediaQuery.of(context).size.height,
-            color: Colors.white,
+            color: ColorsUtils.white,
             child: Padding(
               padding: const EdgeInsets.symmetric(horizontal: 10.0),
               child: Column(
@@ -112,9 +113,9 @@ class _BuddiesScreenState extends State<BuddiesScreen> {
                       padding: const EdgeInsets.all(8),
                       width: MediaQuery.of(context).size.width,
                       decoration: BoxDecoration(
-                          color: const Color(0xFFF5F5F5),
+                          color: ColorsUtils.buddiesBackground,
                           border: Border.all(
-                            color: const Color(0xFFF5F5F5),
+                            color: ColorsUtils.buddiesBackground,
                           ),
                           borderRadius: const BorderRadius.all(Radius.circular(10))),
                       child: SizedBox(
@@ -320,7 +321,7 @@ class _BuddiesScreenState extends State<BuddiesScreen> {
                     textStyle: Theme.of(context)
                         .textTheme
                         .titleSmall!
-                        .copyWith(color: const Color(0xFF2B2B2B), fontSize: 13.0, fontWeight: FontWeight.w600, overflow: TextOverflow.ellipsis),
+                        .copyWith(color: ColorsUtils.chipText, fontSize: 13.0, fontWeight: FontWeight.w600, overflow: TextOverflow.ellipsis),
                   ),
                   const SizedBox(
                     height: 8,
@@ -328,7 +329,7 @@ class _BuddiesScreenState extends State<BuddiesScreen> {
                   CustomTextView(
                     label: allBuddiesModel.aboutYourSelf,
                     type: styleSubTitle,
-                    textStyle: Theme.of(context).textTheme.titleSmall!.copyWith(color: const Color(0xFF2B2B2B), fontSize: 11.0, fontWeight: FontWeight.w500),
+                    textStyle: Theme.of(context).textTheme.titleSmall!.copyWith(color: ColorsUtils.chipText, fontSize: 11.0, fontWeight: FontWeight.w500),
                   ),
                   const SizedBox(
                     height: 8,
@@ -469,7 +470,7 @@ class _BuddiesScreenState extends State<BuddiesScreen> {
                     textStyle: Theme.of(context)
                         .textTheme
                         .titleSmall!
-                        .copyWith(color: const Color(0xFF2B2B2B), fontSize: 13.0, fontWeight: FontWeight.w600, overflow: TextOverflow.ellipsis),
+                        .copyWith(color: ColorsUtils.chipText, fontSize: 13.0, fontWeight: FontWeight.w600, overflow: TextOverflow.ellipsis),
                   ),
                   const SizedBox(
                     height: 8,
@@ -477,7 +478,7 @@ class _BuddiesScreenState extends State<BuddiesScreen> {
                   CustomTextView(
                     label: allBuddiesModel.aboutYourSelf,
                     type: styleSubTitle,
-                    textStyle: Theme.of(context).textTheme.titleSmall!.copyWith(color: const Color(0xFF2B2B2B), fontSize: 11.0, fontWeight: FontWeight.w500),
+                    textStyle: Theme.of(context).textTheme.titleSmall!.copyWith(color: ColorsUtils.chipText, fontSize: 11.0, fontWeight: FontWeight.w500),
                   ),
                   const SizedBox(
                     height: 8,

--- a/lib/screens/buddies/features/buddies/presentaion/create_chat_screen.dart
+++ b/lib/screens/buddies/features/buddies/presentaion/create_chat_screen.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 
 import 'package:flutter/material.dart';
+import 'package:oqdo_mobile_app/utils/colorsUtils.dart';
 import 'package:oqdo_mobile_app/components/custom_app_bar.dart';
 import 'package:oqdo_mobile_app/oqdo_application.dart';
 import 'package:oqdo_mobile_app/screens/buddies/features/buddies/data/get_all_buddies_repository.dart';
@@ -78,7 +79,7 @@ class _CreateChatScreenState extends State<CreateChatScreen> {
           child: Container(
             width: MediaQuery.of(context).size.width,
             height: MediaQuery.of(context).size.height,
-            color: Colors.white,
+            color: ColorsUtils.white,
             child: Padding(
               padding: const EdgeInsets.symmetric(horizontal: 10.0),
               child: Column(
@@ -90,9 +91,9 @@ class _CreateChatScreenState extends State<CreateChatScreen> {
                       padding: const EdgeInsets.all(8),
                       width: MediaQuery.of(context).size.width,
                       decoration: BoxDecoration(
-                          color: const Color(0xFFF5F5F5),
+                          color: ColorsUtils.buddiesBackground,
                           border: Border.all(
-                            color: const Color(0xFFF5F5F5),
+                            color: ColorsUtils.buddiesBackground,
                           ),
                           borderRadius: const BorderRadius.all(Radius.circular(10))),
                       child: SizedBox(

--- a/lib/screens/buddies/features/buddies/presentaion/create_group_screen.dart
+++ b/lib/screens/buddies/features/buddies/presentaion/create_group_screen.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 
 import 'package:flutter/material.dart';
+import 'package:oqdo_mobile_app/utils/colorsUtils.dart';
 import 'package:oqdo_mobile_app/components/custom_app_bar.dart';
 import 'package:oqdo_mobile_app/oqdo_application.dart';
 import 'package:oqdo_mobile_app/screens/buddies/features/buddies/data/get_all_buddies_repository.dart';
@@ -98,7 +99,7 @@ class _CreateGroupScreenState extends State<CreateGroupScreen> {
             quarterTurns: 3,
             child: Icon(
               Icons.arrow_downward,
-              color: Colors.white,
+              color: ColorsUtils.white,
             ),
           )),
       appBar: CustomAppBar(
@@ -110,7 +111,7 @@ class _CreateGroupScreenState extends State<CreateGroupScreen> {
         child: Container(
           width: MediaQuery.of(context).size.width,
           height: MediaQuery.of(context).size.height,
-          color: Colors.white,
+          color: ColorsUtils.white,
           child: Padding(
             padding: const EdgeInsets.symmetric(horizontal: 10.0),
             child: Column(
@@ -165,9 +166,9 @@ class _CreateGroupScreenState extends State<CreateGroupScreen> {
                     padding: const EdgeInsets.all(8),
                     width: MediaQuery.of(context).size.width,
                     decoration: BoxDecoration(
-                        color: const Color(0xFFF5F5F5),
+                        color: ColorsUtils.buddiesBackground,
                         border: Border.all(
-                          color: const Color(0xFFF5F5F5),
+                          color: ColorsUtils.buddiesBackground,
                         ),
                         borderRadius: const BorderRadius.all(Radius.circular(10))),
                     child: SizedBox(
@@ -352,7 +353,7 @@ class _CreateGroupScreenState extends State<CreateGroupScreen> {
             }
           });
         },
-        backgroundColor: Colors.white);
+        backgroundColor: ColorsUtils.white);
   }
 
   Widget singleBuddyView(AllBuddiesModel allBuddiesModel) {
@@ -381,14 +382,14 @@ class _CreateGroupScreenState extends State<CreateGroupScreen> {
               children: [
                 Container(
                   padding: const EdgeInsets.only(top: 10, bottom: 10, left: 4, right: 4),
-                  decoration: BoxDecoration(color: allBuddiesModel.isSelected ? OQDOThemeData.buttonColor : Colors.white),
+                  decoration: BoxDecoration(color: allBuddiesModel.isSelected ? OQDOThemeData.buttonColor : ColorsUtils.white),
                   child: CustomTextView(
                     label: '${allBuddiesModel.firstName} ${allBuddiesModel.lastName}',
                     maxLine: 3,
                     textOverFlow: TextOverflow.ellipsis,
                     type: styleSubTitle,
                     textStyle: Theme.of(context).textTheme.titleSmall!.copyWith(
-                        color: allBuddiesModel.isSelected ? Colors.white : Colors.black,
+                        color: allBuddiesModel.isSelected ? ColorsUtils.white : ColorsUtils.chipText,
                         fontSize: 15.0,
                         fontWeight: FontWeight.w500,
                         overflow: TextOverflow.ellipsis),

--- a/lib/screens/buddies/features/buddies/presentaion/direct_friend_chat_screen.dart
+++ b/lib/screens/buddies/features/buddies/presentaion/direct_friend_chat_screen.dart
@@ -78,7 +78,7 @@ class _DirectFriendChatScreenState extends State<DirectFriendChatScreen> {
     return WillPopScope(
       onWillPop: _willPopCallback,
       child: Scaffold(
-        backgroundColor: Colors.white,
+        backgroundColor: ColorsUtils.white,
         appBar: CustomAppBar(
             title: 'Chat',
             onBack: () {
@@ -91,7 +91,7 @@ class _DirectFriendChatScreenState extends State<DirectFriendChatScreen> {
         body: Container(
           width: MediaQuery.of(context).size.width,
           height: MediaQuery.of(context).size.height,
-          color: Colors.white,
+          color: ColorsUtils.white,
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
@@ -102,7 +102,7 @@ class _DirectFriendChatScreenState extends State<DirectFriendChatScreen> {
                   //crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
                     Card(
-                      color: Colors.white,
+                      color: ColorsUtils.white,
                       elevation: 0,
                       child: ClipPath(
                         clipper: ShapeBorderClipper(shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(10))),
@@ -138,7 +138,7 @@ class _DirectFriendChatScreenState extends State<DirectFriendChatScreen> {
                             textStyle: Theme.of(context)
                                 .textTheme
                                 .titleSmall!
-                                .copyWith(color: const Color(0xFF2B2B2B), fontSize: 16.0, fontWeight: FontWeight.w600, overflow: TextOverflow.ellipsis),
+                                .copyWith(color: ColorsUtils.chipText, fontSize: 16.0, fontWeight: FontWeight.w600, overflow: TextOverflow.ellipsis),
                           ),
                           const SizedBox(
                             height: 6,
@@ -163,7 +163,7 @@ class _DirectFriendChatScreenState extends State<DirectFriendChatScreen> {
                               textStyle: Theme.of(context)
                                   .textTheme
                                   .titleSmall!
-                                  .copyWith(color: const Color(0xFF2B2B2B), fontSize: 14.0, fontWeight: FontWeight.w500, overflow: TextOverflow.ellipsis),
+                                  .copyWith(color: ColorsUtils.chipText, fontSize: 14.0, fontWeight: FontWeight.w500, overflow: TextOverflow.ellipsis),
                             ),
                           ]),
                           const SizedBox(
@@ -192,9 +192,9 @@ class _DirectFriendChatScreenState extends State<DirectFriendChatScreen> {
                       padding: const EdgeInsets.all(8),
                       width: MediaQuery.of(context).size.width,
                       decoration: BoxDecoration(
-                          color: const Color(0xFFF5F5F5),
+                          color: ColorsUtils.buddiesBackground,
                           border: Border.all(
-                            color: const Color(0xFFF5F5F5),
+                            color: ColorsUtils.buddiesBackground,
                           ),
                           borderRadius: const BorderRadius.all(Radius.circular(10))),
                       child: Row(
@@ -330,7 +330,7 @@ class _DirectFriendChatScreenState extends State<DirectFriendChatScreen> {
                             CustomTextView(
                               maxLine: 10,
                               label: messageList[index].message.toString(),
-                              textStyle: const TextStyle(fontSize: 15, color: Colors.black),
+                              textStyle: TextStyle(fontSize: 15, color: ColorsUtils.chipText),
                             ),
                           ],
                         )),
@@ -346,7 +346,7 @@ class _DirectFriendChatScreenState extends State<DirectFriendChatScreen> {
                       children: [
                         CustomTextView(
                           label: formattedDate.toString(),
-                          textStyle: const TextStyle(fontSize: 15, color: Colors.black54),
+                          textStyle: TextStyle(fontSize: 15, color: ColorsUtils.greyText),
                         ),
                       ],
                     ),
@@ -369,7 +369,7 @@ class _DirectFriendChatScreenState extends State<DirectFriendChatScreen> {
             alignment: Alignment.center,
             child: CustomTextView(
               label: "No history found",
-              textStyle: const TextStyle(fontSize: 16, color: Colors.black),
+              textStyle: TextStyle(fontSize: 16, color: ColorsUtils.chipText),
             ),
           )
         ],

--- a/lib/screens/buddies/features/buddies/presentaion/direct_group_chat_screen.dart
+++ b/lib/screens/buddies/features/buddies/presentaion/direct_group_chat_screen.dart
@@ -90,7 +90,7 @@ class _DirectGroupChatScreenState extends State<DirectGroupChatScreen> {
         body: Container(
           width: MediaQuery.of(context).size.width,
           height: MediaQuery.of(context).size.height,
-          color: Colors.white,
+          color: ColorsUtils.white,
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
@@ -105,7 +105,7 @@ class _DirectGroupChatScreenState extends State<DirectGroupChatScreen> {
                     //crossAxisAlignment: CrossAxisAlignment.start,
                     children: [
                       Card(
-                        color: Colors.white,
+                        color: ColorsUtils.white,
                         elevation: 0,
                         child: ClipPath(
                           clipper: ShapeBorderClipper(shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(10))),
@@ -139,7 +139,7 @@ class _DirectGroupChatScreenState extends State<DirectGroupChatScreen> {
                               textStyle: Theme.of(context)
                                   .textTheme
                                   .titleSmall!
-                                  .copyWith(color: const Color(0xFF2B2B2B), fontSize: 16.0, fontWeight: FontWeight.w600, overflow: TextOverflow.ellipsis),
+                                  .copyWith(color: ColorsUtils.chipText, fontSize: 16.0, fontWeight: FontWeight.w600, overflow: TextOverflow.ellipsis),
                             ),
                             const SizedBox(
                               height: 8,
@@ -168,9 +168,9 @@ class _DirectGroupChatScreenState extends State<DirectGroupChatScreen> {
                       padding: const EdgeInsets.all(8),
                       width: MediaQuery.of(context).size.width,
                       decoration: BoxDecoration(
-                          color: const Color(0xFFF5F5F5),
+                          color: ColorsUtils.buddiesBackground,
                           border: Border.all(
-                            color: const Color(0xFFF5F5F5),
+                            color: ColorsUtils.buddiesBackground,
                           ),
                           borderRadius: const BorderRadius.all(Radius.circular(10))),
                       child: Row(
@@ -305,7 +305,7 @@ class _DirectGroupChatScreenState extends State<DirectGroupChatScreen> {
                               child: CustomTextView(
                                 label: "${messageList[index].firstName} ${messageList[index].lastName}",
                                 maxLine: 1,
-                                textStyle: const TextStyle(fontSize: 15, color: Colors.black, fontWeight: FontWeight.w500),
+                                textStyle: TextStyle(fontSize: 15, color: ColorsUtils.chipText, fontWeight: FontWeight.w500),
                               ),
                             ),
                             Visibility(
@@ -316,7 +316,7 @@ class _DirectGroupChatScreenState extends State<DirectGroupChatScreen> {
                             CustomTextView(
                               maxLine: 10,
                               label: messageList[index].message.toString(),
-                              textStyle: const TextStyle(fontSize: 15, color: Colors.black),
+                              textStyle: TextStyle(fontSize: 15, color: ColorsUtils.chipText),
                             ),
                           ],
                         )),
@@ -332,7 +332,7 @@ class _DirectGroupChatScreenState extends State<DirectGroupChatScreen> {
                       children: [
                         CustomTextView(
                           label: formattedDate.toString(),
-                          textStyle: const TextStyle(fontSize: 15, color: Colors.black54),
+                          textStyle: TextStyle(fontSize: 15, color: ColorsUtils.greyText),
                         ),
                       ],
                     ),
@@ -355,7 +355,7 @@ class _DirectGroupChatScreenState extends State<DirectGroupChatScreen> {
             alignment: Alignment.center,
             child: CustomTextView(
               label: "No history found",
-              textStyle: const TextStyle(fontSize: 16, color: Colors.black),
+              textStyle: TextStyle(fontSize: 16, color: ColorsUtils.chipText),
             ),
           )
         ],

--- a/lib/screens/buddies/features/buddies/presentaion/friend_chat_screen.dart
+++ b/lib/screens/buddies/features/buddies/presentaion/friend_chat_screen.dart
@@ -64,7 +64,7 @@ class _FriendChatScreenState extends State<FriendChatScreen> {
     return WillPopScope(
       onWillPop: _willPopCallback,
       child: Scaffold(
-        backgroundColor: Colors.white,
+        backgroundColor: ColorsUtils.white,
         appBar: CustomAppBar(
             title: 'Chat',
             onBack: () {
@@ -77,7 +77,7 @@ class _FriendChatScreenState extends State<FriendChatScreen> {
         body: Container(
           width: MediaQuery.of(context).size.width,
           height: MediaQuery.of(context).size.height,
-          color: Colors.white,
+          color: ColorsUtils.white,
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
@@ -125,7 +125,7 @@ class _FriendChatScreenState extends State<FriendChatScreen> {
                   //crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
                     Card(
-                      color: Colors.white,
+                      color: ColorsUtils.white,
                       elevation: 0,
                       child: ClipPath(
                         clipper: ShapeBorderClipper(shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(10))),
@@ -166,7 +166,7 @@ class _FriendChatScreenState extends State<FriendChatScreen> {
                             textStyle: Theme.of(context)
                                 .textTheme
                                 .titleSmall!
-                                .copyWith(color: const Color(0xFF2B2B2B), fontSize: 16.0, fontWeight: FontWeight.w600, overflow: TextOverflow.ellipsis),
+                                .copyWith(color: ColorsUtils.chipText, fontSize: 16.0, fontWeight: FontWeight.w600, overflow: TextOverflow.ellipsis),
                           ),
                           const SizedBox(
                             height: 6,
@@ -191,7 +191,7 @@ class _FriendChatScreenState extends State<FriendChatScreen> {
                               textStyle: Theme.of(context)
                                   .textTheme
                                   .titleSmall!
-                                  .copyWith(color: const Color(0xFF2B2B2B), fontSize: 14.0, fontWeight: FontWeight.w500, overflow: TextOverflow.ellipsis),
+                                  .copyWith(color: ColorsUtils.chipText, fontSize: 14.0, fontWeight: FontWeight.w500, overflow: TextOverflow.ellipsis),
                             ),
                           ]),
                           const SizedBox(
@@ -220,9 +220,9 @@ class _FriendChatScreenState extends State<FriendChatScreen> {
                       padding: const EdgeInsets.all(8),
                       width: MediaQuery.of(context).size.width,
                       decoration: BoxDecoration(
-                          color: const Color(0xFFF5F5F5),
+                          color: ColorsUtils.buddiesBackground,
                           border: Border.all(
-                            color: const Color(0xFFF5F5F5),
+                            color: ColorsUtils.buddiesBackground,
                           ),
                           borderRadius: const BorderRadius.all(Radius.circular(10))),
                       child: Row(
@@ -324,7 +324,7 @@ class _FriendChatScreenState extends State<FriendChatScreen> {
                             CustomTextView(
                               label: messageList[index].message.toString(),
                               maxLine: 10,
-                              textStyle: const TextStyle(fontSize: 15, color: Colors.black),
+                              textStyle: TextStyle(fontSize: 15, color: ColorsUtils.chipText),
                             ),
                           ],
                         )),
@@ -340,7 +340,7 @@ class _FriendChatScreenState extends State<FriendChatScreen> {
                       children: [
                         CustomTextView(
                           label: formattedDate.toString(),
-                          textStyle: const TextStyle(fontSize: 15, color: Colors.black54),
+                          textStyle: TextStyle(fontSize: 15, color: ColorsUtils.greyText),
                         ),
                       ],
                     ),
@@ -363,7 +363,7 @@ class _FriendChatScreenState extends State<FriendChatScreen> {
             alignment: Alignment.center,
             child: CustomTextView(
               label: "No history found",
-              textStyle: const TextStyle(fontSize: 16, color: Colors.black),
+              textStyle: TextStyle(fontSize: 16, color: ColorsUtils.chipText),
             ),
           )
         ],

--- a/lib/screens/buddies/features/buddies/presentaion/group_chat_screen.dart
+++ b/lib/screens/buddies/features/buddies/presentaion/group_chat_screen.dart
@@ -77,7 +77,7 @@ class _GroupChatScreenState extends State<GroupChatScreen> {
         body: Container(
           width: MediaQuery.of(context).size.width,
           height: MediaQuery.of(context).size.height,
-          color: Colors.white,
+          color: ColorsUtils.white,
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
@@ -125,7 +125,7 @@ class _GroupChatScreenState extends State<GroupChatScreen> {
                     //crossAxisAlignment: CrossAxisAlignment.start,
                     children: [
                       Card(
-                        color: Colors.white,
+                        color: ColorsUtils.white,
                         elevation: 0,
                         child: ClipPath(
                           clipper: ShapeBorderClipper(shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(10))),
@@ -159,7 +159,7 @@ class _GroupChatScreenState extends State<GroupChatScreen> {
                               textStyle: Theme.of(context)
                                   .textTheme
                                   .titleSmall!
-                                  .copyWith(color: const Color(0xFF2B2B2B), fontSize: 16.0, fontWeight: FontWeight.w600, overflow: TextOverflow.ellipsis),
+                                  .copyWith(color: ColorsUtils.chipText, fontSize: 16.0, fontWeight: FontWeight.w600, overflow: TextOverflow.ellipsis),
                             ),
                             const SizedBox(
                               height: 8,
@@ -188,9 +188,9 @@ class _GroupChatScreenState extends State<GroupChatScreen> {
                       padding: const EdgeInsets.all(8),
                       width: MediaQuery.of(context).size.width,
                       decoration: BoxDecoration(
-                          color: const Color(0xFFF5F5F5),
+                          color: ColorsUtils.buddiesBackground,
                           border: Border.all(
-                            color: const Color(0xFFF5F5F5),
+                            color: ColorsUtils.buddiesBackground,
                           ),
                           borderRadius: const BorderRadius.all(Radius.circular(10))),
                       child: Row(
@@ -288,7 +288,7 @@ class _GroupChatScreenState extends State<GroupChatScreen> {
                               child: CustomTextView(
                                 label: "${messageList[index].firstName} ${messageList[index].lastName}",
                                 maxLine: 1,
-                                textStyle: const TextStyle(fontSize: 15, color: Colors.black, fontWeight: FontWeight.w500),
+                                textStyle: TextStyle(fontSize: 15, color: ColorsUtils.chipText, fontWeight: FontWeight.w500),
                               ),
                             ),
                             Visibility(
@@ -299,7 +299,7 @@ class _GroupChatScreenState extends State<GroupChatScreen> {
                             CustomTextView(
                               label: messageList[index].message.toString(),
                               maxLine: 10,
-                              textStyle: const TextStyle(fontSize: 15, color: Colors.black),
+                              textStyle: TextStyle(fontSize: 15, color: ColorsUtils.chipText),
                             ),
                           ],
                         )),
@@ -315,7 +315,7 @@ class _GroupChatScreenState extends State<GroupChatScreen> {
                       children: [
                         CustomTextView(
                           label: formattedDate.toString(),
-                          textStyle: const TextStyle(fontSize: 15, color: Colors.black54),
+                          textStyle: TextStyle(fontSize: 15, color: ColorsUtils.greyText),
                         ),
                       ],
                     ),
@@ -338,7 +338,7 @@ class _GroupChatScreenState extends State<GroupChatScreen> {
             alignment: Alignment.center,
             child: CustomTextView(
               label: "No history found",
-              textStyle: const TextStyle(fontSize: 16, color: Colors.black),
+              textStyle: TextStyle(fontSize: 16, color: ColorsUtils.chipText),
             ),
           )
         ],

--- a/lib/screens/buddies/features/buddies/presentaion/group_detail_screen.dart
+++ b/lib/screens/buddies/features/buddies/presentaion/group_detail_screen.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 
 import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
+import 'package:oqdo_mobile_app/utils/colorsUtils.dart';
 import 'package:oqdo_mobile_app/components/custom_app_bar.dart';
 import 'package:oqdo_mobile_app/oqdo_application.dart';
 import 'package:oqdo_mobile_app/screens/buddies/features/buddies/data/get_all_buddies_repository.dart';
@@ -57,7 +58,7 @@ class _GroupDetailScreenState extends State<GroupDetailScreen> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      backgroundColor: Colors.white,
+      backgroundColor: ColorsUtils.white,
       appBar: CustomAppBar(
           title: 'Group Detail',
           onBack: () {
@@ -99,7 +100,7 @@ class _GroupDetailScreenState extends State<GroupDetailScreen> {
                   child: Icon(
                     Icons.done_rounded,
                     size: 25,
-                    color: Colors.black,
+                    color: ColorsUtils.chipText,
                   ),
                 ),
               ),
@@ -151,7 +152,7 @@ class _GroupDetailScreenState extends State<GroupDetailScreen> {
                 height: 6,
               ),
               const Divider(
-                color: Colors.grey,
+                color: ColorsUtils.greyCircle,
               ),
               const SizedBox(
                 height: 16,
@@ -212,7 +213,7 @@ class _GroupDetailScreenState extends State<GroupDetailScreen> {
                               textStyle: Theme.of(context)
                                   .textTheme
                                   .titleSmall!
-                                  .copyWith(color: const Color(0xFF2B2B2B), fontSize: 14.0, fontWeight: FontWeight.w500, overflow: TextOverflow.ellipsis),
+                                  .copyWith(color: ColorsUtils.chipText, fontSize: 14.0, fontWeight: FontWeight.w500, overflow: TextOverflow.ellipsis),
                             ),
                             const SizedBox(
                               height: 2,
@@ -372,7 +373,7 @@ class _GroupDetailScreenState extends State<GroupDetailScreen> {
                     textStyle: Theme.of(context)
                         .textTheme
                         .titleSmall!
-                        .copyWith(color: const Color(0xFF2B2B2B), fontSize: 14.0, fontWeight: FontWeight.w500, overflow: TextOverflow.ellipsis),
+                        .copyWith(color: ColorsUtils.chipText, fontSize: 14.0, fontWeight: FontWeight.w500, overflow: TextOverflow.ellipsis),
                   ),
                   const SizedBox(
                     height: 2,

--- a/lib/screens/buddies/features/buddies/presentaion/group_info_screen.dart
+++ b/lib/screens/buddies/features/buddies/presentaion/group_info_screen.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 
 import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
+import 'package:oqdo_mobile_app/utils/colorsUtils.dart';
 import 'package:oqdo_mobile_app/components/custom_app_bar.dart';
 import 'package:oqdo_mobile_app/oqdo_application.dart';
 import 'package:oqdo_mobile_app/screens/buddies/features/buddies/data/get_all_buddies_repository.dart';
@@ -44,7 +45,7 @@ class _GroupInfoScreenState extends State<GroupInfoScreen> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      backgroundColor: Colors.white,
+      backgroundColor: ColorsUtils.white,
       appBar: CustomAppBar(
           title: 'Group Detail',
           onBack: () {
@@ -96,7 +97,7 @@ class _GroupInfoScreenState extends State<GroupInfoScreen> {
                 height: 6,
               ),
               const Divider(
-                color: Colors.grey,
+                color: ColorsUtils.greyCircle,
               ),
               const SizedBox(
                 height: 16,
@@ -195,7 +196,7 @@ class _GroupInfoScreenState extends State<GroupInfoScreen> {
                     textStyle: Theme.of(context)
                         .textTheme
                         .titleSmall!
-                        .copyWith(color: const Color(0xFF2B2B2B), fontSize: 14.0, fontWeight: FontWeight.w500, overflow: TextOverflow.ellipsis),
+                        .copyWith(color: ColorsUtils.chipText, fontSize: 14.0, fontWeight: FontWeight.w500, overflow: TextOverflow.ellipsis),
                   ),
                   const SizedBox(
                     height: 2,

--- a/lib/screens/buddies/features/buddies/presentaion/group_list_screen.dart
+++ b/lib/screens/buddies/features/buddies/presentaion/group_list_screen.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 
 import 'package:flutter/material.dart';
+import 'package:oqdo_mobile_app/utils/colorsUtils.dart';
 import 'package:oqdo_mobile_app/components/custom_app_bar.dart';
 import 'package:oqdo_mobile_app/oqdo_application.dart';
 import 'package:oqdo_mobile_app/screens/buddies/features/buddies/data/get_all_buddies_repository.dart';
@@ -93,7 +94,7 @@ class _GroupListScreenState extends State<GroupListScreen> {
           height: 26,
           width: 26,
           fit: BoxFit.fill,
-          color: Colors.white,
+          color: ColorsUtils.white,
         ),
       ),
       appBar: CustomAppBar(
@@ -105,7 +106,7 @@ class _GroupListScreenState extends State<GroupListScreen> {
         child: Container(
           width: MediaQuery.of(context).size.width,
           height: MediaQuery.of(context).size.height,
-          color: Colors.white,
+          color: ColorsUtils.white,
           child: Padding(
             padding: const EdgeInsets.symmetric(horizontal: 10.0),
             child: Column(
@@ -120,9 +121,9 @@ class _GroupListScreenState extends State<GroupListScreen> {
                     padding: const EdgeInsets.all(8),
                     width: MediaQuery.of(context).size.width,
                     decoration: BoxDecoration(
-                        color: const Color(0xFFF5F5F5),
+                        color: ColorsUtils.buddiesBackground,
                         border: Border.all(
-                          color: const Color(0xFFF5F5F5),
+                          color: ColorsUtils.buddiesBackground,
                         ),
                         borderRadius: const BorderRadius.all(Radius.circular(10))),
                     child: SizedBox(
@@ -296,7 +297,7 @@ class _GroupListScreenState extends State<GroupListScreen> {
                     textStyle: Theme.of(context)
                         .textTheme
                         .titleSmall!
-                        .copyWith(color: const Color(0xFF2B2B2B), fontSize: 14.0, fontWeight: FontWeight.w600, overflow: TextOverflow.ellipsis),
+                        .copyWith(color: ColorsUtils.chipText, fontSize: 14.0, fontWeight: FontWeight.w600, overflow: TextOverflow.ellipsis),
                   ),
                   const SizedBox(
                     height: 6,
@@ -304,7 +305,7 @@ class _GroupListScreenState extends State<GroupListScreen> {
                   CustomTextView(
                     label: "${groupModel.groupFriends!.length} Member",
                     type: styleSubTitle,
-                    textStyle: Theme.of(context).textTheme.titleSmall!.copyWith(color: const Color(0xFF2B2B2B), fontSize: 12.0, fontWeight: FontWeight.w500),
+                    textStyle: Theme.of(context).textTheme.titleSmall!.copyWith(color: ColorsUtils.chipText, fontSize: 12.0, fontWeight: FontWeight.w500),
                   ),
                   const SizedBox(
                     height: 4,
@@ -377,7 +378,7 @@ class _GroupListScreenState extends State<GroupListScreen> {
                     textOverFlow: TextOverflow.ellipsis,
                     type: styleSubTitle,
                     textStyle: Theme.of(context).textTheme.titleSmall!.copyWith(
-                        color: const Color(0xFF2B2B2B),
+                        color: ColorsUtils.chipText,
                         fontSize: 14.0,
                         // fontWeight: groupModel.endUserId.toString() ==
                         //         OQDOApplication.instance.endUserID
@@ -392,7 +393,7 @@ class _GroupListScreenState extends State<GroupListScreen> {
                   CustomTextView(
                     label: "${groupModel.groupFriends!.length} Member",
                     type: styleSubTitle,
-                    textStyle: Theme.of(context).textTheme.titleSmall!.copyWith(color: const Color(0xFF2B2B2B), fontSize: 12.0, fontWeight: FontWeight.w500),
+                    textStyle: Theme.of(context).textTheme.titleSmall!.copyWith(color: ColorsUtils.chipText, fontSize: 12.0, fontWeight: FontWeight.w500),
                   ),
                   const SizedBox(
                     height: 8,

--- a/lib/screens/buddies/features/buddies/presentaion/my_friends_screen.dart
+++ b/lib/screens/buddies/features/buddies/presentaion/my_friends_screen.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 
 import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
+import 'package:oqdo_mobile_app/utils/colorsUtils.dart';
 import 'package:oqdo_mobile_app/components/custom_app_bar.dart';
 import 'package:oqdo_mobile_app/oqdo_application.dart';
 import 'package:oqdo_mobile_app/screens/buddies/features/buddies/data/get_all_buddies_repository.dart';
@@ -56,7 +57,7 @@ class _MyFriendsScreenState extends State<MyFriendsScreen> {
           child: Container(
             width: MediaQuery.of(context).size.width,
             height: MediaQuery.of(context).size.height,
-            color: Colors.white,
+            color: ColorsUtils.white,
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
@@ -94,7 +95,7 @@ class _MyFriendsScreenState extends State<MyFriendsScreen> {
                 allPendingFriendsList.isNotEmpty
                     ? const Divider(
                         height: 1,
-                        color: Colors.black87,
+                        color: ColorsUtils.chipText,
                       )
                     : const SizedBox(
                         height: 0,
@@ -226,7 +227,7 @@ class _MyFriendsScreenState extends State<MyFriendsScreen> {
                     textStyle: Theme.of(context)
                         .textTheme
                         .titleSmall!
-                        .copyWith(color: const Color(0xFF2B2B2B), fontSize: 13.0, fontWeight: FontWeight.w600, overflow: TextOverflow.ellipsis),
+                        .copyWith(color: ColorsUtils.chipText, fontSize: 13.0, fontWeight: FontWeight.w600, overflow: TextOverflow.ellipsis),
                   ),
                   const SizedBox(
                     height: 8,
@@ -239,7 +240,7 @@ class _MyFriendsScreenState extends State<MyFriendsScreen> {
                     textStyle: Theme.of(context)
                         .textTheme
                         .titleSmall!
-                        .copyWith(color: const Color(0xFF2B2B2B), fontSize: 11.0, fontWeight: FontWeight.w400, overflow: TextOverflow.ellipsis),
+                        .copyWith(color: ColorsUtils.chipText, fontSize: 11.0, fontWeight: FontWeight.w400, overflow: TextOverflow.ellipsis),
                   ),
                 ],
               ),
@@ -336,7 +337,7 @@ class _MyFriendsScreenState extends State<MyFriendsScreen> {
                     textStyle: Theme.of(context)
                         .textTheme
                         .titleSmall!
-                        .copyWith(color: const Color(0xFF2B2B2B), fontSize: 13.0, fontWeight: FontWeight.w600, overflow: TextOverflow.ellipsis),
+                        .copyWith(color: ColorsUtils.chipText, fontSize: 13.0, fontWeight: FontWeight.w600, overflow: TextOverflow.ellipsis),
                   ),
                   const SizedBox(
                     height: 8,
@@ -349,7 +350,7 @@ class _MyFriendsScreenState extends State<MyFriendsScreen> {
                     textStyle: Theme.of(context)
                         .textTheme
                         .titleSmall!
-                        .copyWith(color: const Color(0xFF2B2B2B), fontSize: 11.0, fontWeight: FontWeight.w400, overflow: TextOverflow.ellipsis),
+                        .copyWith(color: ColorsUtils.chipText, fontSize: 11.0, fontWeight: FontWeight.w400, overflow: TextOverflow.ellipsis),
                   ),
                 ],
               ),
@@ -363,7 +364,7 @@ class _MyFriendsScreenState extends State<MyFriendsScreen> {
                 children: [
                   TextButton(
                     style: TextButton.styleFrom(
-                        backgroundColor: Colors.white,
+                        backgroundColor: ColorsUtils.white,
                         shape: RoundedRectangleBorder(
                             side: BorderSide(color: Theme.of(context).colorScheme.primary, width: 1, style: BorderStyle.solid),
                             borderRadius: const BorderRadius.all(Radius.zero))),

--- a/lib/screens/buddies/features/meetups/presentation/add_meetup_screen.dart
+++ b/lib/screens/buddies/features/meetups/presentation/add_meetup_screen.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 
 import 'package:flutter/material.dart';
+import 'package:oqdo_mobile_app/utils/colorsUtils.dart';
 import 'package:flutter/services.dart';
 import 'package:intl/intl.dart';
 import 'package:oqdo_mobile_app/components/custom_app_bar.dart';
@@ -130,7 +131,7 @@ class _AddMeetupScreenState extends State<AddMeetupScreen> {
                 ),
                 CustomTextView(
                   label: 'Start Time',
-                  textStyle: Theme.of(context).textTheme.bodyMedium!.copyWith(fontSize: 16, color: const Color(0xFF818181), fontWeight: FontWeight.w400),
+                  textStyle: Theme.of(context).textTheme.bodyMedium!.copyWith(fontSize: 16, color: ColorsUtils.greyText, fontWeight: FontWeight.w400),
                 ),
                 const SizedBox(
                   height: 10,
@@ -332,7 +333,7 @@ class _AddMeetupScreenState extends State<AddMeetupScreen> {
                 ),
                 CustomTextView(
                   label: 'End Time',
-                  textStyle: Theme.of(context).textTheme.bodyMedium!.copyWith(fontSize: 16, color: const Color(0xFF818181), fontWeight: FontWeight.w400),
+                  textStyle: Theme.of(context).textTheme.bodyMedium!.copyWith(fontSize: 16, color: ColorsUtils.greyText, fontWeight: FontWeight.w400),
                 ),
                 const SizedBox(
                   height: 10,
@@ -501,7 +502,7 @@ class _AddMeetupScreenState extends State<AddMeetupScreen> {
                 ),
                 CustomTextView(
                   label: 'Add Friends',
-                  textStyle: Theme.of(context).textTheme.bodyMedium!.copyWith(fontSize: 16, color: const Color(0xFF818181), fontWeight: FontWeight.w400),
+                  textStyle: Theme.of(context).textTheme.bodyMedium!.copyWith(fontSize: 16, color: ColorsUtils.greyText, fontWeight: FontWeight.w400),
                 ),
                 const SizedBox(
                   height: 10,
@@ -616,11 +617,11 @@ class _AddMeetupScreenState extends State<AddMeetupScreen> {
           data: ThemeData.dark().copyWith(
             colorScheme: ColorScheme.light(
               primary: Theme.of(context).colorScheme.primary,
-              onPrimary: Colors.white,
-              surface: Colors.white,
-              onSurface: Colors.black,
+              onPrimary: ColorsUtils.white,
+              surface: ColorsUtils.white,
+              onSurface: ColorsUtils.chipText,
             ),
-            dialogBackgroundColor: Colors.white,
+            dialogBackgroundColor: ColorsUtils.white,
           ),
           child: child!,
         );

--- a/lib/screens/buddies/features/meetups/presentation/meetup_details_screen.dart
+++ b/lib/screens/buddies/features/meetups/presentation/meetup_details_screen.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 
 import 'package:flutter/material.dart';
+import 'package:oqdo_mobile_app/utils/colorsUtils.dart';
 import 'package:flutter/services.dart';
 import 'package:intl/intl.dart';
 import 'package:oqdo_mobile_app/components/custom_app_bar.dart';
@@ -220,7 +221,7 @@ class _MeetupDetailsScreenState extends State<MeetupDetailsScreen> {
                   padding: const EdgeInsets.symmetric(horizontal: 20.0),
                   child: CustomTextView(
                     label: 'Creator',
-                    textStyle: Theme.of(context).textTheme.bodyMedium!.copyWith(fontSize: 18, color: const Color(0xff2B2B2B), fontWeight: FontWeight.w500),
+                    textStyle: Theme.of(context).textTheme.bodyMedium!.copyWith(fontSize: 18, color: ColorsUtils.chipText, fontWeight: FontWeight.w500),
                   ),
                 ),
                 const SizedBox(
@@ -230,7 +231,7 @@ class _MeetupDetailsScreenState extends State<MeetupDetailsScreen> {
                   padding: const EdgeInsets.symmetric(horizontal: 20.0),
                   child: CustomTextView(
                     label: '${widget.meetupResponse!.firstName} ${widget.meetupResponse!.lastName}',
-                    textStyle: Theme.of(context).textTheme.bodyMedium!.copyWith(fontSize: 14, color: const Color(0xff2B2B2B), fontWeight: FontWeight.w400),
+                    textStyle: Theme.of(context).textTheme.bodyMedium!.copyWith(fontSize: 14, color: ColorsUtils.chipText, fontWeight: FontWeight.w400),
                   ),
                 ),
                 const SizedBox(
@@ -240,7 +241,7 @@ class _MeetupDetailsScreenState extends State<MeetupDetailsScreen> {
                   padding: const EdgeInsets.symmetric(horizontal: 20.0),
                   child: CustomTextView(
                     label: 'Description',
-                    textStyle: Theme.of(context).textTheme.bodyMedium!.copyWith(fontSize: 18, color: const Color(0xff2B2B2B), fontWeight: FontWeight.w500),
+                    textStyle: Theme.of(context).textTheme.bodyMedium!.copyWith(fontSize: 18, color: ColorsUtils.chipText, fontWeight: FontWeight.w500),
                   ),
                 ),
                 const SizedBox(
@@ -250,7 +251,7 @@ class _MeetupDetailsScreenState extends State<MeetupDetailsScreen> {
                   padding: const EdgeInsets.symmetric(horizontal: 20.0),
                   child: CustomTextView(
                     label: widget.meetupResponse!.description,
-                    textStyle: Theme.of(context).textTheme.bodyMedium!.copyWith(fontSize: 14, color: const Color(0xff2B2B2B), fontWeight: FontWeight.w400),
+                    textStyle: Theme.of(context).textTheme.bodyMedium!.copyWith(fontSize: 14, color: ColorsUtils.chipText, fontWeight: FontWeight.w400),
                   ),
                 ),
                 const SizedBox(
@@ -260,7 +261,7 @@ class _MeetupDetailsScreenState extends State<MeetupDetailsScreen> {
                   padding: const EdgeInsets.symmetric(horizontal: 20.0),
                   child: CustomTextView(
                     label: 'Meetup Details',
-                    textStyle: Theme.of(context).textTheme.bodyMedium!.copyWith(fontSize: 18, color: const Color(0xff2B2B2B), fontWeight: FontWeight.w500),
+                    textStyle: Theme.of(context).textTheme.bodyMedium!.copyWith(fontSize: 18, color: ColorsUtils.chipText, fontWeight: FontWeight.w500),
                   ),
                 ),
                 const SizedBox(
@@ -274,7 +275,7 @@ class _MeetupDetailsScreenState extends State<MeetupDetailsScreen> {
                         label: 'Date: ',
                         textStyle: Theme.of(context).textTheme.bodyMedium!.copyWith(
                               fontWeight: FontWeight.w700,
-                              color: const Color(0xFF2B2B2B),
+                              color: ColorsUtils.chipText,
                               fontSize: 16,
                             ),
                       ),
@@ -285,7 +286,7 @@ class _MeetupDetailsScreenState extends State<MeetupDetailsScreen> {
                         label: widget.meetupResponse!.date!.split('T')[0],
                         textStyle: Theme.of(context).textTheme.bodyMedium!.copyWith(
                               fontWeight: FontWeight.w400,
-                              color: const Color(0xFF2B2B2B),
+                              color: ColorsUtils.chipText,
                               fontSize: 16,
                             ),
                       )
@@ -303,7 +304,7 @@ class _MeetupDetailsScreenState extends State<MeetupDetailsScreen> {
                         label: 'Time: ',
                         textStyle: Theme.of(context).textTheme.bodyMedium!.copyWith(
                               fontWeight: FontWeight.w700,
-                              color: const Color(0xFF2B2B2B),
+                              color: ColorsUtils.chipText,
                               fontSize: 16,
                             ),
                       ),
@@ -314,7 +315,7 @@ class _MeetupDetailsScreenState extends State<MeetupDetailsScreen> {
                         label: '${widget.meetupResponse!.startFrom} - ${widget.meetupResponse!.endAt}',
                         textStyle: Theme.of(context).textTheme.bodyMedium!.copyWith(
                               fontWeight: FontWeight.w400,
-                              color: const Color(0xFF2B2B2B),
+                              color: ColorsUtils.chipText,
                               fontSize: 16,
                             ),
                       ),
@@ -328,7 +329,7 @@ class _MeetupDetailsScreenState extends State<MeetupDetailsScreen> {
                   padding: const EdgeInsets.symmetric(horizontal: 20.0),
                   child: CustomTextView(
                     label: 'Friends',
-                    textStyle: Theme.of(context).textTheme.bodyMedium!.copyWith(fontSize: 18, color: const Color(0xff2B2B2B), fontWeight: FontWeight.w500),
+                    textStyle: Theme.of(context).textTheme.bodyMedium!.copyWith(fontSize: 18, color: ColorsUtils.chipText, fontWeight: FontWeight.w500),
                   ),
                 ),
                 const SizedBox(
@@ -535,7 +536,7 @@ class _MeetupDetailsScreenState extends State<MeetupDetailsScreen> {
             children: [
               CustomTextView(
                 label: '${widget.meetupResponse!.meetUpFriends![index].displayFirstName} ${widget.meetupResponse!.meetUpFriends![index].displayLastName}',
-                textStyle: Theme.of(context).textTheme.bodyMedium!.copyWith(fontSize: 14, color: const Color(0xff2B2B2B), fontWeight: FontWeight.w400),
+                textStyle: Theme.of(context).textTheme.bodyMedium!.copyWith(fontSize: 14, color: ColorsUtils.chipText, fontWeight: FontWeight.w400),
               ),
               const Spacer(),
               Image.asset(
@@ -551,7 +552,7 @@ class _MeetupDetailsScreenState extends State<MeetupDetailsScreen> {
             ],
           ),
           const Divider(
-            color: Color(0xFFCFCFCF),
+            color: ColorsUtils.buddiesBorder,
           )
         ],
       ),

--- a/lib/screens/buddies/features/meetups/presentation/meetup_list_screen.dart
+++ b/lib/screens/buddies/features/meetups/presentation/meetup_list_screen.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 
 import 'package:flutter/material.dart';
+import 'package:oqdo_mobile_app/utils/colorsUtils.dart';
 import 'package:intl/intl.dart';
 import 'package:oqdo_mobile_app/components/custom_app_bar.dart';
 import 'package:oqdo_mobile_app/screens/buddies/features/meetups/data/meet_up_repository.dart';
@@ -238,7 +239,7 @@ class _MeetupListScreenState extends State<MeetupListScreen> {
         children: [
           CustomTextView(
             label: monthStr,
-            textStyle: Theme.of(context).textTheme.titleLarge!.copyWith(fontSize: 20, fontWeight: FontWeight.w500, color: const Color(0xFF333333)),
+            textStyle: Theme.of(context).textTheme.titleLarge!.copyWith(fontSize: 20, fontWeight: FontWeight.w500, color: ColorsUtils.chipText),
           ),
           const Spacer(),
           // GestureDetector(
@@ -263,14 +264,14 @@ class _MeetupListScreenState extends State<MeetupListScreen> {
             calendarFormat: _calendarFormat,
             headerVisible: false,
             daysOfWeekVisible: true,
-            daysOfWeekStyle: const DaysOfWeekStyle(
-                weekdayStyle: TextStyle(color: Color(0xFF006590), fontWeight: FontWeight.w500),
-                weekendStyle: TextStyle(color: Color(0xFF006590), fontWeight: FontWeight.w500)),
+              daysOfWeekStyle: DaysOfWeekStyle(
+                  weekdayStyle: TextStyle(color: ColorsUtils.accentBlue, fontWeight: FontWeight.w500),
+                  weekendStyle: TextStyle(color: ColorsUtils.accentBlue, fontWeight: FontWeight.w500)),
             calendarStyle: CalendarStyle(
               isTodayHighlighted: false,
               outsideDaysVisible: false,
               selectedDecoration: BoxDecoration(color: Theme.of(context).colorScheme.primary, shape: BoxShape.circle),
-              defaultTextStyle: const TextStyle(fontSize: 15, fontWeight: FontWeight.w400, color: Colors.black),
+              defaultTextStyle: TextStyle(fontSize: 15, fontWeight: FontWeight.w400, color: ColorsUtils.chipText),
             ),
             onDaySelected: _onDaySelected,
             selectedDayPredicate: (DateTime date) {

--- a/lib/screens/chat/chat_screen.dart
+++ b/lib/screens/chat/chat_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:oqdo_mobile_app/utils/colorsUtils.dart';
 
 class ChatScreen extends StatefulWidget {
   const ChatScreen({super.key});
@@ -13,7 +14,7 @@ class _ChatScreenState extends State<ChatScreen> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      backgroundColor: Colors.grey[100],
+      backgroundColor: ColorsUtils.buddiesBackground,
       body: SafeArea(
         child: Column(
           children: [
@@ -31,27 +32,27 @@ class _ChatScreenState extends State<ChatScreen> {
   Widget _buildHeader() {
     return Container(
       padding: const EdgeInsets.all(16),
-      color: const Color(0xFF2B5278),
+      color: ColorsUtils.chatPrimary,
       child: Row(
         children: [
           IconButton(
-            icon: const Icon(Icons.arrow_back, color: Colors.white),
+            icon: Icon(Icons.arrow_back, color: ColorsUtils.white),
             onPressed: () => Navigator.pop(context),
           ),
-          const CircleAvatar(
+          CircleAvatar(
             radius: 20,
-            backgroundColor: Colors.grey,
-            child: Icon(Icons.person, color: Colors.white),
+            backgroundColor: ColorsUtils.greyCircle,
+            child: Icon(Icons.person, color: ColorsUtils.white),
           ),
           const SizedBox(width: 12),
-          const Expanded(
+          Expanded(
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
                 Text(
                   'Josh John',
                   style: TextStyle(
-                    color: Colors.white,
+                    color: ColorsUtils.white,
                     fontSize: 16,
                     fontWeight: FontWeight.w600,
                   ),
@@ -66,10 +67,10 @@ class _ChatScreenState extends State<ChatScreen> {
               ],
             ),
           ),
-          const Text(
+          Text(
             'S\$ 50',
             style: TextStyle(
-              color: Colors.white,
+              color: ColorsUtils.white,
               fontSize: 16,
               fontWeight: FontWeight.bold,
             ),
@@ -113,7 +114,7 @@ class _ChatScreenState extends State<ChatScreen> {
         margin: const EdgeInsets.only(bottom: 16),
         padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 10),
         decoration: BoxDecoration(
-          color: isSentByMe ? const Color(0xFF2B5278) : Colors.white,
+          color: isSentByMe ? ColorsUtils.chatPrimary : ColorsUtils.white,
           borderRadius: BorderRadius.circular(20),
           boxShadow: [
             BoxShadow(
@@ -129,7 +130,7 @@ class _ChatScreenState extends State<ChatScreen> {
             Text(
               message,
               style: TextStyle(
-                color: isSentByMe ? Colors.white : Colors.black87,
+                color: isSentByMe ? ColorsUtils.white : ColorsUtils.chipText,
                 fontSize: 16,
               ),
             ),
@@ -137,7 +138,7 @@ class _ChatScreenState extends State<ChatScreen> {
             Text(
               time,
               style: TextStyle(
-                color: isSentByMe ? Colors.white70 : Colors.black54,
+                color: isSentByMe ? Colors.white70 : ColorsUtils.greyText,
                 fontSize: 12,
               ),
             ),
@@ -151,7 +152,7 @@ class _ChatScreenState extends State<ChatScreen> {
     return Container(
       padding: const EdgeInsets.all(16),
       decoration: BoxDecoration(
-        color: Colors.white,
+        color: ColorsUtils.white,
         boxShadow: [
           BoxShadow(
             color: Colors.black.withOpacity(0.05),
@@ -166,7 +167,7 @@ class _ChatScreenState extends State<ChatScreen> {
             child: ElevatedButton(
               onPressed: () {},
               style: ElevatedButton.styleFrom(
-                backgroundColor: const Color(0xFF2B5278),
+                backgroundColor: ColorsUtils.chatPrimary,
                 padding: const EdgeInsets.symmetric(vertical: 12),
                 shape: RoundedRectangleBorder(
                   borderRadius: BorderRadius.circular(8),
@@ -175,7 +176,7 @@ class _ChatScreenState extends State<ChatScreen> {
               child: const Text(
                 'Offer Price',
                 style: TextStyle(
-                  color: Colors.white,
+                  color: ColorsUtils.white,
                   fontSize: 16,
                 ),
               ),
@@ -187,7 +188,7 @@ class _ChatScreenState extends State<ChatScreen> {
             child: ElevatedButton(
               onPressed: () {},
               style: ElevatedButton.styleFrom(
-                backgroundColor: const Color(0xFF2B5278),
+                backgroundColor: ColorsUtils.chatPrimary,
                 padding: const EdgeInsets.symmetric(vertical: 12),
                 shape: RoundedRectangleBorder(
                   borderRadius: BorderRadius.circular(8),
@@ -196,7 +197,7 @@ class _ChatScreenState extends State<ChatScreen> {
               child: const Text(
                 'Ok, Done',
                 style: TextStyle(
-                  color: Colors.white,
+                  color: ColorsUtils.white,
                   fontSize: 16,
                 ),
               ),
@@ -213,9 +214,9 @@ class _ChatScreenState extends State<ChatScreen> {
                 child: Container(
                   padding: const EdgeInsets.symmetric(horizontal: 16),
                   decoration: BoxDecoration(
-                    color: Colors.white,
+                    color: ColorsUtils.white,
                     borderRadius: BorderRadius.circular(25),
-                    border: Border.all(color: Colors.grey[300]!),
+                    border: Border.all(color: ColorsUtils.buddiesBorder),
                   ),
                   child: TextField(
                     controller: _messageController,
@@ -228,7 +229,7 @@ class _ChatScreenState extends State<ChatScreen> {
               ),
               IconButton(
                 icon: const Icon(Icons.send),
-                color: const Color(0xFF2B5278),
+                color: ColorsUtils.chatPrimary,
                 onPressed: () {
                   if (_messageController.text.isNotEmpty) {
                     // Handle send message

--- a/lib/utils/colorsUtils.dart
+++ b/lib/utils/colorsUtils.dart
@@ -50,4 +50,27 @@ class ColorsUtils {
   /// Background color for the close account button
   static Color get closeAccountColor =>
       _isDark ? const Color(0xFFFF5252) : const Color(0xFFFC5555);
+
+  /// Primary brand blue used across chat screens
+  static Color get chatPrimary => const Color(0xFF2B5278);
+
+  /// Accent blue used across buddies features
+  static Color get accentBlue =>
+      _isDark ? const Color(0xFF4FC3F7) : const Color(0xFF006590);
+
+  /// Alternate blue for profile elements
+  static Color get profileBlue =>
+      _isDark ? const Color(0xFF4FC3F7) : const Color(0xFF3C80A8);
+
+  /// Background color for buddies screens
+  static Color get buddiesBackground =>
+      _isDark ? const Color(0xFF2A2A2A) : const Color(0xFFF5F5F5);
+
+  /// Card color for buddies screens
+  static Color get buddiesCard =>
+      _isDark ? const Color(0xFF333333) : const Color(0xFFF1F1F1);
+
+  /// Border color for buddies screens
+  static Color get buddiesBorder =>
+      _isDark ? const Color(0xFF404040) : const Color(0xFFCFCFCF);
 }


### PR DESCRIPTION
## Summary
- add theme-aware colors to `ColorsUtils`
- apply new colors to chat screen
- use `ColorsUtils` across buddies and meetup screens for dark and light themes

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68be748f68ac8332a177d5551342bbfd