### PR TITLE
feat: support theme switching in chat and buddies

### DIFF
--- a/lib/components/custom_app_bar.dart
+++ b/lib/components/custom_app_bar.dart
@@ -15,29 +15,35 @@ class CustomAppBar extends StatelessWidget implements PreferredSizeWidget {
       this.actions = const [],
       required this.onBack,
       this.backgroundColor,
-      this.isIconColorBlack = true,
-      this.isTextColor = true});
+      this.isIconColorBlack,
+      this.isTextColor});
 
   @override
   Widget build(BuildContext context) {
+    final bool isDark = Theme.of(context).brightness == Brightness.dark;
+    final Color resolvedIconColor = isIconColorBlack == null
+        ? (isDark ? Colors.white : Colors.black)
+        : (isIconColorBlack! ? Colors.black : Colors.white);
+
+    final Color resolvedTextColor = (isTextColor == false)
+        ? Colors.white
+        : resolvedIconColor;
+
     return AppBar(
       elevation: 0,
       centerTitle: true,
+      backgroundColor: backgroundColor ?? Theme.of(context).colorScheme.surface,
       leading: IconButton(
-          onPressed: () {
-            onBack();
-          },
-          icon: Icon(
-            Icons.arrow_back,
-            color: (isIconColorBlack ?? true) ? Colors.black : Colors.white,
-          )),
-      backgroundColor: backgroundColor ?? Colors.white,
+        onPressed: onBack,
+        icon: Icon(Icons.arrow_back, color: resolvedIconColor),
+      ),
       title: Text(
         title ?? '',
-        style: Theme.of(context)
-            .textTheme
-            .titleMedium!
-            .copyWith(color: (isIconColorBlack ?? true) ? OQDOThemeData.blackColor : Colors.white, fontWeight: FontWeight.w600, fontSize: 20.0),
+        style: Theme.of(context).textTheme.titleMedium!.copyWith(
+              color: resolvedTextColor,
+              fontWeight: FontWeight.w600,
+              fontSize: 20.0,
+            ),
       ),
       actions: actions,
     );

