### PR TITLE
feat: add theme support to facility screens

### DIFF
--- a/lib/screens/facilities/facilities_list_page.dart
+++ b/lib/screens/facilities/facilities_list_page.dart
@@ -19,11 +19,10 @@ import 'package:oqdo_mobile_app/utils/custom_text_view.dart';
 import 'package:oqdo_mobile_app/utils/network_interceptor.dart';
 import 'package:oqdo_mobile_app/utils/string_manager.dart';
 import 'package:oqdo_mobile_app/utils/utilities.dart';
+import 'package:oqdo_mobile_app/utils/colorsUtils.dart';
 import 'package:oqdo_mobile_app/viewmodels/BookingViewModel.dart';
 import 'package:progress_dialog_null_safe/progress_dialog_null_safe.dart';
 import 'package:provider/provider.dart';
-
-import '../../theme/oqdo_theme_data.dart';
 
 class FacilitiesListPage extends StatefulWidget {
   SelectedHomeModel? selectedHomeModel;
@@ -166,7 +165,7 @@ class FacilitiesListPageState extends State<FacilitiesListPage> {
         child: Container(
           width: MediaQuery.of(context).size.width,
           height: MediaQuery.of(context).size.height,
-          color: Theme.of(context).colorScheme.onBackground,
+          color: Theme.of(context).colorScheme.background,
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
@@ -184,13 +183,13 @@ class FacilitiesListPageState extends State<FacilitiesListPage> {
                             DropdownButton<dynamic>(
                               isExpanded: false,
                               underline: const SizedBox(),
-                              dropdownColor: Theme.of(context).colorScheme.onBackground,
+                              dropdownColor: Theme.of(context).colorScheme.background,
                               hint: CustomTextView(
                                 label: filterList![0],
                                 textStyle: Theme.of(context)
                                     .textTheme
                                     .titleMedium!
-                                    .copyWith(color: OQDOThemeData.greyColor, fontSize: 20.0, fontWeight: FontWeight.w300),
+                                    .copyWith(color: ColorsUtils.greyText, fontSize: 20.0, fontWeight: FontWeight.w300),
                               ),
                               value: selectedTypeValue,
                               items: filterList!.map((interest) {
@@ -201,7 +200,7 @@ class FacilitiesListPageState extends State<FacilitiesListPage> {
                                     textStyle: Theme.of(context)
                                         .textTheme
                                         .titleMedium!
-                                        .copyWith(color: OQDOThemeData.greyColor, fontSize: 20.0, fontWeight: FontWeight.w300),
+                                        .copyWith(color: ColorsUtils.greyText, fontSize: 20.0, fontWeight: FontWeight.w300),
                                   ),
                                 );
                               }).toList(),
@@ -238,15 +237,19 @@ class FacilitiesListPageState extends State<FacilitiesListPage> {
                 padding: const EdgeInsets.symmetric(horizontal: 20.0),
                 child: Container(
                   decoration: BoxDecoration(
-                    color: Colors.white,
+                    color: ColorsUtils.white,
                     borderRadius: BorderRadius.circular(8.0),
-                    border: Border.all(color: Color(0xFFB5B5B5)),
+                    border: Border.all(color: ColorsUtils.filterDivider),
                   ),
                   child: TextField(
                     controller: _searchController,
                     decoration: InputDecoration(
                       hintText: 'Search',
-                      hintStyle: TextStyle(color: Color(0xFF2B2B2B), fontSize: 18.0, fontWeight: FontWeight.bold, fontFamily: 'Montserrat'),
+                      hintStyle: TextStyle(
+                          color: ColorsUtils.greyText,
+                          fontSize: 18.0,
+                          fontWeight: FontWeight.bold,
+                          fontFamily: 'Montserrat'),
                       icon: Padding(
                         padding: const EdgeInsets.only(left: 10.0),
                         child: Image.asset(
@@ -293,7 +296,7 @@ class FacilitiesListPageState extends State<FacilitiesListPage> {
                         ? Center(
                             child: Column(
                               mainAxisAlignment: MainAxisAlignment.center,
-                              children: [CircularProgressIndicator(color: OQDOThemeData.lightColorScheme.primary)],
+                              children: [CircularProgressIndicator(color: Theme.of(context).colorScheme.primary)],
                             ),
                           )
                         : facilitiesList.isNotEmpty
@@ -326,7 +329,7 @@ class FacilitiesListPageState extends State<FacilitiesListPage> {
                                   label: 'Facilities not found',
                                   textStyle: Theme.of(context).textTheme.titleLarge!.copyWith(
                                         fontWeight: FontWeight.w600,
-                                        color: OQDOThemeData.blackColor,
+                                        color: Theme.of(context).colorScheme.onSurface,
                                         fontSize: 16.0,
                                       ),
                                 ),
@@ -362,7 +365,9 @@ class FacilitiesListPageState extends State<FacilitiesListPage> {
                         opacity: 0.7,
                         child: Container(
                           width: MediaQuery.of(context).size.width,
-                          decoration: BoxDecoration(borderRadius: BorderRadius.circular(15), color: Theme.of(context).colorScheme.onBackground),
+                          decoration: BoxDecoration(
+                              borderRadius: BorderRadius.circular(15),
+                              color: Theme.of(context).colorScheme.background),
                           child: CachedNetworkImage(
                             imageUrl: model.listingPageImage!,
                             fit: BoxFit.fill,
@@ -389,7 +394,7 @@ class FacilitiesListPageState extends State<FacilitiesListPage> {
                     textStyle: Theme.of(context).textTheme.titleSmall!.copyWith(
                           fontWeight: FontWeight.w600,
                           fontSize: 18.0,
-                          color: OQDOThemeData.greyColor,
+                          color: Theme.of(context).colorScheme.onSurface,
                         ),
                   ),
                 ),
@@ -424,7 +429,7 @@ class FacilitiesListPageState extends State<FacilitiesListPage> {
               maxLine: 2,
               textOverFlow: TextOverflow.ellipsis,
               type: styleSubTitle,
-              textStyle: Theme.of(context).textTheme.bodyMedium!.copyWith(color: OQDOThemeData.greyColor, fontWeight: FontWeight.w400, fontSize: 16),
+              textStyle: Theme.of(context).textTheme.bodyMedium!.copyWith(color: ColorsUtils.greyText, fontWeight: FontWeight.w400, fontSize: 16),
             ),
             const SizedBox(
               height: 6,
@@ -445,14 +450,14 @@ class FacilitiesListPageState extends State<FacilitiesListPage> {
                     label: 'From S\$ ${model.minimumHrRate?.toStringAsFixed(2) ?? 0.00} / hour',
                     type: styleSubTitle,
                     textOverFlow: TextOverflow.ellipsis,
-                    textStyle: Theme.of(context).textTheme.bodyMedium!.copyWith(color: OQDOThemeData.greyColor, fontWeight: FontWeight.w400, fontSize: 14.0),
+                    textStyle: Theme.of(context).textTheme.bodyMedium!.copyWith(color: ColorsUtils.greyText, fontWeight: FontWeight.w400, fontSize: 14.0),
                   ),
                 ),
                 Container(
                   padding: const EdgeInsets.all(5),
                   decoration: BoxDecoration(
                       border: Border.all(
-                        color: const Color(0xFFE1E1E1),
+                        color: ColorsUtils.filterDivider,
                       ),
                       borderRadius: const BorderRadius.all(Radius.circular(8))),
                   child: Row(
@@ -461,7 +466,7 @@ class FacilitiesListPageState extends State<FacilitiesListPage> {
                         label: model.avgProviderRating!.toStringAsFixed(1),
                         textOverFlow: TextOverflow.ellipsis,
                         textStyle:
-                            Theme.of(context).textTheme.titleSmall!.copyWith(fontSize: 14.0, fontWeight: FontWeight.w400, color: OQDOThemeData.greyColor),
+                            Theme.of(context).textTheme.titleSmall!.copyWith(fontSize: 14.0, fontWeight: FontWeight.w400, color: ColorsUtils.greyText),
                       ),
                       const SizedBox(
                         width: 3,
@@ -492,7 +497,7 @@ class FacilitiesListPageState extends State<FacilitiesListPage> {
           textStyle: Theme.of(context)
               .textTheme
               .titleLarge!
-              .copyWith(fontWeight: FontWeight.bold, fontSize: 20.0, color: OQDOThemeData.greyColor, fontStyle: FontStyle.normal),
+              .copyWith(fontWeight: FontWeight.bold, fontSize: 20.0, color: ColorsUtils.greyText, fontStyle: FontStyle.normal),
         ),
         InkWell(
           onTap: () async {
@@ -897,7 +902,7 @@ class FacilitiesListPageState extends State<FacilitiesListPage> {
         return false;
       },
       child: Container(
-        color: Theme.of(context).colorScheme.onBackground,
+        color: Theme.of(context).colorScheme.background,
         width: MediaQuery.of(context).size.width,
         height: MediaQuery.of(context).size.height,
         child: Column(
@@ -966,7 +971,7 @@ class FacilitiesListPageState extends State<FacilitiesListPage> {
                   textStyle: Theme.of(context)
                       .textTheme
                       .titleMedium!
-                      .copyWith(fontWeight: FontWeight.w400, fontSize: 16.0, decoration: TextDecoration.underline, color: OQDOThemeData.blackColor),
+                      .copyWith(fontWeight: FontWeight.w400, fontSize: 16.0, decoration: TextDecoration.underline, color: Theme.of(context).colorScheme.onSurface),
                 )),
           ),
         ),
@@ -1010,7 +1015,7 @@ class FacilitiesListPageState extends State<FacilitiesListPage> {
                 },
                 child: CustomTextView(
                   label: 'Apply',
-                  textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(fontWeight: FontWeight.w600, fontSize: 16.0, color: OQDOThemeData.whiteColor),
+                  textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(fontWeight: FontWeight.w600, fontSize: 16.0, color: Theme.of(context).colorScheme.onPrimary),
                 )),
           ),
         )
@@ -1026,7 +1031,7 @@ class FacilitiesListPageState extends State<FacilitiesListPage> {
         children: [
           CustomTextView(
             label: 'Filter By',
-            textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(fontWeight: FontWeight.w600, fontSize: 18.0, color: OQDOThemeData.greyColor),
+            textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(fontWeight: FontWeight.w600, fontSize: 18.0, color: Theme.of(context).colorScheme.onSurface),
           ),
           Row(
             children: [
@@ -1051,7 +1056,7 @@ class FacilitiesListPageState extends State<FacilitiesListPage> {
                   textStyle: Theme.of(context)
                       .textTheme
                       .titleSmall!
-                      .copyWith(fontSize: 14.0, fontWeight: FontWeight.w400, decoration: TextDecoration.underline, color: OQDOThemeData.otherTextColor),
+                      .copyWith(fontSize: 14.0, fontWeight: FontWeight.w400, decoration: TextDecoration.underline, color: ColorsUtils.greyText),
                 ),
               ),
               ElevatedButton(
@@ -1070,7 +1075,7 @@ class FacilitiesListPageState extends State<FacilitiesListPage> {
                     }
                   }
                 },
-                style: ElevatedButton.styleFrom(shape: const CircleBorder(), backgroundColor: OQDOThemeData.backgroundColor),
+                style: ElevatedButton.styleFrom(shape: const CircleBorder(), backgroundColor: Theme.of(context).colorScheme.background),
                 child: Image.asset(
                   'assets/images/ic_filter.png',
                   height: 20.0,
@@ -1095,13 +1100,13 @@ class FacilitiesListPageState extends State<FacilitiesListPage> {
                   child: DecoratedBox(
                     decoration: BoxDecoration(
                       shape: BoxShape.rectangle,
-                      border: Border.all(width: 5.0, color: OQDOThemeData.backgroundColor),
+                      border: Border.all(width: 5.0, color: Theme.of(context).colorScheme.background),
                     ),
                     child: SizedBox(
                       height: 100.0,
                       child: Container(
                         decoration: BoxDecoration(
-                          color: isGroupBookingSelected ? OQDOThemeData.dividerColor : OQDOThemeData.backgroundColor,
+                          color: isGroupBookingSelected ? Theme.of(context).colorScheme.primary : Theme.of(context).colorScheme.background,
                           shape: BoxShape.rectangle,
                           borderRadius: const BorderRadius.all(Radius.circular(2.0)),
                         ),
@@ -1111,7 +1116,7 @@ class FacilitiesListPageState extends State<FacilitiesListPage> {
                             textStyle: Theme.of(context).textTheme.titleSmall!.copyWith(
                                 fontWeight: FontWeight.w500,
                                 fontSize: 15.0,
-                                color: isGroupBookingSelected ? OQDOThemeData.whiteColor : OQDOThemeData.blackColor),
+                                color: isGroupBookingSelected ? Theme.of(context).colorScheme.onPrimary : Theme.of(context).colorScheme.onSurface),
                           ),
                         ),
                       ),
@@ -1129,9 +1134,9 @@ class FacilitiesListPageState extends State<FacilitiesListPage> {
                     child: Container(
                       height: 100.0,
                       decoration: BoxDecoration(
-                        color: OQDOThemeData.whiteColor,
+                        color: Theme.of(context).colorScheme.background,
                         border: Border.all(
-                          color: Colors.black,
+                          color: Theme.of(context).colorScheme.onSurface,
                           width: 1,
                         ),
                         borderRadius: BorderRadius.circular(2),
@@ -1140,7 +1145,7 @@ class FacilitiesListPageState extends State<FacilitiesListPage> {
                         child: CustomTextView(
                           label: 'Group Booking',
                           textStyle:
-                              Theme.of(context).textTheme.titleSmall!.copyWith(color: OQDOThemeData.greyColor, fontSize: 15.0, fontWeight: FontWeight.w500),
+                              Theme.of(context).textTheme.titleSmall!.copyWith(color: ColorsUtils.greyText, fontSize: 15.0, fontWeight: FontWeight.w500),
                         ),
                       ),
                     ),
@@ -1154,13 +1159,13 @@ class FacilitiesListPageState extends State<FacilitiesListPage> {
                   child: DecoratedBox(
                     decoration: BoxDecoration(
                       shape: BoxShape.rectangle,
-                      border: Border.all(width: 5.0, color: OQDOThemeData.backgroundColor),
+                      border: Border.all(width: 5.0, color: Theme.of(context).colorScheme.background),
                     ),
                     child: SizedBox(
                       height: 100.0,
                       child: Container(
                         decoration: BoxDecoration(
-                          color: isIndividualBookingSelected ? OQDOThemeData.dividerColor : OQDOThemeData.backgroundColor,
+                          color: isIndividualBookingSelected ? Theme.of(context).colorScheme.primary : Theme.of(context).colorScheme.background,
                           shape: BoxShape.rectangle,
                           borderRadius: const BorderRadius.all(Radius.circular(2.0)),
                         ),
@@ -1170,7 +1175,7 @@ class FacilitiesListPageState extends State<FacilitiesListPage> {
                           textStyle: Theme.of(context).textTheme.titleSmall!.copyWith(
                               fontWeight: FontWeight.w500,
                               fontSize: 15.0,
-                              color: isIndividualBookingSelected ? OQDOThemeData.whiteColor : OQDOThemeData.blackColor),
+                              color: isIndividualBookingSelected ? Theme.of(context).colorScheme.onPrimary : Theme.of(context).colorScheme.onSurface),
                         )),
                       ),
                     ),
@@ -1187,9 +1192,9 @@ class FacilitiesListPageState extends State<FacilitiesListPage> {
                     child: Container(
                       height: 100.0,
                       decoration: BoxDecoration(
-                        color: OQDOThemeData.whiteColor,
+                        color: Theme.of(context).colorScheme.background,
                         border: Border.all(
-                          color: Colors.black,
+                          color: Theme.of(context).colorScheme.onSurface,
                           width: 1,
                         ),
                         borderRadius: BorderRadius.circular(2),
@@ -1198,7 +1203,7 @@ class FacilitiesListPageState extends State<FacilitiesListPage> {
                         child: CustomTextView(
                           label: 'Individual Booking',
                           textStyle:
-                              Theme.of(context).textTheme.titleSmall!.copyWith(color: OQDOThemeData.greyColor, fontSize: 15.0, fontWeight: FontWeight.w500),
+                              Theme.of(context).textTheme.titleSmall!.copyWith(color: ColorsUtils.greyText, fontSize: 15.0, fontWeight: FontWeight.w500),
                         ),
                       ),
                     ),
@@ -1293,7 +1298,7 @@ class FacilitiesListPageState extends State<FacilitiesListPage> {
                     maxLine: 3,
                     textOverFlow: TextOverflow.ellipsis,
                     label: selectedValuesFromKey[index].Name,
-                    textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 16.0, fontWeight: FontWeight.w500, color: OQDOThemeData.greyColor),
+                    textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 16.0, fontWeight: FontWeight.w500, color: ColorsUtils.greyText),
                   ),
                 ),
               ],
@@ -1325,11 +1330,11 @@ class FacilitiesListPageState extends State<FacilitiesListPage> {
           child: Container(
             height: 80.0,
             width: double.infinity,
-            color: selectedValue == key ? OQDOThemeData.filterDividerColor : OQDOThemeData.whiteColor,
+            color: selectedValue == key ? ColorsUtils.filterDivider : Theme.of(context).colorScheme.background,
             child: Center(
               child: CustomTextView(
                 label: key,
-                textStyle: Theme.of(context).textTheme.titleLarge!.copyWith(fontSize: 14.0, color: OQDOThemeData.greyColor, fontWeight: FontWeight.w700),
+                textStyle: Theme.of(context).textTheme.titleLarge!.copyWith(fontSize: 14.0, color: ColorsUtils.greyText, fontWeight: FontWeight.w700),
               ),
             ),
           ),
@@ -1337,7 +1342,7 @@ class FacilitiesListPageState extends State<FacilitiesListPage> {
         SizedBox(
           height: 1.0,
           child: Container(
-            color: OQDOThemeData.filterDividerColor,
+            color: ColorsUtils.filterDivider,
           ),
         ),
       ],

--- a/lib/screens/facilities/facility_details_screen.dart
+++ b/lib/screens/facilities/facility_details_screen.dart
@@ -25,7 +25,6 @@ import 'package:carousel_slider/carousel_slider.dart';
 import 'package:provider/provider.dart';
 
 import '../../components/my_button.dart';
-import '../../theme/oqdo_theme_data.dart';
 import '../../utils/custom_text_view.dart';
 
 class FacilityDetailsScreen extends StatefulWidget {
@@ -130,7 +129,7 @@ class _FacilityDetailsScreenState extends State<FacilityDetailsScreen> {
         body: SafeArea(
           child: Container(
             padding: const EdgeInsets.only(left: 16.0, right: 16.0),
-            color: Theme.of(context).colorScheme.onBackground,
+            color: Theme.of(context).colorScheme.background,
             child: SingleChildScrollView(
               child: Column(
                 children: [
@@ -223,7 +222,7 @@ class _FacilityDetailsScreenState extends State<FacilityDetailsScreen> {
             label: widget.getFacilityByIdModel!.title,
             maxLine: 2,
             textOverFlow: TextOverflow.ellipsis,
-            textStyle: Theme.of(context).textTheme.titleLarge!.copyWith(fontSize: 18.0, color: OQDOThemeData.greyColor, fontWeight: FontWeight.w800),
+            textStyle: Theme.of(context).textTheme.titleLarge!.copyWith(fontSize: 18.0, color: Theme.of(context).colorScheme.onSurface, fontWeight: FontWeight.w800),
           ),
           const SizedBox(
             height: 8.0,
@@ -232,7 +231,7 @@ class _FacilityDetailsScreenState extends State<FacilityDetailsScreen> {
             label: '${widget.getFacilityByIdModel!.subTitle}',
             maxLine: 3,
             textOverFlow: TextOverflow.ellipsis,
-            textStyle: Theme.of(context).textTheme.titleSmall!.copyWith(fontWeight: FontWeight.w400, fontSize: 18.0, color: OQDOThemeData.greyColor),
+            textStyle: Theme.of(context).textTheme.titleSmall!.copyWith(fontWeight: FontWeight.w400, fontSize: 18.0, color: ColorsUtils.greyText),
           ),
           const SizedBox(
             height: 8.0,
@@ -242,7 +241,7 @@ class _FacilityDetailsScreenState extends State<FacilityDetailsScreen> {
             children: [
               CustomTextView(
                 label: 'From S\$ ${widget.getFacilityByIdModel?.ratePerHour?.toStringAsFixed(2) ?? 0.00} / hour',
-                textStyle: Theme.of(context).textTheme.titleSmall!.copyWith(fontSize: 14.0, fontWeight: FontWeight.w400, color: OQDOThemeData.greyColor),
+                textStyle: Theme.of(context).textTheme.titleSmall!.copyWith(fontSize: 14.0, fontWeight: FontWeight.w400, color: ColorsUtils.greyText),
               ),
               Row(
                 children: [
@@ -281,7 +280,7 @@ class _FacilityDetailsScreenState extends State<FacilityDetailsScreen> {
                       textStyle: Theme.of(context)
                           .textTheme
                           .titleSmall!
-                          .copyWith(fontSize: 12.0, fontWeight: FontWeight.w400, color: OQDOThemeData.greyColor, decoration: TextDecoration.underline),
+                          .copyWith(fontSize: 12.0, fontWeight: FontWeight.w400, color: ColorsUtils.greyText, decoration: TextDecoration.underline),
                     ),
                   )
                 ],
@@ -340,7 +339,7 @@ class _FacilityDetailsScreenState extends State<FacilityDetailsScreen> {
                   decoration: BoxDecoration(
                       shape: BoxShape.circle,
                       color:
-                          (Theme.of(context).brightness == Brightness.dark ? Colors.white : Colors.black).withOpacity(_currentIndex == entry.key ? 0.9 : 0.4)),
+                          Theme.of(context).colorScheme.onSurface.withOpacity(_currentIndex == entry.key ? 0.9 : 0.4)),
                 ),
               );
             }).toList(),
@@ -359,7 +358,7 @@ class _FacilityDetailsScreenState extends State<FacilityDetailsScreen> {
           children: [
             CustomTextView(
               label: 'Description',
-              textStyle: const TextStyle(fontSize: 16.0, color: OQDOThemeData.blackColor, fontWeight: FontWeight.bold),
+              textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(color: Theme.of(context).colorScheme.onSurface, fontWeight: FontWeight.bold),
             ),
             const SizedBox(
               width: 10,
@@ -390,14 +389,14 @@ class _FacilityDetailsScreenState extends State<FacilityDetailsScreen> {
           label: widget.getFacilityByIdModel!.description,
           maxLine: 10,
           textOverFlow: TextOverflow.ellipsis,
-          textStyle: const TextStyle(fontSize: 16.0, color: OQDOThemeData.greyColor),
+          textStyle: Theme.of(context).textTheme.bodyMedium!.copyWith(fontSize: 16.0, color: ColorsUtils.greyText),
         ),
         const SizedBox(
           height: 25.0,
         ),
         CustomTextView(
           label: 'Note',
-          textStyle: const TextStyle(fontSize: 16.0, color: OQDOThemeData.blackColor, fontWeight: FontWeight.bold),
+          textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(color: Theme.of(context).colorScheme.onSurface, fontWeight: FontWeight.bold),
         ),
         const SizedBox(
           height: 10.0,
@@ -405,9 +404,9 @@ class _FacilityDetailsScreenState extends State<FacilityDetailsScreen> {
         CustomTextView(
           label: "If your preferred time slot is not available here, please feel free to reach out to the Service Provider directly.",
           maxLine: 3,
-          textStyle: const TextStyle(
+          textStyle: Theme.of(context).textTheme.bodyMedium!.copyWith(
             fontSize: 16.0,
-            color: OQDOThemeData.greyColor,
+            color: ColorsUtils.greyText,
           ),
         ),
         const SizedBox(
@@ -415,7 +414,7 @@ class _FacilityDetailsScreenState extends State<FacilityDetailsScreen> {
         ),
         CustomTextView(
           label: 'Availability',
-          textStyle: const TextStyle(fontSize: 16.0, color: OQDOThemeData.greyColor, fontWeight: FontWeight.bold),
+          textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(color: Theme.of(context).colorScheme.onSurface, fontWeight: FontWeight.bold),
         ),
         const SizedBox(
           height: 20.0,
@@ -437,7 +436,7 @@ class _FacilityDetailsScreenState extends State<FacilityDetailsScreen> {
               flex: 1,
               child: CustomTextView(
                 label: 'Facility Available for',
-                textStyle: const TextStyle(color: OQDOThemeData.greyColor, fontSize: 14.0),
+                textStyle: Theme.of(context).textTheme.bodyMedium!.copyWith(color: ColorsUtils.greyText, fontSize: 14.0),
               ),
             ),
             Flexible(
@@ -448,7 +447,7 @@ class _FacilityDetailsScreenState extends State<FacilityDetailsScreen> {
                     alignment: Alignment.topLeft,
                     child: CustomTextView(
                       label: widget.getFacilityByIdModel!.bookingType == 'I' ? 'Individual Booking' : 'Group Booking',
-                      textStyle: const TextStyle(fontSize: 16.0, color: OQDOThemeData.greyColor, fontWeight: FontWeight.bold),
+                      textStyle: Theme.of(context).textTheme.bodyMedium!.copyWith(fontSize: 16.0, color: ColorsUtils.greyText, fontWeight: FontWeight.bold),
                     ),
                   ),
                   const SizedBox(
@@ -478,7 +477,7 @@ class _FacilityDetailsScreenState extends State<FacilityDetailsScreen> {
               flex: 1,
               child: CustomTextView(
                 label: 'Slot time',
-                textStyle: const TextStyle(color: OQDOThemeData.greyColor, fontSize: 14.0),
+                textStyle: Theme.of(context).textTheme.bodyMedium!.copyWith(color: ColorsUtils.greyText, fontSize: 14.0),
               ),
             ),
             Flexible(
@@ -487,7 +486,7 @@ class _FacilityDetailsScreenState extends State<FacilityDetailsScreen> {
                 alignment: Alignment.topLeft,
                 child: CustomTextView(
                   label: '${widget.getFacilityByIdModel!.slotTimeHour} Hours',
-                  textStyle: const TextStyle(fontSize: 16.0, color: OQDOThemeData.greyColor, fontWeight: FontWeight.bold),
+                  textStyle: Theme.of(context).textTheme.bodyMedium!.copyWith(fontSize: 16.0, color: ColorsUtils.greyText, fontWeight: FontWeight.bold),
                 ),
               ),
             ),
@@ -503,7 +502,7 @@ class _FacilityDetailsScreenState extends State<FacilityDetailsScreen> {
               flex: 1,
               child: CustomTextView(
                 label: 'Capacity',
-                textStyle: const TextStyle(color: OQDOThemeData.greyColor, fontSize: 14.0),
+                textStyle: Theme.of(context).textTheme.bodyMedium!.copyWith(color: ColorsUtils.greyText, fontSize: 14.0),
               ),
             ),
             Flexible(
@@ -512,7 +511,7 @@ class _FacilityDetailsScreenState extends State<FacilityDetailsScreen> {
                 alignment: Alignment.topLeft,
                 child: CustomTextView(
                   label: widget.getFacilityByIdModel!.facilityCapacity.toString(),
-                  textStyle: const TextStyle(fontSize: 16.0, color: OQDOThemeData.greyColor, fontWeight: FontWeight.bold),
+                  textStyle: Theme.of(context).textTheme.bodyMedium!.copyWith(fontSize: 16.0, color: ColorsUtils.greyText, fontWeight: FontWeight.bold),
                 ),
               ),
             ),
@@ -553,7 +552,7 @@ class _FacilityDetailsScreenState extends State<FacilityDetailsScreen> {
         ),
         CustomTextView(
           label: 'Slots',
-          textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(color: OQDOThemeData.greyColor, fontWeight: FontWeight.bold, fontSize: 16),
+          textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(color: Theme.of(context).colorScheme.onSurface, fontWeight: FontWeight.bold, fontSize: 16),
         ),
         const SizedBox(height: 8),
         slotListView(),
@@ -565,7 +564,7 @@ class _FacilityDetailsScreenState extends State<FacilityDetailsScreen> {
             Expanded(
               child: CustomTextView(
                 label: 'Address',
-                textStyle: const TextStyle(fontSize: 16.0, color: OQDOThemeData.blackColor, fontWeight: FontWeight.bold),
+                textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 16.0, color: Theme.of(context).colorScheme.onSurface, fontWeight: FontWeight.bold),
               ),
             ),
             Expanded(
@@ -573,7 +572,7 @@ class _FacilityDetailsScreenState extends State<FacilityDetailsScreen> {
                 label: widget.getFacilityByIdModel!.address,
                 maxLine: 8,
                 textOverFlow: TextOverflow.ellipsis,
-                textStyle: const TextStyle(color: OQDOThemeData.greyColor, fontSize: 16.0),
+                textStyle: Theme.of(context).textTheme.bodyMedium!.copyWith(color: ColorsUtils.greyText, fontSize: 16.0),
               ),
             ),
           ],
@@ -586,13 +585,13 @@ class _FacilityDetailsScreenState extends State<FacilityDetailsScreen> {
             Expanded(
               child: CustomTextView(
                 label: 'Contact Number',
-                textStyle: const TextStyle(fontSize: 16.0, color: OQDOThemeData.blackColor, fontWeight: FontWeight.bold),
+                textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 16.0, color: Theme.of(context).colorScheme.onSurface, fontWeight: FontWeight.bold),
               ),
             ),
             Expanded(
               child: CustomTextView(
                 label: widget.getFacilityByIdModel!.mobileNumber,
-                textStyle: const TextStyle(color: OQDOThemeData.greyColor, fontSize: 16.0),
+                textStyle: Theme.of(context).textTheme.bodyMedium!.copyWith(color: ColorsUtils.greyText, fontSize: 16.0),
               ),
             ),
           ],
@@ -646,7 +645,9 @@ class _FacilityDetailsScreenState extends State<FacilityDetailsScreen> {
                                 style: TextStyle(
                                     fontSize: 12,
                                     decoration: TextDecoration.underline,
-                                    color: addFacilitySlotModel.sunday! ? Theme.of(context).colorScheme.onBackground : Theme.of(context).colorScheme.primary),
+                                    color: addFacilitySlotModel.sunday!
+                                        ? Theme.of(context).colorScheme.onPrimary
+                                        : Theme.of(context).colorScheme.primary),
                               ),
                             ),
                             const SizedBox(
@@ -660,7 +661,9 @@ class _FacilityDetailsScreenState extends State<FacilityDetailsScreen> {
                                 style: TextStyle(
                                     fontSize: 12,
                                     decoration: TextDecoration.underline,
-                                    color: addFacilitySlotModel.monday! ? Theme.of(context).colorScheme.onBackground : Theme.of(context).colorScheme.primary),
+                                    color: addFacilitySlotModel.monday!
+                                        ? Theme.of(context).colorScheme.onPrimary
+                                        : Theme.of(context).colorScheme.primary),
                               ),
                             ),
                             const SizedBox(
@@ -674,7 +677,9 @@ class _FacilityDetailsScreenState extends State<FacilityDetailsScreen> {
                                 style: TextStyle(
                                     fontSize: 12,
                                     decoration: TextDecoration.underline,
-                                    color: addFacilitySlotModel.tuesday! ? Theme.of(context).colorScheme.onBackground : Theme.of(context).colorScheme.primary),
+                                    color: addFacilitySlotModel.tuesday!
+                                        ? Theme.of(context).colorScheme.onPrimary
+                                        : Theme.of(context).colorScheme.primary),
                               ),
                             ),
                             const SizedBox(
@@ -688,8 +693,9 @@ class _FacilityDetailsScreenState extends State<FacilityDetailsScreen> {
                                 style: TextStyle(
                                     fontSize: 12,
                                     decoration: TextDecoration.underline,
-                                    color:
-                                        addFacilitySlotModel.wednesday! ? Theme.of(context).colorScheme.onBackground : Theme.of(context).colorScheme.primary),
+                                    color: addFacilitySlotModel.wednesday!
+                                        ? Theme.of(context).colorScheme.onPrimary
+                                        : Theme.of(context).colorScheme.primary),
                               ),
                             ),
                             const SizedBox(
@@ -703,7 +709,9 @@ class _FacilityDetailsScreenState extends State<FacilityDetailsScreen> {
                                 style: TextStyle(
                                     fontSize: 12,
                                     decoration: TextDecoration.underline,
-                                    color: addFacilitySlotModel.thursday! ? Theme.of(context).colorScheme.onBackground : Theme.of(context).colorScheme.primary),
+                                    color: addFacilitySlotModel.thursday!
+                                        ? Theme.of(context).colorScheme.onPrimary
+                                        : Theme.of(context).colorScheme.primary),
                               ),
                             ),
                             const SizedBox(
@@ -717,7 +725,9 @@ class _FacilityDetailsScreenState extends State<FacilityDetailsScreen> {
                                 style: TextStyle(
                                     fontSize: 12,
                                     decoration: TextDecoration.underline,
-                                    color: addFacilitySlotModel.friday! ? Theme.of(context).colorScheme.onBackground : Theme.of(context).colorScheme.primary),
+                                    color: addFacilitySlotModel.friday!
+                                        ? Theme.of(context).colorScheme.onPrimary
+                                        : Theme.of(context).colorScheme.primary),
                               ),
                             ),
                             const SizedBox(
@@ -731,7 +741,9 @@ class _FacilityDetailsScreenState extends State<FacilityDetailsScreen> {
                                 style: TextStyle(
                                     fontSize: 12,
                                     decoration: TextDecoration.underline,
-                                    color: addFacilitySlotModel.saturday! ? Theme.of(context).colorScheme.onBackground : Theme.of(context).colorScheme.primary),
+                                    color: addFacilitySlotModel.saturday!
+                                        ? Theme.of(context).colorScheme.onPrimary
+                                        : Theme.of(context).colorScheme.primary),
                               ),
                             ),
                           ],

--- a/lib/utils/colorsUtils.dart
+++ b/lib/utils/colorsUtils.dart
@@ -43,6 +43,10 @@ class ColorsUtils {
   static Color get yellowStatus =>
       _isDark ? const Color(0xFFFFD54F) : const Color(0xFFE1B000);
 
+  /// Divider color used across filter sections
+  static Color get filterDivider =>
+      _isDark ? const Color(0xFF404040) : const Color(0xFFE3E3E3);
+
   /// Background color for the refer and earn section
   static Color get referEarnColor =>
       _isDark ? const Color(0xFF4FC3F7) : const Color(0xFF006590);


### PR DESCRIPTION
## Summary
- update facility list and detail screens to respect light and dark themes
- centralize filter divider color in ColorUtils

## Testing
- `dart format lib/screens/facilities/facilities_list_page.dart lib/screens/facilities/facility_details_screen.dart lib/utils/colorsUtils.dart` *(fails: command not found: dart)*
- `dart analyze` *(fails: command not found: dart)*
- `flutter test` *(fails: command not found: flutter)*

------
https://chatgpt.com/codex/tasks/task_e_68beac946370833290eddfdadc430f21