### PR TITLE
feat: support theme switching in chat and buddies

### DIFF
--- a/lib/components/custom_app_bar.dart
+++ b/lib/components/custom_app_bar.dart
@@ -15,29 +15,35 @@ class CustomAppBar extends StatelessWidget implements PreferredSizeWidget {
       this.actions = const [],
       required this.onBack,
       this.backgroundColor,
-      this.isIconColorBlack = true,
-      this.isTextColor = true});
+      this.isIconColorBlack,
+      this.isTextColor});
 
   @override
   Widget build(BuildContext context) {
+    final bool isDark = Theme.of(context).brightness == Brightness.dark;
+    final Color resolvedIconColor = isIconColorBlack == null
+        ? (isDark ? Colors.white : Colors.black)
+        : (isIconColorBlack! ? Colors.black : Colors.white);
+
+    final Color resolvedTextColor = (isTextColor == false)
+        ? Colors.white
+        : resolvedIconColor;
+
     return AppBar(
       elevation: 0,
       centerTitle: true,
+      backgroundColor: backgroundColor ?? Theme.of(context).colorScheme.surface,
       leading: IconButton(
-          onPressed: () {
-            onBack();
-          },
-          icon: Icon(
-            Icons.arrow_back,
-            color: (isIconColorBlack ?? true) ? Colors.black : Colors.white,
-          )),
-      backgroundColor: backgroundColor ?? Colors.white,
+        onPressed: onBack,
+        icon: Icon(Icons.arrow_back, color: resolvedIconColor),
+      ),
       title: Text(
         title ?? '',
-        style: Theme.of(context)
-            .textTheme
-            .titleMedium!
-            .copyWith(color: (isIconColorBlack ?? true) ? OQDOThemeData.blackColor : Colors.white, fontWeight: FontWeight.w600, fontSize: 20.0),
+        style: Theme.of(context).textTheme.titleMedium!.copyWith(
+              color: resolvedTextColor,
+              fontWeight: FontWeight.w600,
+              fontSize: 20.0,
+            ),
       ),
       actions: actions,
     );