--- a/lib/screens/buddies/features/buddies/presentaion/buddies_screen.dart
+++ b/lib/screens/buddies/features/buddies/presentaion/buddies_screen.dart
@@ -71,6 +71,7 @@ class _BuddiesScreenState extends State<BuddiesScreen> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
+      backgroundColor: Theme.of(context).colorScheme.background,
       appBar: CustomAppBar(
         title: 'Buddies',
         onBack: () {
@@ -98,7 +99,7 @@ class _BuddiesScreenState extends State<BuddiesScreen> {
           child: Container(
             width: MediaQuery.of(context).size.width,
             height: MediaQuery.of(context).size.height,
-            color: ColorsUtils.white,
+            color: Theme.of(context).colorScheme.background,
             child: Padding(
               padding: const EdgeInsets.symmetric(horizontal: 10.0),
               child: Column(

--- a/lib/screens/buddies/features/buddies/presentaion/group_list_screen.dart
+++ b/lib/screens/buddies/features/buddies/presentaion/group_list_screen.dart
@@ -70,6 +70,7 @@ class _GroupListScreenState extends State<GroupListScreen> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
+      backgroundColor: Theme.of(context).colorScheme.background,
       floatingActionButton: FloatingActionButton(
         elevation: 0.0,
         backgroundColor: OQDOThemeData.dividerColor,
@@ -94,7 +95,9 @@ class _GroupListScreenState extends State<GroupListScreen> {
           height: 26,
           width: 26,
           fit: BoxFit.fill,
-          color: ColorsUtils.white,
+          color: Theme.of(context).brightness == Brightness.dark
+              ? Colors.white
+              : Colors.black,
         ),
       ),
       appBar: CustomAppBar(
@@ -106,7 +109,7 @@ class _GroupListScreenState extends State<GroupListScreen> {
         child: Container(
           width: MediaQuery.of(context).size.width,
           height: MediaQuery.of(context).size.height,
-          color: ColorsUtils.white,
+          color: Theme.of(context).colorScheme.background,
           child: Padding(
             padding: const EdgeInsets.symmetric(horizontal: 10.0),
             child: Column(

--- a/lib/screens/buddies/features/buddies/presentaion/my_friends_screen.dart
+++ b/lib/screens/buddies/features/buddies/presentaion/my_friends_screen.dart
@@ -47,6 +47,7 @@ class _MyFriendsScreenState extends State<MyFriendsScreen> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
+      backgroundColor: Theme.of(context).colorScheme.background,
       appBar: CustomAppBar(
           title: 'Your Friends',
           onBack: () {
@@ -57,7 +58,7 @@ class _MyFriendsScreenState extends State<MyFriendsScreen> {
           child: Container(
             width: MediaQuery.of(context).size.width,
             height: MediaQuery.of(context).size.height,
-            color: ColorsUtils.white,
+            color: Theme.of(context).colorScheme.background,
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
@@ -364,7 +365,7 @@ class _MyFriendsScreenState extends State<MyFriendsScreen> {
                 children: [
                   TextButton(
                     style: TextButton.styleFrom(
-                        backgroundColor: ColorsUtils.white,
+                        backgroundColor: Theme.of(context).colorScheme.surface,
                         shape: RoundedRectangleBorder(
                             side: BorderSide(color: Theme.of(context).colorScheme.primary, width: 1, style: BorderStyle.solid),
                             borderRadius: const BorderRadius.all(Radius.zero))),

--- a/lib/screens/chat/chat_screen.dart
+++ b/lib/screens/chat/chat_screen.dart
@@ -14,7 +14,7 @@ class _ChatScreenState extends State<ChatScreen> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      backgroundColor: ColorsUtils.buddiesBackground,
+      backgroundColor: Theme.of(context).colorScheme.background,
       body: SafeArea(
         child: Column(
           children: [
@@ -114,7 +114,9 @@ class _ChatScreenState extends State<ChatScreen> {
         margin: const EdgeInsets.only(bottom: 16),
         padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 10),
         decoration: BoxDecoration(
-          color: isSentByMe ? ColorsUtils.chatPrimary : ColorsUtils.white,
+          color: isSentByMe
+              ? ColorsUtils.chatPrimary
+              : Theme.of(context).colorScheme.surface,
           borderRadius: BorderRadius.circular(20),
           boxShadow: [
             BoxShadow(
@@ -124,19 +126,19 @@ class _ChatScreenState extends State<ChatScreen> {
             ),
           ],
         ),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Text(
-              message,
-              style: TextStyle(
-                color: isSentByMe ? ColorsUtils.white : ColorsUtils.chipText,
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                message,
+                style: TextStyle(
+                color: isSentByMe ? Colors.white : ColorsUtils.chipText,
                 fontSize: 16,
               ),
-            ),
-            const SizedBox(height: 4),
-            Text(
-              time,
+              ),
+              const SizedBox(height: 4),
+              Text(
+                time,
               style: TextStyle(
                 color: isSentByMe ? Colors.white70 : ColorsUtils.greyText,
                 fontSize: 12,
@@ -152,7 +154,7 @@ class _ChatScreenState extends State<ChatScreen> {
     return Container(
       padding: const EdgeInsets.all(16),
       decoration: BoxDecoration(
-        color: ColorsUtils.white,
+        color: Theme.of(context).colorScheme.surface,
         boxShadow: [
           BoxShadow(
             color: Colors.black.withOpacity(0.05),
@@ -164,19 +166,19 @@ class _ChatScreenState extends State<ChatScreen> {
         children: [
           SizedBox(
             width: double.infinity,
-            child: ElevatedButton(
-              onPressed: () {},
-              style: ElevatedButton.styleFrom(
-                backgroundColor: ColorsUtils.chatPrimary,
-                padding: const EdgeInsets.symmetric(vertical: 12),
-                shape: RoundedRectangleBorder(
-                  borderRadius: BorderRadius.circular(8),
+              child: ElevatedButton(
+                onPressed: () {},
+                style: ElevatedButton.styleFrom(
+                  backgroundColor: ColorsUtils.chatPrimary,
+                  padding: const EdgeInsets.symmetric(vertical: 12),
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(8),
+                  ),
                 ),
-              ),
-              child: Text(
-                'Offer Price',
-                style: TextStyle(
-                  color: ColorsUtils.white,
+                child: Text(
+                  'Offer Price',
+                style: const TextStyle(
+                  color: Colors.white,
                   fontSize: 16,
                 ),
               ),
@@ -196,8 +198,8 @@ class _ChatScreenState extends State<ChatScreen> {
               ),
               child: Text(
                 'Ok, Done',
-                style: TextStyle(
-                  color: ColorsUtils.white,
+                style: const TextStyle(
+                  color: Colors.white,
                   fontSize: 16,
                 ),
               ),
@@ -214,7 +216,7 @@ class _ChatScreenState extends State<ChatScreen> {
                 child: Container(
                   padding: const EdgeInsets.symmetric(horizontal: 16),
                   decoration: BoxDecoration(
-                    color: ColorsUtils.white,
+                    color: Theme.of(context).colorScheme.surface,
                     borderRadius: BorderRadius.circular(25),
                     border: Border.all(color: ColorsUtils.buddiesBorder),
                   ),

--- a/lib/screens/home/conversation_screen.dart
+++ b/lib/screens/home/conversation_screen.dart
@@ -11,7 +11,7 @@ import 'package:oqdo_mobile_app/screens/buddies/features/buddies/data/model/frie
 import 'package:oqdo_mobile_app/screens/buddies/features/buddies/data/model/get_conversation_list_response.dart';
 import 'package:oqdo_mobile_app/screens/buddies/features/buddies/data/model/group_chat_response.dart';
 import 'package:oqdo_mobile_app/screens/buddies/features/buddies/domain/chat_provider.dart';
-import 'package:oqdo_mobile_app/theme/oqdo_theme_data.dart';
+import 'package:oqdo_mobile_app/utils/colorsUtils.dart';
 import 'package:oqdo_mobile_app/utils/constants.dart';
 import 'package:oqdo_mobile_app/utils/custom_text_view.dart';
 import 'package:oqdo_mobile_app/utils/network_interceptor.dart';
@@ -90,9 +90,10 @@ class _ConversationScreenState extends State<ConversationScreen> {
   Widget build(BuildContext context) {
     return Scaffold(
       key: scaffoldKey,
+      backgroundColor: Theme.of(context).colorScheme.background,
       floatingActionButton: FloatingActionButton(
         elevation: 0.0,
-        backgroundColor: OQDOThemeData.dividerColor,
+        backgroundColor: Theme.of(context).colorScheme.primary,
         onPressed: () async {
           var isChange = await Navigator.of(context).pushNamed(Constants.createChatScreen);
           if (isChange != null && isChange == true) {
@@ -106,7 +107,9 @@ class _ConversationScreenState extends State<ConversationScreen> {
           height: 26,
           width: 26,
           fit: BoxFit.fill,
-          color: Colors.white,
+          color: Theme.of(context).brightness == Brightness.dark
+              ? Colors.white
+              : Colors.black,
         ),
       ),
       body: SafeArea(
@@ -115,7 +118,7 @@ class _ConversationScreenState extends State<ConversationScreen> {
           child: Container(
             width: width,
             height: height,
-            color: OQDOThemeData.whiteColor,
+            color: Theme.of(context).colorScheme.background,
             child: Column(
               children: [
                 Consumer<ChatProvider>(
@@ -144,9 +147,9 @@ class _ConversationScreenState extends State<ConversationScreen> {
                     padding: const EdgeInsets.all(8),
                     width: MediaQuery.of(context).size.width,
                     decoration: BoxDecoration(
-                        color: const Color(0xFFF5F5F5),
+                        color: ColorsUtils.buddiesBackground,
                         border: Border.all(
-                          color: const Color(0xFFF5F5F5),
+                          color: ColorsUtils.buddiesBackground,
                         ),
                         borderRadius: const BorderRadius.all(Radius.circular(10))),
                     child: SizedBox(
@@ -154,7 +157,7 @@ class _ConversationScreenState extends State<ConversationScreen> {
                       child: TextFormField(
                         autocorrect: false,
                         autofocus: false,
-                        cursorColor: OQDOThemeData.greyColor,
+                        cursorColor: ColorsUtils.greyText,
                         minLines: 1,
                         controller: _searchActivityController,
                         decoration: InputDecoration(
@@ -164,6 +167,9 @@ class _ConversationScreenState extends State<ConversationScreen> {
                             height: 20,
                             width: 20,
                             fit: BoxFit.fill,
+                            color: Theme.of(context).brightness == Brightness.dark
+                                ? Colors.white
+                                : Colors.black,
                           ),
                           hintText: 'Search...',
                         ),
@@ -208,7 +214,10 @@ class _ConversationScreenState extends State<ConversationScreen> {
                                         textStyle: Theme.of(context)
                                             .textTheme
                                             .titleMedium!
-                                            .copyWith(fontSize: 16, color: OQDOThemeData.greyColor, fontWeight: FontWeight.w500),
+                                            .copyWith(
+                                                fontSize: 16,
+                                                color: ColorsUtils.greyText,
+                                                fontWeight: FontWeight.w500),
                                       ),
                                     ],
                                   )
@@ -259,7 +268,9 @@ class _ConversationScreenState extends State<ConversationScreen> {
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             Card(
-              color: conversation.profileImage != null ? Colors.white : Colors.black12,
+              color: conversation.profileImage != null
+                  ? ColorsUtils.white
+                  : ColorsUtils.greyCircle,
               elevation: 0,
               child: ClipPath(
                 clipper: ShapeBorderClipper(shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(10))),
@@ -295,14 +306,20 @@ class _ConversationScreenState extends State<ConversationScreen> {
                   crossAxisAlignment: CrossAxisAlignment.stretch,
                   children: [
                     CustomTextView(
-                      label: conversation.chatType == "F" ? '${conversation.firstName} ${conversation.lastName}' : conversation.groupName.toString(),
+                      label: conversation.chatType == "F"
+                          ? '${conversation.firstName} ${conversation.lastName}'
+                          : conversation.groupName.toString(),
                       maxLine: 1,
                       textOverFlow: TextOverflow.ellipsis,
                       type: styleSubTitle,
                       textStyle: Theme.of(context)
                           .textTheme
                           .titleSmall!
-                          .copyWith(color: const Color(0xFF2B2B2B), fontSize: 14.0, fontWeight: FontWeight.w600, overflow: TextOverflow.ellipsis),
+                          .copyWith(
+                              color: ColorsUtils.chipText,
+                              fontSize: 14.0,
+                              fontWeight: FontWeight.w600,
+                              overflow: TextOverflow.ellipsis),
                     ),
                     const SizedBox(
                       height: 8,
@@ -315,7 +332,11 @@ class _ConversationScreenState extends State<ConversationScreen> {
                       textStyle: Theme.of(context)
                           .textTheme
                           .titleSmall!
-                          .copyWith(color: const Color(0xFF2B2B2B), fontSize: 12.0, fontWeight: FontWeight.w400, overflow: TextOverflow.ellipsis),
+                          .copyWith(
+                              color: ColorsUtils.greyText,
+                              fontSize: 12.0,
+                              fontWeight: FontWeight.w400,
+                              overflow: TextOverflow.ellipsis),
                     ),
                   ],
                 ),


### PR DESCRIPTION
## Summary
- switch CustomAppBar to dynamically choose icon and text colors based on active theme
- apply theme-aware backgrounds to chat and buddies list screens
- ensure list icons flip between black and white depending on light or dark mode
- update conversation list to use theme-based surfaces and ColorsUtils helpers

## Testing
- ❌ `flutter format lib/screens/home/conversation_screen.dart lib/utils/colorsUtils.dart` (flutter: command not found)


------
https://chatgpt.com/codex/tasks/task_e_68be798cef588332a7b0716885e3ed6a