### PR TITLE
Use theme colors for appointment screens

### DIFF
--- a/lib/screens/appointment/copoun_screen.dart
+++ b/lib/screens/appointment/copoun_screen.dart
@@ -32,8 +32,10 @@ class _CopounScreenState extends State<CopounScreen> {
 
   @override
   Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+
     return Scaffold(
-      backgroundColor: Colors.white,
+      backgroundColor: colorScheme.background,
       appBar: CustomAppBar(
           title: 'Book Appointment',
           onBack: () {
@@ -48,7 +50,7 @@ class _CopounScreenState extends State<CopounScreen> {
               label: 'Select Coupon',
               textStyle: Theme.of(context).textTheme.titleLarge!.copyWith(
                     fontSize: 19,
-                    color: const Color(0xFF2B2B2B),
+                    color: colorScheme.onBackground,
                     fontWeight: FontWeight.bold,
                   ),
             ),
@@ -83,13 +85,13 @@ class _CopounScreenState extends State<CopounScreen> {
               : Expanded(
                   child: Center(
                   child: isLoading
-                      ? const CircularProgressIndicator(
-                          valueColor: AlwaysStoppedAnimation<Color>(Color(0xFF006990)),
+                      ? CircularProgressIndicator(
+                          valueColor: AlwaysStoppedAnimation<Color>(colorScheme.primary),
                         )
                       : CustomTextView(
                           label: 'No Coupons Available',
-                          textStyle: const TextStyle(
-                            color: Color(0xFF2B2B2B),
+                          textStyle: TextStyle(
+                            color: colorScheme.onBackground,
                             fontSize: 19,
                             fontWeight: FontWeight.bold,
                           ),

--- a/lib/screens/appointment/views/appointment_btn_view.dart
+++ b/lib/screens/appointment/views/appointment_btn_view.dart
@@ -13,10 +13,12 @@ class AppointmentButton extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+
     return ElevatedButton(
       onPressed: onPressed,
       style: ElevatedButton.styleFrom(
-        backgroundColor: const Color(0xFF006990),
+        backgroundColor: colorScheme.primary,
         shape: RoundedRectangleBorder(
           borderRadius: BorderRadius.circular(20.0),
         ),
@@ -34,8 +36,8 @@ class AppointmentButton extends StatelessWidget {
               children: [
                 CustomTextView(
                   label: 'S\$ ${amount.toStringAsFixed(2)}',
-                  textStyle: const TextStyle(
-                    color: Colors.white,
+                  textStyle: TextStyle(
+                    color: colorScheme.onPrimary,
                     fontSize: 14,
                     fontFamily: 'SFPro',
                     fontWeight: FontWeight.w700,
@@ -44,9 +46,9 @@ class AppointmentButton extends StatelessWidget {
                 const SizedBox(height: 4),
                 CustomTextView(
                   label: 'To Pay',
-                  textStyle: const TextStyle(
+                  textStyle: TextStyle(
                     fontFamily: 'SFPro',
-                    color: Colors.white60,
+                    color: colorScheme.onPrimary.withOpacity(0.6),
                     fontSize: 12,
                   ),
                 ),
@@ -57,8 +59,8 @@ class AppointmentButton extends StatelessWidget {
               children: [
                 CustomTextView(
                   label: 'Book Appointments',
-                  textStyle: const TextStyle(
-                    color: Colors.white,
+                  textStyle: TextStyle(
+                    color: colorScheme.onPrimary,
                     fontSize: 14,
                     fontFamily: 'SFPro',
                     fontWeight: FontWeight.w500,

--- a/lib/screens/appointment/views/discount_coupon.dart
+++ b/lib/screens/appointment/views/discount_coupon.dart
@@ -15,10 +15,12 @@ class DiscountCoupon extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+
     return SizedBox(
       height: 140,
       child: CustomPaint(
-        painter: TicketShapePainter(),
+        painter: TicketShapePainter(colorScheme.primary, colorScheme.onPrimary),
         child: Container(
           padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 24),
           child: Column(
@@ -26,16 +28,16 @@ class DiscountCoupon extends StatelessWidget {
             children: [
               Text(
                 couponCode,
-                style: const TextStyle(
-                  color: Colors.white,
+                style: TextStyle(
+                  color: colorScheme.onPrimary,
                   fontSize: 16,
                   fontWeight: FontWeight.w600,
                 ),
               ),
               CustomTextView(
                 label: 'Save $discountAmount',
-                textStyle: const TextStyle(
-                  color: Colors.white,
+                textStyle: TextStyle(
+                  color: colorScheme.onPrimary,
                   fontSize: 24,
                   fontWeight: FontWeight.w700,
                   fontFamily: 'Montserrat',
@@ -43,8 +45,8 @@ class DiscountCoupon extends StatelessWidget {
               ),
               CustomTextView(
                 label: 'Expire Date: $expiryDate',
-                textStyle: const TextStyle(
-                  color: Colors.white,
+                textStyle: TextStyle(
+                  color: colorScheme.onPrimary,
                   fontSize: 10,
                   fontWeight: FontWeight.w500,
                   fontFamily: 'Montserrat',
@@ -59,11 +61,16 @@ class DiscountCoupon extends StatelessWidget {
 }
 
 class TicketShapePainter extends CustomPainter {
+  TicketShapePainter(this.backgroundColor, this.gridColor);
+
+  final Color backgroundColor;
+  final Color gridColor;
+
   @override
   void paint(Canvas canvas, Size size) {
     // Main ticket shape paint
     final Paint paint = Paint()
-      ..color = const Color(0xFF006994) // Deep blue color
+      ..color = backgroundColor
       ..style = PaintingStyle.fill;
 
     const double circleRadius = 20;
@@ -125,7 +132,7 @@ class TicketShapePainter extends CustomPainter {
 
     // Grid pattern paint
     final Paint gridPaint = Paint()
-      ..color = Colors.white.withOpacity(0.05)
+      ..color = gridColor.withOpacity(0.05)
       ..strokeWidth = 0.5
       ..style = PaintingStyle.stroke;
 

--- a/lib/screens/appointment/views/selected_discount_view.dart
+++ b/lib/screens/appointment/views/selected_discount_view.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:oqdo_mobile_app/theme/custom_colors.dart';
 import 'package:oqdo_mobile_app/utils/custom_text_view.dart';
 
 class SelectedDiscountView extends StatelessWidget {
@@ -15,11 +16,14 @@ class SelectedDiscountView extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    final customColors = Theme.of(context).extension<CustomColors>()!;
+
     return Container(
       margin: const EdgeInsets.all(10.0),
       decoration: BoxDecoration(
-        color: const Color(0xFFF4FBFF),
-        border: Border.all(color: const Color(0xFF0099FA).withOpacity(0.5), width: 2),
+        color: colorScheme.primary.withOpacity(0.05),
+        border: Border.all(color: colorScheme.primary.withOpacity(0.5), width: 2),
         borderRadius: BorderRadius.circular(8),
       ),
       child: Padding(
@@ -32,26 +36,26 @@ class SelectedDiscountView extends StatelessWidget {
             Expanded(
               child: Text.rich(
                 TextSpan(
-                  style: const TextStyle(
+                  style: TextStyle(
                     fontSize: 16,
                     fontWeight: FontWeight.w600,
-                    color: Color(0xFF0099FA),
+                    color: colorScheme.primary,
                   ),
                   children: [
                     const TextSpan(text: 'You Saved '),
                     TextSpan(
                       text: percentage,
-                      style: const TextStyle(
+                      style: TextStyle(
                         fontWeight: FontWeight.bold,
-                        color: Color(0xFF0099FA),
+                        color: colorScheme.primary,
                       ),
                     ),
                     const TextSpan(text: ' with '),
                     TextSpan(
                       text: couponCode,
-                      style: const TextStyle(
+                      style: TextStyle(
                         fontWeight: FontWeight.bold,
-                        color: Color(0xFF0099FA),
+                        color: colorScheme.primary,
                       ),
                     ),
                   ],
@@ -63,17 +67,17 @@ class SelectedDiscountView extends StatelessWidget {
             TextButton(
               onPressed: onRemove,
               style: TextButton.styleFrom(
-                foregroundColor: const Color(0xFFFF0000),
+                foregroundColor: customColors.redColor,
                 padding: const EdgeInsets.symmetric(horizontal: 8),
                 minimumSize: Size.zero,
                 tapTargetSize: MaterialTapTargetSize.shrinkWrap,
               ),
               child: CustomTextView(
                 label: 'Remove',
-                textStyle: const TextStyle(
+                textStyle: TextStyle(
                   fontSize: 16,
                   fontWeight: FontWeight.w600,
-                  color: Color(0xFFFF0000),
+                  color: customColors.redColor,
                 ),
               ),
             ),


### PR DESCRIPTION
## Summary
- replace hardcoded colors in appointment coupon workflow with theme-based values
- draw discount coupon with painter colors from theme
- align appointment CTA widget with ColorScheme

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bfe308f20883328dffc37980191810