--- a/lib/screens/buddies/features/buddies/presentaion/buddies_screen.dart
+++ b/lib/screens/buddies/features/buddies/presentaion/buddies_screen.dart
@@ -71,6 +71,7 @@ class _BuddiesScreenState extends State<BuddiesScreen> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
+      backgroundColor: Theme.of(context).colorScheme.background,
       appBar: CustomAppBar(
         title: 'Buddies',
         onBack: () {
@@ -98,7 +99,7 @@ class _BuddiesScreenState extends State<BuddiesScreen> {
           child: Container(
             width: MediaQuery.of(context).size.width,
             height: MediaQuery.of(context).size.height,
-            color: ColorsUtils.white,
+            color: Theme.of(context).colorScheme.background,
             child: Padding(
               padding: const EdgeInsets.symmetric(horizontal: 10.0),
               child: Column(

--- a/lib/screens/buddies/features/buddies/presentaion/group_list_screen.dart
+++ b/lib/screens/buddies/features/buddies/presentaion/group_list_screen.dart
@@ -70,6 +70,7 @@ class _GroupListScreenState extends State<GroupListScreen> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
+      backgroundColor: Theme.of(context).colorScheme.background,
       floatingActionButton: FloatingActionButton(
         elevation: 0.0,
         backgroundColor: OQDOThemeData.dividerColor,
@@ -94,7 +95,9 @@ class _GroupListScreenState extends State<GroupListScreen> {
           height: 26,
           width: 26,
           fit: BoxFit.fill,
-          color: ColorsUtils.white,
+          color: Theme.of(context).brightness == Brightness.dark
+              ? Colors.white
+              : Colors.black,
         ),
       ),
       appBar: CustomAppBar(
@@ -106,7 +109,7 @@ class _GroupListScreenState extends State<GroupListScreen> {
         child: Container(
           width: MediaQuery.of(context).size.width,
           height: MediaQuery.of(context).size.height,
-          color: ColorsUtils.white,
+          color: Theme.of(context).colorScheme.background,
           child: Padding(
             padding: const EdgeInsets.symmetric(horizontal: 10.0),
             child: Column(

--- a/lib/screens/buddies/features/buddies/presentaion/my_friends_screen.dart
+++ b/lib/screens/buddies/features/buddies/presentaion/my_friends_screen.dart
@@ -47,6 +47,7 @@ class _MyFriendsScreenState extends State<MyFriendsScreen> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
+      backgroundColor: Theme.of(context).colorScheme.background,
       appBar: CustomAppBar(
           title: 'Your Friends',
           onBack: () {
@@ -57,7 +58,7 @@ class _MyFriendsScreenState extends State<MyFriendsScreen> {
           child: Container(
             width: MediaQuery.of(context).size.width,
             height: MediaQuery.of(context).size.height,
-            color: ColorsUtils.white,
+            color: Theme.of(context).colorScheme.background,
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
@@ -364,7 +365,7 @@ class _MyFriendsScreenState extends State<MyFriendsScreen> {
                 children: [
                   TextButton(
                     style: TextButton.styleFrom(
-                        backgroundColor: ColorsUtils.white,
+                        backgroundColor: Theme.of(context).colorScheme.surface,
                         shape: RoundedRectangleBorder(
                             side: BorderSide(color: Theme.of(context).colorScheme.primary, width: 1, style: BorderStyle.solid),
                             borderRadius: const BorderRadius.all(Radius.zero))),

--- a/lib/screens/chat/chat_screen.dart
+++ b/lib/screens/chat/chat_screen.dart
@@ -14,7 +14,7 @@ class _ChatScreenState extends State<ChatScreen> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      backgroundColor: ColorsUtils.buddiesBackground,
+      backgroundColor: Theme.of(context).colorScheme.background,
       body: SafeArea(
         child: Column(
           children: [
@@ -114,7 +114,9 @@ class _ChatScreenState extends State<ChatScreen> {
         margin: const EdgeInsets.only(bottom: 16),
         padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 10),
         decoration: BoxDecoration(
-          color: isSentByMe ? ColorsUtils.chatPrimary : ColorsUtils.white,
+          color: isSentByMe
+              ? ColorsUtils.chatPrimary
+              : Theme.of(context).colorScheme.surface,
           borderRadius: BorderRadius.circular(20),
           boxShadow: [
             BoxShadow(
@@ -124,19 +126,19 @@ class _ChatScreenState extends State<ChatScreen> {
             ),
           ],
         ),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Text(
-              message,
-              style: TextStyle(
-                color: isSentByMe ? ColorsUtils.white : ColorsUtils.chipText,
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                message,
+                style: TextStyle(
+                color: isSentByMe ? Colors.white : ColorsUtils.chipText,
                 fontSize: 16,
               ),
-            ),
-            const SizedBox(height: 4),
-            Text(
-              time,
+              ),
+              const SizedBox(height: 4),
+              Text(
+                time,
               style: TextStyle(
                 color: isSentByMe ? Colors.white70 : ColorsUtils.greyText,
                 fontSize: 12,
@@ -152,7 +154,7 @@ class _ChatScreenState extends State<ChatScreen> {
     return Container(
       padding: const EdgeInsets.all(16),
       decoration: BoxDecoration(
-        color: ColorsUtils.white,
+        color: Theme.of(context).colorScheme.surface,
         boxShadow: [
           BoxShadow(
             color: Colors.black.withOpacity(0.05),
@@ -164,19 +166,19 @@ class _ChatScreenState extends State<ChatScreen> {
         children: [
           SizedBox(
             width: double.infinity,
-            child: ElevatedButton(
-              onPressed: () {},
-              style: ElevatedButton.styleFrom(
-                backgroundColor: ColorsUtils.chatPrimary,
-                padding: const EdgeInsets.symmetric(vertical: 12),
-                shape: RoundedRectangleBorder(
-                  borderRadius: BorderRadius.circular(8),
+              child: ElevatedButton(
+                onPressed: () {},
+                style: ElevatedButton.styleFrom(
+                  backgroundColor: ColorsUtils.chatPrimary,
+                  padding: const EdgeInsets.symmetric(vertical: 12),
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(8),
+                  ),
                 ),
-              ),
-              child: Text(
-                'Offer Price',
-                style: TextStyle(
-                  color: ColorsUtils.white,
+                child: Text(
+                  'Offer Price',
+                style: const TextStyle(
+                  color: Colors.white,
                   fontSize: 16,
                 ),
               ),
@@ -196,8 +198,8 @@ class _ChatScreenState extends State<ChatScreen> {
               ),
               child: Text(
                 'Ok, Done',
-                style: TextStyle(
-                  color: ColorsUtils.white,
+                style: const TextStyle(
+                  color: Colors.white,
                   fontSize: 16,
                 ),
               ),
@@ -214,7 +216,7 @@ class _ChatScreenState extends State<ChatScreen> {
                 child: Container(
                   padding: const EdgeInsets.symmetric(horizontal: 16),
                   decoration: BoxDecoration(
-                    color: ColorsUtils.white,
+                    color: Theme.of(context).colorScheme.surface,
                     borderRadius: BorderRadius.circular(25),
                     border: Border.all(color: ColorsUtils.buddiesBorder),
                   ),


### PR DESCRIPTION
## Summary
- switch CustomAppBar to dynamically choose icon and text colors based on active theme
- apply theme-aware backgrounds to chat and buddies list screens
- ensure list icons flip between black and white depending on light or dark mode

## Testing
- ❌ `flutter format ...` *(flutter: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68be798cef588332a7b0716885e3ed6a