### PR TITLE
refactor: apply theme colors to appointment screens

### DIFF
--- a/lib/screens/appointment/CoachEndUserCancelAppointment.dart
+++ b/lib/screens/appointment/CoachEndUserCancelAppointment.dart
@@ -11,7 +11,6 @@ import 'package:oqdo_mobile_app/model/CancelCoachAppointmentModel.dart';
 import 'package:oqdo_mobile_app/model/coach_appointment_details_response_model.dart' as model;
 import 'package:oqdo_mobile_app/model/end_user_appointment_model_details.dart';
 import 'package:oqdo_mobile_app/oqdo_application.dart';
-import 'package:oqdo_mobile_app/theme/oqdo_theme_data.dart';
 import 'package:oqdo_mobile_app/utils/constants.dart';
 import 'package:oqdo_mobile_app/utils/custom_text_view.dart';
 import 'package:oqdo_mobile_app/utils/network_interceptor.dart';
@@ -88,7 +87,7 @@ class _CoachEndUserCancelAppointmentState extends State<CoachEndUserCancelAppoin
                                   textStyle: Theme.of(context)
                                       .textTheme
                                       .titleLarge!
-                                      .copyWith(fontSize: 20, color: OQDOThemeData.greyColor, fontWeight: FontWeight.w500),
+                                      .copyWith(fontSize: 20, color: Theme.of(context).colorScheme.onSurface, fontWeight: FontWeight.w500),
                                 ),
                               ),
                               const SizedBox(
@@ -101,7 +100,7 @@ class _CoachEndUserCancelAppointmentState extends State<CoachEndUserCancelAppoin
                                   textStyle: Theme.of(context)
                                       .textTheme
                                       .titleSmall!
-                                      .copyWith(fontSize: 14.0, fontWeight: FontWeight.w400, color: OQDOThemeData.greyColor),
+                                      .copyWith(fontSize: 14.0, fontWeight: FontWeight.w400, color: Theme.of(context).colorScheme.onSurface),
                                 ),
                               ),
                               const SizedBox(
@@ -117,7 +116,7 @@ class _CoachEndUserCancelAppointmentState extends State<CoachEndUserCancelAppoin
                                       textStyle: Theme.of(context)
                                           .textTheme
                                           .titleSmall!
-                                          .copyWith(color: OQDOThemeData.otherTextColor, fontWeight: FontWeight.w600, fontSize: 12.0),
+                                          .copyWith(color: Theme.of(context).extension<CustomColors>()!.greyText, fontWeight: FontWeight.w600, fontSize: 12.0),
                                     ),
                                   ],
                                 ),
@@ -132,7 +131,7 @@ class _CoachEndUserCancelAppointmentState extends State<CoachEndUserCancelAppoin
                                   textStyle: Theme.of(context)
                                       .textTheme
                                       .titleMedium!
-                                      .copyWith(fontSize: 14, color: const Color(0xFF818181), fontWeight: FontWeight.w400),
+                                      .copyWith(fontSize: 14, color: Theme.of(context).extension<CustomColors>()!.greyText, fontWeight: FontWeight.w400),
                                 ),
                               ),
                               const SizedBox(
@@ -145,7 +144,7 @@ class _CoachEndUserCancelAppointmentState extends State<CoachEndUserCancelAppoin
                                   textStyle: Theme.of(context)
                                       .textTheme
                                       .titleMedium!
-                                      .copyWith(fontSize: 14, color: const Color(0xFF818181), fontWeight: FontWeight.w400),
+                                      .copyWith(fontSize: 14, color: Theme.of(context).extension<CustomColors>()!.greyText, fontWeight: FontWeight.w400),
                                 ),
                               ),
                               const SizedBox(
@@ -158,7 +157,7 @@ class _CoachEndUserCancelAppointmentState extends State<CoachEndUserCancelAppoin
                                   textStyle: Theme.of(context)
                                       .textTheme
                                       .titleMedium!
-                                      .copyWith(fontSize: 14, color: const Color(0xFF818181), fontWeight: FontWeight.w400),
+                                      .copyWith(fontSize: 14, color: Theme.of(context).extension<CustomColors>()!.greyText, fontWeight: FontWeight.w400),
                                 ),
                               ),
                               const SizedBox(
@@ -171,7 +170,7 @@ class _CoachEndUserCancelAppointmentState extends State<CoachEndUserCancelAppoin
                                   textStyle: Theme.of(context)
                                       .textTheme
                                       .titleMedium!
-                                      .copyWith(fontSize: 14, color: const Color(0xFF818181), fontWeight: FontWeight.w400),
+                                      .copyWith(fontSize: 14, color: Theme.of(context).extension<CustomColors>()!.greyText, fontWeight: FontWeight.w400),
                                 ),
                               ),
                               const SizedBox(
@@ -184,7 +183,7 @@ class _CoachEndUserCancelAppointmentState extends State<CoachEndUserCancelAppoin
                                   textStyle: Theme.of(context)
                                       .textTheme
                                       .titleMedium!
-                                      .copyWith(fontSize: 14, color: const Color(0xFF818181), fontWeight: FontWeight.w400),
+                                      .copyWith(fontSize: 14, color: Theme.of(context).extension<CustomColors>()!.greyText, fontWeight: FontWeight.w400),
                                 ),
                               ),
                               const SizedBox(
@@ -199,7 +198,7 @@ class _CoachEndUserCancelAppointmentState extends State<CoachEndUserCancelAppoin
                                   textStyle: Theme.of(context)
                                       .textTheme
                                       .titleMedium!
-                                      .copyWith(fontSize: 14, color: const Color(0xFF818181), fontWeight: FontWeight.w400),
+                                      .copyWith(fontSize: 14, color: Theme.of(context).extension<CustomColors>()!.greyText, fontWeight: FontWeight.w400),
                                 ),
                               ),
                               const SizedBox(
@@ -207,7 +206,7 @@ class _CoachEndUserCancelAppointmentState extends State<CoachEndUserCancelAppoin
                               ),
                               const Divider(
                                 height: 1,
-                                color: Color(0xFFCACACA),
+                                color: Theme.of(context).colorScheme.outline,
                               ),
                               const SizedBox(
                                 height: 20.0,
@@ -231,14 +230,14 @@ class _CoachEndUserCancelAppointmentState extends State<CoachEndUserCancelAppoin
                                       textStyle: Theme.of(context)
                                           .textTheme
                                           .titleMedium!
-                                          .copyWith(fontSize: 16.0, fontWeight: FontWeight.w500, color: OQDOThemeData.greyColor),
+                                          .copyWith(fontSize: 16.0, fontWeight: FontWeight.w500, color: Theme.of(context).colorScheme.onSurface),
                                     ),
                                     CustomTextView(
                                       label: 'S\$ ${totalRefundAmount.toStringAsFixed(2)}',
                                       textStyle: Theme.of(context)
                                           .textTheme
                                           .titleMedium!
-                                          .copyWith(fontSize: 16.0, fontWeight: FontWeight.w400, color: OQDOThemeData.greyColor),
+                                          .copyWith(fontSize: 16.0, fontWeight: FontWeight.w400, color: Theme.of(context).colorScheme.onSurface),
                                     )
                                   ],
                                 ),
@@ -246,7 +245,7 @@ class _CoachEndUserCancelAppointmentState extends State<CoachEndUserCancelAppoin
                               const SizedBox(height: 15.0),
                               const Divider(
                                 height: 1,
-                                color: OQDOThemeData.greyColor,
+                                color: Theme.of(context).colorScheme.onSurface,
                               ),
                               const SizedBox(height: 15.0),
                               Padding(
@@ -259,14 +258,14 @@ class _CoachEndUserCancelAppointmentState extends State<CoachEndUserCancelAppoin
                                       textStyle: Theme.of(context)
                                           .textTheme
                                           .titleMedium!
-                                          .copyWith(fontSize: 16.0, fontWeight: FontWeight.w500, color: OQDOThemeData.blackColor),
+                                          .copyWith(fontSize: 16.0, fontWeight: FontWeight.w500, color: Theme.of(context).colorScheme.onBackground),
                                     ),
                                     CustomTextView(
                                       label: 'S\$ ${totalDiscountAmount.toStringAsFixed(2)}',
                                       textStyle: Theme.of(context)
                                           .textTheme
                                           .titleMedium!
-                                          .copyWith(fontSize: 16.0, fontWeight: FontWeight.w500, color: OQDOThemeData.blackColor),
+                                          .copyWith(fontSize: 16.0, fontWeight: FontWeight.w500, color: Theme.of(context).colorScheme.onBackground),
                                     )
                                   ],
                                 ),
@@ -274,7 +273,7 @@ class _CoachEndUserCancelAppointmentState extends State<CoachEndUserCancelAppoin
                               const SizedBox(height: 15.0),
                               const Divider(
                                 height: 1,
-                                color: OQDOThemeData.greyColor,
+                                color: Theme.of(context).colorScheme.onSurface,
                               ),
                               const SizedBox(height: 20.0),
                               Padding(
@@ -300,7 +299,7 @@ class _CoachEndUserCancelAppointmentState extends State<CoachEndUserCancelAppoin
                                       textStyle: Theme.of(context)
                                           .textTheme
                                           .titleSmall!
-                                          .copyWith(fontSize: 16.0, fontWeight: FontWeight.w400, color: OQDOThemeData.greyColor),
+                                          .copyWith(fontSize: 16.0, fontWeight: FontWeight.w400, color: Theme.of(context).colorScheme.onSurface),
                                     ),
                                   ],
                                 ),
@@ -395,7 +394,7 @@ class _CoachEndUserCancelAppointmentState extends State<CoachEndUserCancelAppoin
                         label:
                             '${convertDateToString(bookingSlotList[index].bookingDate!).split(',')[1].split(' ')[2]} ${convertDateToString(bookingSlotList[index].bookingDate!).split(',')[1].split(' ')[1]} - ${convertDateToString(bookingSlotList[index].bookingDate!).split(',')[0]}',
                         textStyle:
-                            Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 18.0, fontWeight: FontWeight.w500, color: OQDOThemeData.greyColor),
+                            Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 18.0, fontWeight: FontWeight.w500, color: Theme.of(context).colorScheme.onSurface),
                       ),
                       const SizedBox(
                         height: 5.0,
@@ -407,7 +406,7 @@ class _CoachEndUserCancelAppointmentState extends State<CoachEndUserCancelAppoin
                           CustomTextView(
                             label: '${bookingSlotList[index].startTime} - ${bookingSlotList[index].endTime}',
                             textStyle:
-                                Theme.of(context).textTheme.titleSmall!.copyWith(fontSize: 12.0, fontWeight: FontWeight.w400, color: OQDOThemeData.greyColor),
+                                Theme.of(context).textTheme.titleSmall!.copyWith(fontSize: 12.0, fontWeight: FontWeight.w400, color: Theme.of(context).colorScheme.onSurface),
                           ),
                           const SizedBox(
                             width: 15,
@@ -415,7 +414,7 @@ class _CoachEndUserCancelAppointmentState extends State<CoachEndUserCancelAppoin
                           CustomTextView(
                             label: 'S\$ ${bookingSlotList[index].ratePerHour?.toStringAsFixed(2) ?? 0.00}/hour',
                             textStyle:
-                                Theme.of(context).textTheme.titleSmall!.copyWith(fontSize: 12.0, fontWeight: FontWeight.w400, color: OQDOThemeData.greyColor),
+                                Theme.of(context).textTheme.titleSmall!.copyWith(fontSize: 12.0, fontWeight: FontWeight.w400, color: Theme.of(context).colorScheme.onSurface),
                           ),
                         ],
                       ),
@@ -431,11 +430,11 @@ class _CoachEndUserCancelAppointmentState extends State<CoachEndUserCancelAppoin
               children: [
                 CustomTextView(
                   label: 'Refund Amount: ',
-                  textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 10.0, fontWeight: FontWeight.w500, color: OQDOThemeData.greyColor),
+                  textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 10.0, fontWeight: FontWeight.w500, color: Theme.of(context).colorScheme.onSurface),
                 ),
                 CustomTextView(
                   label: 'S\$ ${bookingSlotList[index].amount?.toStringAsFixed(2) ?? 0.00}',
-                  textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 12.0, fontWeight: FontWeight.w500, color: OQDOThemeData.buttonColor),
+                  textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 12.0, fontWeight: FontWeight.w500, color: Theme.of(context).colorScheme.primary),
                 ),
               ],
             ),

--- a/lib/screens/appointment/EndUserFacilityAppointmentDetails.dart
+++ b/lib/screens/appointment/EndUserFacilityAppointmentDetails.dart
@@ -10,7 +10,6 @@ import 'package:oqdo_mobile_app/components/custom_app_bar.dart';
 import 'package:oqdo_mobile_app/components/my_button.dart';
 import 'package:oqdo_mobile_app/model/end_user_appointment_model_details.dart';
 import 'package:oqdo_mobile_app/model/facility_appointment_details_model.dart';
-import 'package:oqdo_mobile_app/theme/oqdo_theme_data.dart';
 import 'package:oqdo_mobile_app/utils/constants.dart';
 import 'package:oqdo_mobile_app/utils/custom_text_view.dart';
 import 'package:oqdo_mobile_app/utils/extentions.dart';
@@ -57,7 +56,7 @@ class _EndUserFacilityAppointmentDetailsState extends State<EndUserFacilityAppoi
         child: Container(
           width: MediaQuery.of(context).size.width,
           height: MediaQuery.of(context).size.height,
-          color: OQDOThemeData.whiteColor,
+          color: Theme.of(context).extension<CustomColors>()!.white,
           child: _facilityAppointmentDetailModel != null
               ? SingleChildScrollView(
                   child: Column(
@@ -118,7 +117,7 @@ class _EndUserFacilityAppointmentDetailsState extends State<EndUserFacilityAppoi
                         child: CustomTextView(
                           label: 'Name: ${_facilityAppointmentDetailModel!.facilityName}',
                           textStyle:
-                              Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 14, color: const Color(0xFF818181), fontWeight: FontWeight.w400),
+                              Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 14, color: Theme.of(context).extension<CustomColors>()!.greyText, fontWeight: FontWeight.w400),
                         ),
                       ),
                       const SizedBox(
@@ -129,7 +128,7 @@ class _EndUserFacilityAppointmentDetailsState extends State<EndUserFacilityAppoi
                         child: CustomTextView(
                           label: 'Email ID: ${_facilityAppointmentDetailModel!.facilityEmail}',
                           textStyle:
-                              Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 14, color: const Color(0xFF818181), fontWeight: FontWeight.w400),
+                              Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 14, color: Theme.of(context).extension<CustomColors>()!.greyText, fontWeight: FontWeight.w400),
                         ),
                       ),
                       const SizedBox(
@@ -140,7 +139,7 @@ class _EndUserFacilityAppointmentDetailsState extends State<EndUserFacilityAppoi
                         child: CustomTextView(
                           label: 'Phone number: ${_facilityAppointmentDetailModel!.facilityMobileNumber}',
                           textStyle:
-                              Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 14, color: const Color(0xFF818181), fontWeight: FontWeight.w400),
+                              Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 14, color: Theme.of(context).extension<CustomColors>()!.greyText, fontWeight: FontWeight.w400),
                         ),
                       ),
                       const SizedBox(
@@ -151,7 +150,7 @@ class _EndUserFacilityAppointmentDetailsState extends State<EndUserFacilityAppoi
                         child: CustomTextView(
                           label: _facilityAppointmentDetailModel!.bookingType == 'I' ? 'Booking For: Individual' : 'Booking For: Group',
                           textStyle:
-                              Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 14, color: const Color(0xFF818181), fontWeight: FontWeight.w400),
+                              Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 14, color: Theme.of(context).extension<CustomColors>()!.greyText, fontWeight: FontWeight.w400),
                         ),
                       ),
                       const SizedBox(
@@ -164,7 +163,7 @@ class _EndUserFacilityAppointmentDetailsState extends State<EndUserFacilityAppoi
                           textOverFlow: TextOverflow.ellipsis,
                           label: 'Address : ${_facilityAppointmentDetailModel!.address}',
                           textStyle:
-                              Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 14, color: const Color(0xFF818181), fontWeight: FontWeight.w400),
+                              Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 14, color: Theme.of(context).extension<CustomColors>()!.greyText, fontWeight: FontWeight.w400),
                         ),
                       ),
                       const SizedBox(
@@ -175,7 +174,7 @@ class _EndUserFacilityAppointmentDetailsState extends State<EndUserFacilityAppoi
                         child: CustomTextView(
                           label: 'Order ID: ${_facilityAppointmentDetailModel!.bookingNo}',
                           textStyle:
-                              Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 14, color: const Color(0xFF818181), fontWeight: FontWeight.w400),
+                              Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 14, color: Theme.of(context).extension<CustomColors>()!.greyText, fontWeight: FontWeight.w400),
                         ),
                       ),
                       const SizedBox(
@@ -217,11 +216,11 @@ class _EndUserFacilityAppointmentDetailsState extends State<EndUserFacilityAppoi
         //   children: [
         //     CustomTextView(
         //       label: 'Total Amount',
-        //       textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(fontWeight: FontWeight.w600, color: OQDOThemeData.greyColor, fontSize: 18.0),
+        //       textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(fontWeight: FontWeight.w600, color: Theme.of(context).colorScheme.onSurface, fontSize: 18.0),
         //     ),
         //     CustomTextView(
         //       label: 'S\$ ${_facilityAppointmentDetailModel!.totalAmt}',
-        //       textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(fontWeight: FontWeight.w400, color: OQDOThemeData.greyColor, fontSize: 18.0),
+        //       textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(fontWeight: FontWeight.w400, color: Theme.of(context).colorScheme.onSurface, fontSize: 18.0),
         //     ),
         //   ],
         // ),
@@ -235,7 +234,7 @@ class _EndUserFacilityAppointmentDetailsState extends State<EndUserFacilityAppoi
               children: [
                 CustomTextView(
                   label: 'Add Feedback',
-                  textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(fontWeight: FontWeight.w600, color: OQDOThemeData.greyColor, fontSize: 18.0),
+                  textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(fontWeight: FontWeight.w600, color: Theme.of(context).colorScheme.onSurface, fontSize: 18.0),
                 ),
                 const SizedBox(
                   height: 10,
@@ -251,7 +250,7 @@ class _EndUserFacilityAppointmentDetailsState extends State<EndUserFacilityAppoi
                   itemPadding: const EdgeInsets.symmetric(horizontal: 2.0),
                   itemBuilder: (context, _) => const Icon(
                     Icons.star,
-                    color: Colors.amber,
+                    color: Theme.of(context).extension<CustomColors>()!.yellowStatus,
                     size: 15,
                   ),
                   onRatingUpdate: (rating) {
@@ -277,15 +276,15 @@ class _EndUserFacilityAppointmentDetailsState extends State<EndUserFacilityAppoi
                 decoration: BoxDecoration(
                     borderRadius: const BorderRadius.only(
                         topLeft: Radius.circular(10), bottomLeft: Radius.circular(10), bottomRight: Radius.circular(10), topRight: Radius.circular(10)),
-                    border: Border.all(color: const Color(0xffF1F1F1)),
-                    color: const Color(0xffEFEFEF).withOpacity(0.5)),
+                    border: Border.all(color: Theme.of(context).extension<CustomColors>()!.buddiesCard),
+                    color: Theme.of(context).extension<CustomColors>()!.greyButton.withOpacity(0.5)),
                 child: Row(
                   mainAxisAlignment: MainAxisAlignment.center,
                   children: [
                     const Icon(
                       Icons.add,
                       size: 20,
-                      color: Color(0xFF006590),
+                      color: Theme.of(context).colorScheme.primary,
                     ),
                     const SizedBox(
                       width: 10,
@@ -293,7 +292,7 @@ class _EndUserFacilityAppointmentDetailsState extends State<EndUserFacilityAppoi
                     CustomTextView(
                       label: 'Add Feedback',
                       type: styleSubTitle,
-                      textStyle: Theme.of(context).textTheme.titleSmall!.copyWith(color: const Color(0xFF006590), fontSize: 14.0, fontWeight: FontWeight.w500),
+                      textStyle: Theme.of(context).textTheme.titleSmall!.copyWith(color: Theme.of(context).colorScheme.primary, fontSize: 14.0, fontWeight: FontWeight.w500),
                     ),
                   ],
                 ),
@@ -393,7 +392,7 @@ class _EndUserFacilityAppointmentDetailsState extends State<EndUserFacilityAppoi
                   CustomTextView(
                     label:
                         '${convertDateToString(bookingSlotList[index].bookingDate!).split(',')[1].split(' ')[2]} ${convertDateToString(bookingSlotList[index].bookingDate!).split(',')[1].split(' ')[1]} - ${convertDateToString(bookingSlotList[index].bookingDate!).split(',')[0]}',
-                    textStyle: Theme.of(context).textTheme.titleLarge!.copyWith(fontSize: 20.0, color: OQDOThemeData.greyColor, fontWeight: FontWeight.w500),
+                    textStyle: Theme.of(context).textTheme.titleLarge!.copyWith(fontSize: 20.0, color: Theme.of(context).colorScheme.onSurface, fontWeight: FontWeight.w500),
                   ),
                   const SizedBox(
                     height: 5.0,
@@ -404,7 +403,7 @@ class _EndUserFacilityAppointmentDetailsState extends State<EndUserFacilityAppoi
                       CustomTextView(
                         label: '${bookingSlotList[index].startTime}-${bookingSlotList[index].endTime}',
                         textStyle:
-                            Theme.of(context).textTheme.titleLarge!.copyWith(fontSize: 16.0, color: OQDOThemeData.greyColor, fontWeight: FontWeight.w500),
+                            Theme.of(context).textTheme.titleLarge!.copyWith(fontSize: 16.0, color: Theme.of(context).colorScheme.onSurface, fontWeight: FontWeight.w500),
                       ),
                       const SizedBox(
                         width: 15,
@@ -412,7 +411,7 @@ class _EndUserFacilityAppointmentDetailsState extends State<EndUserFacilityAppoi
                       CustomTextView(
                         label: 'S\$ ${bookingSlotList[index].ratePerHour?.toStringAsFixed(2) ?? 0.00}/hour',
                         textStyle:
-                            Theme.of(context).textTheme.titleLarge!.copyWith(fontSize: 16.0, color: OQDOThemeData.greyColor, fontWeight: FontWeight.w500),
+                            Theme.of(context).textTheme.titleLarge!.copyWith(fontSize: 16.0, color: Theme.of(context).colorScheme.onSurface, fontWeight: FontWeight.w500),
                       ),
                     ],
                   ),
@@ -427,7 +426,7 @@ class _EndUserFacilityAppointmentDetailsState extends State<EndUserFacilityAppoi
                       ? CustomTextView(
                           label: 'Cancelled',
                           textStyle:
-                              Theme.of(context).textTheme.titleLarge!.copyWith(fontSize: 14.0, color: OQDOThemeData.errorColor, fontWeight: FontWeight.w500),
+                              Theme.of(context).textTheme.titleLarge!.copyWith(fontSize: 14.0, color: Theme.of(context).colorScheme.error, fontWeight: FontWeight.w500),
                         )
                       : const SizedBox(),
                   const SizedBox(
@@ -435,7 +434,7 @@ class _EndUserFacilityAppointmentDetailsState extends State<EndUserFacilityAppoi
                   ),
                   CustomTextView(
                     label: 'S\$ ${bookingSlotList[index].bookingAmount?.toStringAsFixed(2) ?? 0.00}',
-                    textStyle: Theme.of(context).textTheme.titleLarge!.copyWith(fontSize: 20.0, color: OQDOThemeData.greyColor, fontWeight: FontWeight.w500),
+                    textStyle: Theme.of(context).textTheme.titleLarge!.copyWith(fontSize: 20.0, color: Theme.of(context).colorScheme.onSurface, fontWeight: FontWeight.w500),
                   ),
                 ],
               ),
@@ -443,7 +442,7 @@ class _EndUserFacilityAppointmentDetailsState extends State<EndUserFacilityAppoi
           ),
           const Divider(
             thickness: 1.0,
-            color: Color(0xFFEFEFEF),
+            color: Theme.of(context).extension<CustomColors>()!.greyButton,
           ),
         ],
       ),
@@ -465,7 +464,7 @@ class _EndUserFacilityAppointmentDetailsState extends State<EndUserFacilityAppoi
               Container(
                 decoration: BoxDecoration(
                   shape: BoxShape.rectangle,
-                  border: Border.all(width: 7.0, color: const Color.fromRGBO(0, 101, 144, 0.5)),
+                  border: Border.all(width: 7.0, color: Theme.of(context).colorScheme.primary.withOpacity(0.5)),
                 ),
               ),
               const SizedBox(width: 20.0),
@@ -507,14 +506,14 @@ class _EndUserFacilityAppointmentDetailsState extends State<EndUserFacilityAppoi
                 children: [
                   CustomTextView(
                     label: '${_facilityAppointmentDetailModel!.facilitySetupTitle}\n${_facilityAppointmentDetailModel!.facilitySetupSubTitle}',
-                    textStyle: Theme.of(context).textTheme.titleSmall!.copyWith(fontWeight: FontWeight.w500, fontSize: 18.0, color: OQDOThemeData.greyColor),
+                    textStyle: Theme.of(context).textTheme.titleSmall!.copyWith(fontWeight: FontWeight.w500, fontSize: 18.0, color: Theme.of(context).colorScheme.onSurface),
                   ),
                   const SizedBox(
                     height: 8.0,
                   ),
                   CustomTextView(
                     label: '${_facilityAppointmentDetailModel!.activityName} - ${_facilityAppointmentDetailModel!.subActivityName}',
-                    textStyle: Theme.of(context).textTheme.titleSmall!.copyWith(fontSize: 14.0, fontWeight: FontWeight.w400, color: OQDOThemeData.greyColor),
+                    textStyle: Theme.of(context).textTheme.titleSmall!.copyWith(fontSize: 14.0, fontWeight: FontWeight.w400, color: Theme.of(context).colorScheme.onSurface),
                   )
                 ],
               )
@@ -539,8 +538,8 @@ class _EndUserFacilityAppointmentDetailsState extends State<EndUserFacilityAppoi
   Widget _paymentSummaryView() {
     return Container(
       decoration: BoxDecoration(
-        color: OQDOThemeData.whiteColor,
-        border: Border.all(color: OQDOThemeData.otherTextColor),
+        color: Theme.of(context).extension<CustomColors>()!.white,
+        border: Border.all(color: Theme.of(context).extension<CustomColors>()!.greyText),
       ),
       padding: const EdgeInsets.all(8.0),
       child: Column(
@@ -551,7 +550,7 @@ class _EndUserFacilityAppointmentDetailsState extends State<EndUserFacilityAppoi
             textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(
                   fontSize: 16.0,
                   fontWeight: FontWeight.w600,
-                  color: OQDOThemeData.buttonColor,
+                  color: Theme.of(context).colorScheme.primary,
                 ),
           ),
           const SizedBox(
@@ -570,13 +569,13 @@ class _EndUserFacilityAppointmentDetailsState extends State<EndUserFacilityAppoi
             children: [
               CustomTextView(
                 label: "Total Amount : ",
-                textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 16.0, fontWeight: FontWeight.w600, color: OQDOThemeData.blackColor),
+                textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 16.0, fontWeight: FontWeight.w600, color: Theme.of(context).colorScheme.onBackground),
               ),
               Column(
                 children: [
                   CustomTextView(
                     label: 'S\$ ${totalAmount.toStringAsFixed(2)}',
-                    textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 14.0, fontWeight: FontWeight.w600, color: OQDOThemeData.blackColor),
+                    textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 14.0, fontWeight: FontWeight.w600, color: Theme.of(context).colorScheme.onBackground),
                   ),
                 ],
               ),
@@ -586,7 +585,7 @@ class _EndUserFacilityAppointmentDetailsState extends State<EndUserFacilityAppoi
             height: 10,
           ),
           const Divider(
-            color: OQDOThemeData.greyColor,
+            color: Theme.of(context).colorScheme.onSurface,
           ),
           const SizedBox(
             height: 10,
@@ -606,7 +605,7 @@ class _EndUserFacilityAppointmentDetailsState extends State<EndUserFacilityAppoi
                           textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(
                               fontSize: 14.0,
                               fontWeight: FontWeight.w600,
-                              color: discountedAmount <= 0 ? OQDOThemeData.blackColor : Theme.of(context).colorScheme.secondaryContainer),
+                              color: discountedAmount <= 0 ? Theme.of(context).colorScheme.onBackground : Theme.of(context).colorScheme.secondaryContainer),
                         ),
                         const SizedBox(
                           height: 3,
@@ -615,7 +614,7 @@ class _EndUserFacilityAppointmentDetailsState extends State<EndUserFacilityAppoi
                           label: 'Applied on booking fees (S\$ ${bookingAmount.toStringAsFixed(2)})',
                           maxLine: 2,
                           textStyle:
-                              Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 12.0, fontWeight: FontWeight.w500, color: OQDOThemeData.greyColor),
+                              Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 12.0, fontWeight: FontWeight.w500, color: Theme.of(context).colorScheme.onSurface),
                         ).visible(discountedAmount > 0),
                       ],
                     ),
@@ -633,7 +632,7 @@ class _EndUserFacilityAppointmentDetailsState extends State<EndUserFacilityAppoi
                           textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(
                               fontSize: 13.0,
                               fontWeight: FontWeight.w600,
-                              color: discountedAmount <= 0 ? OQDOThemeData.blackColor : Theme.of(context).colorScheme.secondaryContainer),
+                              color: discountedAmount <= 0 ? Theme.of(context).colorScheme.onBackground : Theme.of(context).colorScheme.secondaryContainer),
                         ),
                       ],
                     ),
@@ -663,7 +662,7 @@ class _EndUserFacilityAppointmentDetailsState extends State<EndUserFacilityAppoi
                 children: [
                   CustomTextView(
                     label: title,
-                    textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 14.0, fontWeight: FontWeight.w600, color: OQDOThemeData.blackColor),
+                    textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 14.0, fontWeight: FontWeight.w600, color: Theme.of(context).colorScheme.onBackground),
                   ),
                   const SizedBox(
                     height: 3,
@@ -671,7 +670,7 @@ class _EndUserFacilityAppointmentDetailsState extends State<EndUserFacilityAppoi
                   CustomTextView(
                     label: details,
                     maxLine: 2,
-                    textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 12.0, fontWeight: FontWeight.w500, color: OQDOThemeData.greyColor),
+                    textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 12.0, fontWeight: FontWeight.w500, color: Theme.of(context).colorScheme.onSurface),
                   ),
                 ],
               ),
@@ -686,7 +685,7 @@ class _EndUserFacilityAppointmentDetailsState extends State<EndUserFacilityAppoi
                     label: 'S\$ $rate',
                     maxLine: 2,
                     textOverFlow: TextOverflow.ellipsis,
-                    textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 13.0, fontWeight: FontWeight.w600, color: OQDOThemeData.blackColor),
+                    textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 13.0, fontWeight: FontWeight.w600, color: Theme.of(context).colorScheme.onBackground),
                   ),
                 ],
               ),
@@ -697,7 +696,7 @@ class _EndUserFacilityAppointmentDetailsState extends State<EndUserFacilityAppoi
           height: 3,
         ),
         const Divider(
-          color: OQDOThemeData.greyColor,
+          color: Theme.of(context).colorScheme.onSurface,
         ),
       ],
     );
@@ -716,7 +715,7 @@ class _EndUserFacilityAppointmentDetailsState extends State<EndUserFacilityAppoi
   //               children: [
   //                 CustomTextView(
   //                   label: title,
-  //                   textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 14.0, fontWeight: FontWeight.w600, color: OQDOThemeData.blackColor),
+  //                   textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 14.0, fontWeight: FontWeight.w600, color: Theme.of(context).colorScheme.onBackground),
   //                 ),
   //                 const SizedBox(
   //                   height: 3,
@@ -724,7 +723,7 @@ class _EndUserFacilityAppointmentDetailsState extends State<EndUserFacilityAppoi
   //                 CustomTextView(
   //                   label: details,
   //                   maxLine: 2,
-  //                   textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 12.0, fontWeight: FontWeight.w500, color: OQDOThemeData.greyColor),
+  //                   textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 12.0, fontWeight: FontWeight.w500, color: Theme.of(context).colorScheme.onSurface),
   //                 ),
   //               ],
   //             ),
@@ -738,7 +737,7 @@ class _EndUserFacilityAppointmentDetailsState extends State<EndUserFacilityAppoi
   //                   maxLine: 2,
   //                   textOverFlow: TextOverflow.ellipsis,
   //                   label: 'S\$ $rate',
-  //                   textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 13.0, fontWeight: FontWeight.w600, color: OQDOThemeData.blackColor),
+  //                   textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 13.0, fontWeight: FontWeight.w600, color: Theme.of(context).colorScheme.onBackground),
   //                 ),
   //               ],
   //             ),
@@ -749,7 +748,7 @@ class _EndUserFacilityAppointmentDetailsState extends State<EndUserFacilityAppoi
   //         height: 3,
   //       ),
   //       const Divider(
-  //         color: OQDOThemeData.greyColor,
+  //         color: Theme.of(context).colorScheme.onSurface,
   //       ),
   //     ],
   //   );
@@ -968,7 +967,7 @@ class _EndUserFacilityAppointmentDetailsState extends State<EndUserFacilityAppoi
               padding: const EdgeInsets.only(left: 20.0),
               child: CustomTextView(
                 label: 'Transaction History',
-                textStyle: Theme.of(context).textTheme.titleLarge!.copyWith(fontSize: 20, color: OQDOThemeData.blackColor, fontWeight: FontWeight.w500),
+                textStyle: Theme.of(context).textTheme.titleLarge!.copyWith(fontSize: 20, color: Theme.of(context).colorScheme.onBackground, fontWeight: FontWeight.w500),
               ),
             ),
           ),
@@ -1178,7 +1177,7 @@ class _EndUserFacilityAppointmentDetailsState extends State<EndUserFacilityAppoi
                                   color: paymentTransaction[index].status == 'A'
                                       ? Theme.of(context).extension<CustomColors>()!.greenAmount
                                       : paymentTransaction[index].status == 'P'
-                                          ? Colors.yellow
+                                          ? Theme.of(context).extension<CustomColors>()!.yellowStatus
                                           : Theme.of(context).extension<CustomColors>()!.redAmount,
                                   fontWeight: FontWeight.w500),
                               overflow: TextOverflow.ellipsis,
@@ -1377,7 +1376,7 @@ class _EndUserFacilityAppointmentDetailsState extends State<EndUserFacilityAppoi
                 //                   color: paymentTransaction[index].status == 'A'
                 //                       ? Theme.of(context).extension<CustomColors>()!.greenAmount
                 //                       : paymentTransaction[index].status == 'P'
-                //                           ? Colors.yellow
+                //                           ? Theme.of(context).extension<CustomColors>()!.yellowStatus
                 //                           : Theme.of(context).extension<CustomColors>()!.redAmount,
                 //                   fontWeight: FontWeight.w500),
                 //               overflow: TextOverflow.ellipsis,

--- a/lib/screens/appointment/FacilityEndUserCancelAppointment.dart
+++ b/lib/screens/appointment/FacilityEndUserCancelAppointment.dart
@@ -11,7 +11,6 @@ import 'package:oqdo_mobile_app/model/CancelFacilityAppointmentModel.dart';
 import 'package:oqdo_mobile_app/model/end_user_appointment_model_details.dart';
 import 'package:oqdo_mobile_app/model/facility_appointment_details_model.dart';
 import 'package:oqdo_mobile_app/oqdo_application.dart';
-import 'package:oqdo_mobile_app/theme/oqdo_theme_data.dart';
 import 'package:oqdo_mobile_app/utils/constants.dart';
 import 'package:oqdo_mobile_app/utils/custom_text_view.dart';
 import 'package:oqdo_mobile_app/utils/network_interceptor.dart';
@@ -85,7 +84,7 @@ class _FacilityEndUserCancelAppointmentState extends State<FacilityEndUserCancel
                                   textStyle: Theme.of(context)
                                       .textTheme
                                       .titleLarge!
-                                      .copyWith(fontSize: 20, color: OQDOThemeData.greyColor, fontWeight: FontWeight.w500),
+                                      .copyWith(fontSize: 20, color: Theme.of(context).colorScheme.onSurface, fontWeight: FontWeight.w500),
                                 ),
                               ),
                               const SizedBox(
@@ -98,7 +97,7 @@ class _FacilityEndUserCancelAppointmentState extends State<FacilityEndUserCancel
                                   textStyle: Theme.of(context)
                                       .textTheme
                                       .titleLarge!
-                                      .copyWith(fontSize: 16, color: OQDOThemeData.greyColor, fontWeight: FontWeight.w500),
+                                      .copyWith(fontSize: 16, color: Theme.of(context).colorScheme.onSurface, fontWeight: FontWeight.w500),
                                 ),
                               ),
                               const SizedBox(
@@ -114,7 +113,7 @@ class _FacilityEndUserCancelAppointmentState extends State<FacilityEndUserCancel
                                       textStyle: Theme.of(context)
                                           .textTheme
                                           .titleSmall!
-                                          .copyWith(color: OQDOThemeData.otherTextColor, fontWeight: FontWeight.w600, fontSize: 12.0),
+                                          .copyWith(color: Theme.of(context).extension<CustomColors>()!.greyText, fontWeight: FontWeight.w600, fontSize: 12.0),
                                     ),
                                   ],
                                 ),
@@ -129,7 +128,7 @@ class _FacilityEndUserCancelAppointmentState extends State<FacilityEndUserCancel
                                   textStyle: Theme.of(context)
                                       .textTheme
                                       .titleMedium!
-                                      .copyWith(fontSize: 14, color: const Color(0xFF818181), fontWeight: FontWeight.w400),
+                                      .copyWith(fontSize: 14, color: Theme.of(context).extension<CustomColors>()!.greyText, fontWeight: FontWeight.w400),
                                 ),
                               ),
                               const SizedBox(
@@ -142,7 +141,7 @@ class _FacilityEndUserCancelAppointmentState extends State<FacilityEndUserCancel
                                   textStyle: Theme.of(context)
                                       .textTheme
                                       .titleMedium!
-                                      .copyWith(fontSize: 14, color: const Color(0xFF818181), fontWeight: FontWeight.w400),
+                                      .copyWith(fontSize: 14, color: Theme.of(context).extension<CustomColors>()!.greyText, fontWeight: FontWeight.w400),
                                 ),
                               ),
                               const SizedBox(
@@ -155,7 +154,7 @@ class _FacilityEndUserCancelAppointmentState extends State<FacilityEndUserCancel
                                   textStyle: Theme.of(context)
                                       .textTheme
                                       .titleMedium!
-                                      .copyWith(fontSize: 14, color: const Color(0xFF818181), fontWeight: FontWeight.w400),
+                                      .copyWith(fontSize: 14, color: Theme.of(context).extension<CustomColors>()!.greyText, fontWeight: FontWeight.w400),
                                 ),
                               ),
                               const SizedBox(
@@ -168,7 +167,7 @@ class _FacilityEndUserCancelAppointmentState extends State<FacilityEndUserCancel
                                   textStyle: Theme.of(context)
                                       .textTheme
                                       .titleMedium!
-                                      .copyWith(fontSize: 14, color: const Color(0xFF818181), fontWeight: FontWeight.w400),
+                                      .copyWith(fontSize: 14, color: Theme.of(context).extension<CustomColors>()!.greyText, fontWeight: FontWeight.w400),
                                 ),
                               ),
                               const SizedBox(
@@ -181,7 +180,7 @@ class _FacilityEndUserCancelAppointmentState extends State<FacilityEndUserCancel
                                   textStyle: Theme.of(context)
                                       .textTheme
                                       .titleMedium!
-                                      .copyWith(fontSize: 14, color: const Color(0xFF818181), fontWeight: FontWeight.w400),
+                                      .copyWith(fontSize: 14, color: Theme.of(context).extension<CustomColors>()!.greyText, fontWeight: FontWeight.w400),
                                 ),
                               ),
                               const SizedBox(
@@ -196,7 +195,7 @@ class _FacilityEndUserCancelAppointmentState extends State<FacilityEndUserCancel
                                   textStyle: Theme.of(context)
                                       .textTheme
                                       .titleMedium!
-                                      .copyWith(fontSize: 14, color: const Color(0xFF818181), fontWeight: FontWeight.w400),
+                                      .copyWith(fontSize: 14, color: Theme.of(context).extension<CustomColors>()!.greyText, fontWeight: FontWeight.w400),
                                 ),
                               ),
                               const SizedBox(
@@ -204,7 +203,7 @@ class _FacilityEndUserCancelAppointmentState extends State<FacilityEndUserCancel
                               ),
                               const Divider(
                                 height: 1,
-                                color: Color(0xFFCACACA),
+                                color: Theme.of(context).colorScheme.outline,
                               ),
                               const SizedBox(
                                 height: 20.0,
@@ -228,14 +227,14 @@ class _FacilityEndUserCancelAppointmentState extends State<FacilityEndUserCancel
                                       textStyle: Theme.of(context)
                                           .textTheme
                                           .titleMedium!
-                                          .copyWith(fontSize: 16.0, fontWeight: FontWeight.w500, color: OQDOThemeData.greyColor),
+                                          .copyWith(fontSize: 16.0, fontWeight: FontWeight.w500, color: Theme.of(context).colorScheme.onSurface),
                                     ),
                                     CustomTextView(
                                       label: 'S\$ ${totalRefundAmount.toStringAsFixed(2)}',
                                       textStyle: Theme.of(context)
                                           .textTheme
                                           .titleMedium!
-                                          .copyWith(fontSize: 16.0, fontWeight: FontWeight.w400, color: OQDOThemeData.greyColor),
+                                          .copyWith(fontSize: 16.0, fontWeight: FontWeight.w400, color: Theme.of(context).colorScheme.onSurface),
                                     )
                                   ],
                                 ),
@@ -243,7 +242,7 @@ class _FacilityEndUserCancelAppointmentState extends State<FacilityEndUserCancel
                               const SizedBox(height: 15.0),
                               const Divider(
                                 height: 1,
-                                color: OQDOThemeData.greyColor,
+                                color: Theme.of(context).colorScheme.onSurface,
                               ),
                               const SizedBox(height: 15.0),
                               Padding(
@@ -256,14 +255,14 @@ class _FacilityEndUserCancelAppointmentState extends State<FacilityEndUserCancel
                                       textStyle: Theme.of(context)
                                           .textTheme
                                           .titleMedium!
-                                          .copyWith(fontSize: 16.0, fontWeight: FontWeight.w500, color: OQDOThemeData.blackColor),
+                                          .copyWith(fontSize: 16.0, fontWeight: FontWeight.w500, color: Theme.of(context).colorScheme.onBackground),
                                     ),
                                     CustomTextView(
                                       label: 'S\$ ${totalDiscountAmount.toStringAsFixed(2)}',
                                       textStyle: Theme.of(context)
                                           .textTheme
                                           .titleMedium!
-                                          .copyWith(fontSize: 16.0, fontWeight: FontWeight.w500, color: OQDOThemeData.blackColor),
+                                          .copyWith(fontSize: 16.0, fontWeight: FontWeight.w500, color: Theme.of(context).colorScheme.onBackground),
                                     )
                                   ],
                                 ),
@@ -271,7 +270,7 @@ class _FacilityEndUserCancelAppointmentState extends State<FacilityEndUserCancel
                               const SizedBox(height: 15.0),
                               const Divider(
                                 height: 1,
-                                color: OQDOThemeData.greyColor,
+                                color: Theme.of(context).colorScheme.onSurface,
                               ),
                               const SizedBox(height: 20.0),
                               Padding(
@@ -297,7 +296,7 @@ class _FacilityEndUserCancelAppointmentState extends State<FacilityEndUserCancel
                                       textStyle: Theme.of(context)
                                           .textTheme
                                           .titleSmall!
-                                          .copyWith(fontSize: 16.0, fontWeight: FontWeight.w400, color: OQDOThemeData.greyColor),
+                                          .copyWith(fontSize: 16.0, fontWeight: FontWeight.w400, color: Theme.of(context).colorScheme.onSurface),
                                     ),
                                   ],
                                 ),
@@ -392,7 +391,7 @@ class _FacilityEndUserCancelAppointmentState extends State<FacilityEndUserCancel
                         label:
                             '${convertDateToString(bookingSlotList[index].bookingDate!).split(',')[1].split(' ')[2]} ${convertDateToString(bookingSlotList[index].bookingDate!).split(',')[1].split(' ')[1]} - ${convertDateToString(bookingSlotList[index].bookingDate!).split(',')[0]}',
                         textStyle:
-                            Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 18.0, fontWeight: FontWeight.w500, color: OQDOThemeData.greyColor),
+                            Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 18.0, fontWeight: FontWeight.w500, color: Theme.of(context).colorScheme.onSurface),
                       ),
                       const SizedBox(
                         height: 5.0,
@@ -404,7 +403,7 @@ class _FacilityEndUserCancelAppointmentState extends State<FacilityEndUserCancel
                           CustomTextView(
                             label: '${bookingSlotList[index].startTime} - ${bookingSlotList[index].endTime}',
                             textStyle:
-                                Theme.of(context).textTheme.titleSmall!.copyWith(fontSize: 12.0, fontWeight: FontWeight.w400, color: OQDOThemeData.greyColor),
+                                Theme.of(context).textTheme.titleSmall!.copyWith(fontSize: 12.0, fontWeight: FontWeight.w400, color: Theme.of(context).colorScheme.onSurface),
                           ),
                           const SizedBox(
                             width: 15,
@@ -412,7 +411,7 @@ class _FacilityEndUserCancelAppointmentState extends State<FacilityEndUserCancel
                           CustomTextView(
                             label: 'S\$ ${bookingSlotList[index].ratePerHour?.toStringAsFixed(2) ?? 0.00}/hour',
                             textStyle:
-                                Theme.of(context).textTheme.titleSmall!.copyWith(fontSize: 12.0, fontWeight: FontWeight.w400, color: OQDOThemeData.greyColor),
+                                Theme.of(context).textTheme.titleSmall!.copyWith(fontSize: 12.0, fontWeight: FontWeight.w400, color: Theme.of(context).colorScheme.onSurface),
                           ),
                         ],
                       ),
@@ -428,11 +427,11 @@ class _FacilityEndUserCancelAppointmentState extends State<FacilityEndUserCancel
               children: [
                 CustomTextView(
                   label: 'Refund Amount: ',
-                  textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 10.0, fontWeight: FontWeight.w500, color: OQDOThemeData.greyColor),
+                  textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 10.0, fontWeight: FontWeight.w500, color: Theme.of(context).colorScheme.onSurface),
                 ),
                 CustomTextView(
                   label: 'S\$ ${bookingSlotList[index].amount?.toStringAsFixed(2) ?? 0.00}',
-                  textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 12.0, fontWeight: FontWeight.w500, color: OQDOThemeData.buttonColor),
+                  textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 12.0, fontWeight: FontWeight.w500, color: Theme.of(context).colorScheme.primary),
                 ),
               ],
             ),

--- a/lib/screens/appointment/appointment_view_order_screen.dart
+++ b/lib/screens/appointment/appointment_view_order_screen.dart
@@ -17,7 +17,6 @@ import 'package:oqdo_mobile_app/viewmodels/appointment_view_model.dart';
 import 'package:progress_dialog_null_safe/progress_dialog_null_safe.dart';
 import 'package:provider/provider.dart';
 
-import '../../theme/oqdo_theme_data.dart';
 import '../../utils/custom_text_view.dart';
 import '../../utils/textfields_widget.dart';
 
@@ -61,7 +60,7 @@ class _EndUserCoachAppointmentDetailsScreenState extends State<EndUserCoachAppoi
         child: Container(
           width: MediaQuery.of(context).size.width,
           height: MediaQuery.of(context).size.height,
-          color: OQDOThemeData.whiteColor,
+          color: Theme.of(context).extension<CustomColors>()!.white,
           child: coachAppointmentDetailResponseModel != null
               ? SingleChildScrollView(
                   child: Column(
@@ -122,7 +121,7 @@ class _EndUserCoachAppointmentDetailsScreenState extends State<EndUserCoachAppoi
                         child: CustomTextView(
                           label: 'Name: ${coachAppointmentDetailResponseModel!.coachFirstName} ${coachAppointmentDetailResponseModel!.coachLastName}',
                           textStyle:
-                              Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 14, color: const Color(0xFF818181), fontWeight: FontWeight.w400),
+                              Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 14, color: Theme.of(context).extension<CustomColors>()!.greyText, fontWeight: FontWeight.w400),
                         ),
                       ),
                       const SizedBox(
@@ -133,7 +132,7 @@ class _EndUserCoachAppointmentDetailsScreenState extends State<EndUserCoachAppoi
                         child: CustomTextView(
                           label: 'Email ID: ${coachAppointmentDetailResponseModel!.coachEmail}',
                           textStyle:
-                              Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 14, color: const Color(0xFF818181), fontWeight: FontWeight.w400),
+                              Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 14, color: Theme.of(context).extension<CustomColors>()!.greyText, fontWeight: FontWeight.w400),
                         ),
                       ),
                       const SizedBox(
@@ -144,7 +143,7 @@ class _EndUserCoachAppointmentDetailsScreenState extends State<EndUserCoachAppoi
                         child: CustomTextView(
                           label: 'Phone number: ${coachAppointmentDetailResponseModel!.coachMobileNumber}',
                           textStyle:
-                              Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 14, color: const Color(0xFF818181), fontWeight: FontWeight.w400),
+                              Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 14, color: Theme.of(context).extension<CustomColors>()!.greyText, fontWeight: FontWeight.w400),
                         ),
                       ),
                       const SizedBox(
@@ -155,7 +154,7 @@ class _EndUserCoachAppointmentDetailsScreenState extends State<EndUserCoachAppoi
                         child: CustomTextView(
                           label: coachAppointmentDetailResponseModel!.bookingType == 'I' ? 'Booking For: Individual' : 'Booking For: Group',
                           textStyle:
-                              Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 14, color: const Color(0xFF818181), fontWeight: FontWeight.w400),
+                              Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 14, color: Theme.of(context).extension<CustomColors>()!.greyText, fontWeight: FontWeight.w400),
                         ),
                       ),
                       const SizedBox(
@@ -168,7 +167,7 @@ class _EndUserCoachAppointmentDetailsScreenState extends State<EndUserCoachAppoi
                           maxLine: 3,
                           textOverFlow: TextOverflow.ellipsis,
                           textStyle:
-                              Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 14, color: const Color(0xFF818181), fontWeight: FontWeight.w400),
+                              Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 14, color: Theme.of(context).extension<CustomColors>()!.greyText, fontWeight: FontWeight.w400),
                         ),
                       ),
                       const SizedBox(
@@ -179,7 +178,7 @@ class _EndUserCoachAppointmentDetailsScreenState extends State<EndUserCoachAppoi
                         child: CustomTextView(
                           label: 'Order ID: ${coachAppointmentDetailResponseModel!.bookingNo}',
                           textStyle:
-                              Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 14, color: const Color(0xFF818181), fontWeight: FontWeight.w400),
+                              Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 14, color: Theme.of(context).extension<CustomColors>()!.greyText, fontWeight: FontWeight.w400),
                         ),
                       ),
                       const SizedBox(
@@ -221,11 +220,11 @@ class _EndUserCoachAppointmentDetailsScreenState extends State<EndUserCoachAppoi
         //   children: [
         //     CustomTextView(
         //       label: 'Total Amount',
-        //       textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(fontWeight: FontWeight.w600, color: OQDOThemeData.greyColor, fontSize: 18.0),
+        //       textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(fontWeight: FontWeight.w600, color: Theme.of(context).colorScheme.onSurface, fontSize: 18.0),
         //     ),
         //     CustomTextView(
         //       label: 'S\$ ${coachAppointmentDetailResponseModel!.totalAmt}',
-        //       textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(fontWeight: FontWeight.w400, color: OQDOThemeData.greyColor, fontSize: 18.0),
+        //       textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(fontWeight: FontWeight.w400, color: Theme.of(context).colorScheme.onSurface, fontSize: 18.0),
         //     ),
         //   ],
         // ),
@@ -234,7 +233,7 @@ class _EndUserCoachAppointmentDetailsScreenState extends State<EndUserCoachAppoi
         // ),
         // CustomTextView(
         //   label: 'Order ID: ${coachAppointmentDetailResponseModel!.bookingNo}',
-        //   textStyle: Theme.of(context).textTheme.bodySmall!.copyWith(fontWeight: FontWeight.w500, color: OQDOThemeData.greyColor, fontSize: 15.0),
+        //   textStyle: Theme.of(context).textTheme.bodySmall!.copyWith(fontWeight: FontWeight.w500, color: Theme.of(context).colorScheme.onSurface, fontSize: 15.0),
         // ),
         const SizedBox(
           height: 25.0,
@@ -246,7 +245,7 @@ class _EndUserCoachAppointmentDetailsScreenState extends State<EndUserCoachAppoi
               children: [
                 CustomTextView(
                   label: 'Add Feedback',
-                  textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(fontWeight: FontWeight.w600, color: OQDOThemeData.greyColor, fontSize: 18.0),
+                  textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(fontWeight: FontWeight.w600, color: Theme.of(context).colorScheme.onSurface, fontSize: 18.0),
                 ),
                 const SizedBox(
                   height: 10,
@@ -263,7 +262,7 @@ class _EndUserCoachAppointmentDetailsScreenState extends State<EndUserCoachAppoi
                   itemPadding: const EdgeInsets.symmetric(horizontal: 2.0),
                   itemBuilder: (context, _) => const Icon(
                     Icons.star,
-                    color: Colors.amber,
+                    color: Theme.of(context).extension<CustomColors>()!.yellowStatus,
                     size: 15,
                   ),
                   onRatingUpdate: (rating) {
@@ -289,15 +288,15 @@ class _EndUserCoachAppointmentDetailsScreenState extends State<EndUserCoachAppoi
                 decoration: BoxDecoration(
                     borderRadius: const BorderRadius.only(
                         topLeft: Radius.circular(10), bottomLeft: Radius.circular(10), bottomRight: Radius.circular(10), topRight: Radius.circular(10)),
-                    border: Border.all(color: const Color(0xffF1F1F1)),
-                    color: const Color(0xffEFEFEF).withOpacity(0.5)),
+                    border: Border.all(color: Theme.of(context).extension<CustomColors>()!.buddiesCard),
+                    color: Theme.of(context).extension<CustomColors>()!.greyButton.withOpacity(0.5)),
                 child: Row(
                   mainAxisAlignment: MainAxisAlignment.center,
                   children: [
                     const Icon(
                       Icons.add,
                       size: 20,
-                      color: Color(0xFF006590),
+                      color: Theme.of(context).colorScheme.primary,
                     ),
                     const SizedBox(
                       width: 10,
@@ -305,7 +304,7 @@ class _EndUserCoachAppointmentDetailsScreenState extends State<EndUserCoachAppoi
                     CustomTextView(
                       label: 'Add Feedback',
                       type: styleSubTitle,
-                      textStyle: Theme.of(context).textTheme.titleSmall!.copyWith(color: const Color(0xFF006590), fontSize: 14.0, fontWeight: FontWeight.w500),
+                      textStyle: Theme.of(context).textTheme.titleSmall!.copyWith(color: Theme.of(context).colorScheme.primary, fontSize: 14.0, fontWeight: FontWeight.w500),
                     ),
                   ],
                 ),
@@ -407,7 +406,7 @@ class _EndUserCoachAppointmentDetailsScreenState extends State<EndUserCoachAppoi
                   CustomTextView(
                     label:
                         '${convertDateToString(bookingSlotList[index].bookingDate!).split(',')[1].split(' ')[2]} ${convertDateToString(bookingSlotList[index].bookingDate!).split(',')[1].split(' ')[1]} - ${convertDateToString(bookingSlotList[index].bookingDate!).split(',')[0]}',
-                    textStyle: Theme.of(context).textTheme.titleLarge!.copyWith(fontSize: 20.0, color: OQDOThemeData.greyColor, fontWeight: FontWeight.w500),
+                    textStyle: Theme.of(context).textTheme.titleLarge!.copyWith(fontSize: 20.0, color: Theme.of(context).colorScheme.onSurface, fontWeight: FontWeight.w500),
                   ),
                   const SizedBox(
                     height: 5.0,
@@ -418,7 +417,7 @@ class _EndUserCoachAppointmentDetailsScreenState extends State<EndUserCoachAppoi
                       CustomTextView(
                         label: '${bookingSlotList[index].startTime}-${bookingSlotList[index].endTime}',
                         textStyle:
-                            Theme.of(context).textTheme.titleLarge!.copyWith(fontSize: 16.0, color: OQDOThemeData.greyColor, fontWeight: FontWeight.w500),
+                            Theme.of(context).textTheme.titleLarge!.copyWith(fontSize: 16.0, color: Theme.of(context).colorScheme.onSurface, fontWeight: FontWeight.w500),
                       ),
                       const SizedBox(
                         width: 15,
@@ -426,7 +425,7 @@ class _EndUserCoachAppointmentDetailsScreenState extends State<EndUserCoachAppoi
                       CustomTextView(
                         label: 'S\$ ${bookingSlotList[index].ratePerHour?.toStringAsFixed(2) ?? 0.00}/hour',
                         textStyle:
-                            Theme.of(context).textTheme.titleLarge!.copyWith(fontSize: 16.0, color: OQDOThemeData.greyColor, fontWeight: FontWeight.w500),
+                            Theme.of(context).textTheme.titleLarge!.copyWith(fontSize: 16.0, color: Theme.of(context).colorScheme.onSurface, fontWeight: FontWeight.w500),
                       ),
                     ],
                   ),
@@ -441,7 +440,7 @@ class _EndUserCoachAppointmentDetailsScreenState extends State<EndUserCoachAppoi
                       ? CustomTextView(
                           label: 'Cancelled',
                           textStyle:
-                              Theme.of(context).textTheme.titleLarge!.copyWith(fontSize: 14.0, color: OQDOThemeData.errorColor, fontWeight: FontWeight.w500),
+                              Theme.of(context).textTheme.titleLarge!.copyWith(fontSize: 14.0, color: Theme.of(context).colorScheme.error, fontWeight: FontWeight.w500),
                         )
                       : const SizedBox(),
                   const SizedBox(
@@ -449,7 +448,7 @@ class _EndUserCoachAppointmentDetailsScreenState extends State<EndUserCoachAppoi
                   ),
                   CustomTextView(
                     label: 'S\$ ${bookingSlotList[index].amount?.toStringAsFixed(2) ?? 0.00}',
-                    textStyle: Theme.of(context).textTheme.titleLarge!.copyWith(fontSize: 20.0, color: OQDOThemeData.greyColor, fontWeight: FontWeight.w500),
+                    textStyle: Theme.of(context).textTheme.titleLarge!.copyWith(fontSize: 20.0, color: Theme.of(context).colorScheme.onSurface, fontWeight: FontWeight.w500),
                   ),
                 ],
               ),
@@ -457,7 +456,7 @@ class _EndUserCoachAppointmentDetailsScreenState extends State<EndUserCoachAppoi
           ),
           const Divider(
             thickness: 1.0,
-            color: Color(0xFFEFEFEF),
+            color: Theme.of(context).extension<CustomColors>()!.greyButton,
           ),
         ],
       ),
@@ -490,7 +489,7 @@ class _EndUserCoachAppointmentDetailsScreenState extends State<EndUserCoachAppoi
               Container(
                 decoration: BoxDecoration(
                   shape: BoxShape.rectangle,
-                  border: Border.all(width: 7.0, color: const Color.fromRGBO(0, 101, 144, 0.5)),
+                  border: Border.all(width: 7.0, color: Theme.of(context).colorScheme.primary.withOpacity(0.5)),
                 ),
               ),
               const SizedBox(width: 20.0),
@@ -532,14 +531,14 @@ class _EndUserCoachAppointmentDetailsScreenState extends State<EndUserCoachAppoi
                 children: [
                   CustomTextView(
                     label: coachAppointmentDetailResponseModel!.setupName,
-                    textStyle: Theme.of(context).textTheme.titleSmall!.copyWith(fontWeight: FontWeight.w500, fontSize: 18.0, color: OQDOThemeData.greyColor),
+                    textStyle: Theme.of(context).textTheme.titleSmall!.copyWith(fontWeight: FontWeight.w500, fontSize: 18.0, color: Theme.of(context).colorScheme.onSurface),
                   ),
                   const SizedBox(
                     height: 8,
                   ),
                   CustomTextView(
                     label: '${coachAppointmentDetailResponseModel!.activityName} - ${coachAppointmentDetailResponseModel!.subActivityName}',
-                    textStyle: Theme.of(context).textTheme.titleSmall!.copyWith(fontSize: 14.0, fontWeight: FontWeight.w400, color: OQDOThemeData.greyColor),
+                    textStyle: Theme.of(context).textTheme.titleSmall!.copyWith(fontSize: 14.0, fontWeight: FontWeight.w400, color: Theme.of(context).colorScheme.onSurface),
                   )
                 ],
               )
@@ -568,8 +567,8 @@ class _EndUserCoachAppointmentDetailsScreenState extends State<EndUserCoachAppoi
   Widget _paymentSummaryView() {
     return Container(
       decoration: BoxDecoration(
-        color: OQDOThemeData.whiteColor,
-        border: Border.all(color: OQDOThemeData.otherTextColor),
+        color: Theme.of(context).extension<CustomColors>()!.white,
+        border: Border.all(color: Theme.of(context).extension<CustomColors>()!.greyText),
       ),
       padding: const EdgeInsets.all(8.0),
       child: Column(
@@ -580,7 +579,7 @@ class _EndUserCoachAppointmentDetailsScreenState extends State<EndUserCoachAppoi
             textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(
                   fontSize: 16.0,
                   fontWeight: FontWeight.w600,
-                  color: OQDOThemeData.buttonColor,
+                  color: Theme.of(context).colorScheme.primary,
                 ),
           ),
           const SizedBox(
@@ -599,13 +598,13 @@ class _EndUserCoachAppointmentDetailsScreenState extends State<EndUserCoachAppoi
             children: [
               CustomTextView(
                 label: "Total Amount : ",
-                textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 16.0, fontWeight: FontWeight.w600, color: OQDOThemeData.blackColor),
+                textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 16.0, fontWeight: FontWeight.w600, color: Theme.of(context).colorScheme.onBackground),
               ),
               Column(
                 children: [
                   CustomTextView(
                     label: 'S\$ ${totalAmount.toStringAsFixed(2)}',
-                    textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 14.0, fontWeight: FontWeight.w600, color: OQDOThemeData.blackColor),
+                    textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 14.0, fontWeight: FontWeight.w600, color: Theme.of(context).colorScheme.onBackground),
                   ),
                 ],
               ),
@@ -615,7 +614,7 @@ class _EndUserCoachAppointmentDetailsScreenState extends State<EndUserCoachAppoi
             height: 10,
           ),
           const Divider(
-            color: OQDOThemeData.greyColor,
+            color: Theme.of(context).colorScheme.onSurface,
           ),
           const SizedBox(
             height: 10,
@@ -635,7 +634,7 @@ class _EndUserCoachAppointmentDetailsScreenState extends State<EndUserCoachAppoi
                           textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(
                               fontSize: 14.0,
                               fontWeight: FontWeight.w600,
-                              color: discountedAmount <= 0 ? OQDOThemeData.blackColor : Theme.of(context).colorScheme.secondaryContainer),
+                              color: discountedAmount <= 0 ? Theme.of(context).colorScheme.onBackground : Theme.of(context).colorScheme.secondaryContainer),
                         ),
                         const SizedBox(
                           height: 3,
@@ -644,7 +643,7 @@ class _EndUserCoachAppointmentDetailsScreenState extends State<EndUserCoachAppoi
                           label: 'Applied on booking fees (S\$ ${bookingAmount.toStringAsFixed(2)})',
                           maxLine: 2,
                           textStyle:
-                              Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 12.0, fontWeight: FontWeight.w500, color: OQDOThemeData.greyColor),
+                              Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 12.0, fontWeight: FontWeight.w500, color: Theme.of(context).colorScheme.onSurface),
                         ).visible(discountedAmount > 0),
                       ],
                     ),
@@ -662,7 +661,7 @@ class _EndUserCoachAppointmentDetailsScreenState extends State<EndUserCoachAppoi
                           textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(
                               fontSize: 13.0,
                               fontWeight: FontWeight.w600,
-                              color: discountedAmount <= 0 ? OQDOThemeData.blackColor : Theme.of(context).colorScheme.secondaryContainer),
+                              color: discountedAmount <= 0 ? Theme.of(context).colorScheme.onBackground : Theme.of(context).colorScheme.secondaryContainer),
                         ),
                       ],
                     ),
@@ -692,7 +691,7 @@ class _EndUserCoachAppointmentDetailsScreenState extends State<EndUserCoachAppoi
                 children: [
                   CustomTextView(
                     label: title,
-                    textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 14.0, fontWeight: FontWeight.w600, color: OQDOThemeData.blackColor),
+                    textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 14.0, fontWeight: FontWeight.w600, color: Theme.of(context).colorScheme.onBackground),
                   ),
                   const SizedBox(
                     height: 3,
@@ -700,7 +699,7 @@ class _EndUserCoachAppointmentDetailsScreenState extends State<EndUserCoachAppoi
                   CustomTextView(
                     label: details,
                     maxLine: 2,
-                    textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 12.0, fontWeight: FontWeight.w500, color: OQDOThemeData.greyColor),
+                    textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 12.0, fontWeight: FontWeight.w500, color: Theme.of(context).colorScheme.onSurface),
                   ),
                 ],
               ),
@@ -715,7 +714,7 @@ class _EndUserCoachAppointmentDetailsScreenState extends State<EndUserCoachAppoi
                     label: 'S\$ $rate',
                     maxLine: 2,
                     textOverFlow: TextOverflow.ellipsis,
-                    textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 13.0, fontWeight: FontWeight.w600, color: OQDOThemeData.blackColor),
+                    textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 13.0, fontWeight: FontWeight.w600, color: Theme.of(context).colorScheme.onBackground),
                   ),
                 ],
               ),
@@ -726,7 +725,7 @@ class _EndUserCoachAppointmentDetailsScreenState extends State<EndUserCoachAppoi
           height: 3,
         ),
         const Divider(
-          color: OQDOThemeData.greyColor,
+          color: Theme.of(context).colorScheme.onSurface,
         ),
       ],
     );
@@ -940,7 +939,7 @@ class _EndUserCoachAppointmentDetailsScreenState extends State<EndUserCoachAppoi
               padding: const EdgeInsets.only(left: 20.0),
               child: CustomTextView(
                 label: 'Transaction History',
-                textStyle: Theme.of(context).textTheme.titleLarge!.copyWith(fontSize: 20, color: OQDOThemeData.blackColor, fontWeight: FontWeight.w500),
+                textStyle: Theme.of(context).textTheme.titleLarge!.copyWith(fontSize: 20, color: Theme.of(context).colorScheme.onBackground, fontWeight: FontWeight.w500),
               ),
             ),
           ),
@@ -1150,7 +1149,7 @@ class _EndUserCoachAppointmentDetailsScreenState extends State<EndUserCoachAppoi
                                   color: paymentTransaction[index].status == 'A'
                                       ? Theme.of(context).extension<CustomColors>()!.greenAmount
                                       : paymentTransaction[index].status == 'P'
-                                          ? Colors.yellow
+                                          ? Theme.of(context).extension<CustomColors>()!.yellowStatus
                                           : Theme.of(context).extension<CustomColors>()!.redAmount,
                                   fontWeight: FontWeight.w500),
                               overflow: TextOverflow.ellipsis,

--- a/lib/screens/appointment/cancel_appointment_reason_screen.dart
+++ b/lib/screens/appointment/cancel_appointment_reason_screen.dart
@@ -1,10 +1,10 @@
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
+import 'package:oqdo_mobile_app/theme/custom_colors.dart';
 import 'package:oqdo_mobile_app/components/custom_app_bar.dart';
 
 import '../../components/my_button.dart';
 import '../../helper/helpers.dart';
-import '../../theme/oqdo_theme_data.dart';
 import '../../utils/constants.dart';
 import '../../utils/custom_text_view.dart';
 import '../../utils/textfields_widget.dart';
@@ -49,7 +49,7 @@ class _CancelAppointmentReasonScreenState extends State<CancelAppointmentReasonS
                   padding: const EdgeInsets.only(left: 20.0),
                   child: CustomTextView(
                     label: 'Indoor Basketball Court',
-                    textStyle: Theme.of(context).textTheme.titleLarge!.copyWith(fontSize: 20, color: OQDOThemeData.greyColor, fontWeight: FontWeight.w500),
+                    textStyle: Theme.of(context).textTheme.titleLarge!.copyWith(fontSize: 20, color: Theme.of(context).colorScheme.onSurface, fontWeight: FontWeight.w500),
                   ),
                 ),
                 const SizedBox(
@@ -62,7 +62,7 @@ class _CancelAppointmentReasonScreenState extends State<CancelAppointmentReasonS
                     textStyle: Theme.of(context)
                         .textTheme
                         .titleSmall!
-                        .copyWith(color: OQDOThemeData.otherTextColor, fontWeight: FontWeight.w600, decoration: TextDecoration.underline, fontSize: 12.0),
+                        .copyWith(color: Theme.of(context).extension<CustomColors>()!.greyText, fontWeight: FontWeight.w600, decoration: TextDecoration.underline, fontSize: 12.0),
                   ),
                 ),
                 const SizedBox(
@@ -72,7 +72,7 @@ class _CancelAppointmentReasonScreenState extends State<CancelAppointmentReasonS
                   padding: const EdgeInsets.only(left: 20.0, right: 20.0, bottom: 10.0),
                   child: CustomTextView(
                     label: 'Select Reason For Cancelling Appointment',
-                    textStyle: Theme.of(context).textTheme.titleLarge!.copyWith(fontSize: 18.0, color: OQDOThemeData.greyColor, fontWeight: FontWeight.w400),
+                    textStyle: Theme.of(context).textTheme.titleLarge!.copyWith(fontSize: 18.0, color: Theme.of(context).colorScheme.onSurface, fontWeight: FontWeight.w400),
                   ),
                 ),
                 ListView.builder(
@@ -135,7 +135,7 @@ class _CancelAppointmentReasonScreenState extends State<CancelAppointmentReasonS
         contentPadding: const EdgeInsets.symmetric(horizontal: 5.0, vertical: 0),
         title: CustomTextView(
           label: _cancelReasons[index],
-          textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 16.0, fontWeight: FontWeight.w400, color: OQDOThemeData.greyColor),
+          textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 16.0, fontWeight: FontWeight.w400, color: Theme.of(context).colorScheme.onSurface),
         ),
         value: _cancelReasons[index],
         groupValue: _selectedReason,
@@ -161,13 +161,13 @@ class _CancelAppointmentReasonScreenState extends State<CancelAppointmentReasonS
       builder: (BuildContext context) => CupertinoAlertDialog(
         title: CustomTextView(
           label: '',
-          textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(fontWeight: FontWeight.w400, fontSize: 18.0, color: OQDOThemeData.greyColor),
+          textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(fontWeight: FontWeight.w400, fontSize: 18.0, color: Theme.of(context).colorScheme.onSurface),
         ),
         content: Center(
           child: CustomTextView(
             label: 'Are You Sure You Want To Cancel Appointment?',
             maxLine: 2,
-            textStyle: Theme.of(context).textTheme.titleLarge!.copyWith(fontSize: 16.0, fontWeight: FontWeight.w600, color: OQDOThemeData.greyColor),
+            textStyle: Theme.of(context).textTheme.titleLarge!.copyWith(fontSize: 16.0, fontWeight: FontWeight.w600, color: Theme.of(context).colorScheme.onSurface),
           ),
         ),
         actions: [
@@ -178,7 +178,7 @@ class _CancelAppointmentReasonScreenState extends State<CancelAppointmentReasonS
             },
             child: CustomTextView(
               label: 'No',
-              textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 16.0, fontWeight: FontWeight.w400, color: OQDOThemeData.dialogActionColor),
+              textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 16.0, fontWeight: FontWeight.w400, color: Theme.of(context).colorScheme.primary),
             ),
           ),
           CupertinoDialogAction(
@@ -188,7 +188,7 @@ class _CancelAppointmentReasonScreenState extends State<CancelAppointmentReasonS
             },
             child: CustomTextView(
               label: 'Yes',
-              textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 16.0, fontWeight: FontWeight.w400, color: OQDOThemeData.dialogActionColor),
+              textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 16.0, fontWeight: FontWeight.w400, color: Theme.of(context).colorScheme.primary),
             ),
           )
         ],

--- a/lib/screens/appointment/cancel_coach_appointment_reason_screen.dart
+++ b/lib/screens/appointment/cancel_coach_appointment_reason_screen.dart
@@ -4,6 +4,7 @@ import 'dart:convert';
 
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
+import 'package:oqdo_mobile_app/theme/custom_colors.dart';
 import 'package:oqdo_mobile_app/components/custom_app_bar.dart';
 import 'package:oqdo_mobile_app/model/CancelCoachAppointmentModel.dart';
 import 'package:oqdo_mobile_app/model/cancel_reason_list_response_model.dart';
@@ -15,7 +16,6 @@ import 'package:progress_dialog_null_safe/progress_dialog_null_safe.dart';
 import 'package:provider/provider.dart';
 import '../../components/my_button.dart';
 import '../../helper/helpers.dart';
-import '../../theme/oqdo_theme_data.dart';
 import '../../utils/constants.dart';
 import '../../utils/custom_text_view.dart';
 import '../../utils/textfields_widget.dart';
@@ -70,7 +70,7 @@ class _CancelCoachAppointmentReasonScreenState extends State<CancelCoachAppointm
                                   label: '${widget.cancelCoachAppointmentModel!.coachAppointmentDetailResponseModel!.setupName} ',
                                   textStyle: Theme.of(context).textTheme.titleLarge!.copyWith(
                                         fontSize: 20,
-                                        color: OQDOThemeData.greyColor,
+                                        color: Theme.of(context).colorScheme.onSurface,
                                         fontWeight: FontWeight.w500,
                                       ),
                                 ),
@@ -83,7 +83,7 @@ class _CancelCoachAppointmentReasonScreenState extends State<CancelCoachAppointm
                                       '${widget.cancelCoachAppointmentModel!.coachAppointmentDetailResponseModel!.activityName} - ${widget.cancelCoachAppointmentModel!.coachAppointmentDetailResponseModel!.subActivityName}',
                                   textStyle: Theme.of(context).textTheme.titleLarge!.copyWith(
                                         fontSize: 20,
-                                        color: OQDOThemeData.greyColor,
+                                        color: Theme.of(context).colorScheme.onSurface,
                                         fontWeight: FontWeight.w500,
                                       ),
                                 ),
@@ -95,7 +95,7 @@ class _CancelCoachAppointmentReasonScreenState extends State<CancelCoachAppointm
                                   label: 'Select Reason For Cancelling Appointment',
                                   textStyle: Theme.of(context).textTheme.titleLarge!.copyWith(
                                         fontSize: 18.0,
-                                        color: OQDOThemeData.greyColor,
+                                        color: Theme.of(context).colorScheme.onSurface,
                                         fontWeight: FontWeight.w400,
                                       ),
                                 ),
@@ -163,7 +163,7 @@ class _CancelCoachAppointmentReasonScreenState extends State<CancelCoachAppointm
       contentPadding: const EdgeInsets.symmetric(horizontal: 5.0, vertical: 0),
       title: CustomTextView(
         label: model.cancelreason,
-        textStyle: Theme.of(context).textTheme.bodyMedium!.copyWith(fontSize: 18, fontWeight: FontWeight.w400, color: OQDOThemeData.greyColor),
+        textStyle: Theme.of(context).textTheme.bodyMedium!.copyWith(fontSize: 18, fontWeight: FontWeight.w400, color: Theme.of(context).colorScheme.onSurface),
       ),
       activeColor: Theme.of(context).colorScheme.primary,
       value: model.cancelReasonId.toString(),
@@ -191,13 +191,13 @@ class _CancelCoachAppointmentReasonScreenState extends State<CancelCoachAppointm
       builder: (BuildContext context) => CupertinoAlertDialog(
         title: CustomTextView(
           label: '',
-          textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(fontWeight: FontWeight.w400, fontSize: 18.0, color: OQDOThemeData.greyColor),
+          textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(fontWeight: FontWeight.w400, fontSize: 18.0, color: Theme.of(context).colorScheme.onSurface),
         ),
         content: Center(
           child: CustomTextView(
             label: 'Are you sure you want to\ncancel this appointment?',
             maxLine: 2,
-            textStyle: Theme.of(context).textTheme.titleLarge!.copyWith(fontSize: 16.0, fontWeight: FontWeight.w600, color: OQDOThemeData.greyColor),
+            textStyle: Theme.of(context).textTheme.titleLarge!.copyWith(fontSize: 16.0, fontWeight: FontWeight.w600, color: Theme.of(context).colorScheme.onSurface),
           ),
         ),
         actions: [
@@ -208,7 +208,7 @@ class _CancelCoachAppointmentReasonScreenState extends State<CancelCoachAppointm
             },
             child: CustomTextView(
               label: 'No',
-              textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 16.0, fontWeight: FontWeight.w400, color: OQDOThemeData.dialogActionColor),
+              textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 16.0, fontWeight: FontWeight.w400, color: Theme.of(context).colorScheme.primary),
             ),
           ),
           CupertinoDialogAction(
@@ -219,7 +219,7 @@ class _CancelCoachAppointmentReasonScreenState extends State<CancelCoachAppointm
             },
             child: CustomTextView(
               label: 'Yes',
-              textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 16.0, fontWeight: FontWeight.w400, color: OQDOThemeData.dialogActionColor),
+              textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 16.0, fontWeight: FontWeight.w400, color: Theme.of(context).colorScheme.primary),
             ),
           )
         ],

--- a/lib/screens/appointment/cancel_facility_appointment_reason_screen.dart
+++ b/lib/screens/appointment/cancel_facility_appointment_reason_screen.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
+import 'package:oqdo_mobile_app/theme/custom_colors.dart';
 import 'package:oqdo_mobile_app/components/custom_app_bar.dart';
 import 'package:oqdo_mobile_app/model/CancelFacilityAppointmentModel.dart';
 import 'package:oqdo_mobile_app/model/cancel_reason_list_response_model.dart';
@@ -13,7 +14,6 @@ import 'package:progress_dialog_null_safe/progress_dialog_null_safe.dart';
 import 'package:provider/provider.dart';
 
 import '../../components/my_button.dart';
-import '../../theme/oqdo_theme_data.dart';
 import '../../utils/constants.dart';
 import '../../utils/custom_text_view.dart';
 import '../../utils/textfields_widget.dart';
@@ -70,7 +70,7 @@ class _CancelFacilityAppointmentReasonScreenState extends State<CancelFacilityAp
                                 label:
                                     '${widget.cancelFacilityAppointmentModel!.facilityAppointmentDetailModel!.facilitySetupTitle!.trim()} - ${widget.cancelFacilityAppointmentModel!.facilityAppointmentDetailModel!.facilitySetupSubTitle!.trim()}',
                                 textStyle:
-                                    Theme.of(context).textTheme.titleLarge!.copyWith(fontSize: 20, color: OQDOThemeData.greyColor, fontWeight: FontWeight.w500),
+                                    Theme.of(context).textTheme.titleLarge!.copyWith(fontSize: 20, color: Theme.of(context).colorScheme.onSurface, fontWeight: FontWeight.w500),
                               ),
                             ),
                             const SizedBox(
@@ -82,7 +82,7 @@ class _CancelFacilityAppointmentReasonScreenState extends State<CancelFacilityAp
                                 label:
                                     '${widget.cancelFacilityAppointmentModel!.facilityAppointmentDetailModel!.activityName} - ${widget.cancelFacilityAppointmentModel!.facilityAppointmentDetailModel!.subActivityName}',
                                 textStyle:
-                                    Theme.of(context).textTheme.titleLarge!.copyWith(fontSize: 17, color: OQDOThemeData.greyColor, fontWeight: FontWeight.w500),
+                                    Theme.of(context).textTheme.titleLarge!.copyWith(fontSize: 17, color: Theme.of(context).colorScheme.onSurface, fontWeight: FontWeight.w500),
                               ),
                             ),
                             const SizedBox(
@@ -95,7 +95,7 @@ class _CancelFacilityAppointmentReasonScreenState extends State<CancelFacilityAp
                                 textStyle: Theme.of(context)
                                     .textTheme
                                     .titleLarge!
-                                    .copyWith(fontSize: 18.0, color: OQDOThemeData.greyColor, fontWeight: FontWeight.w400),
+                                    .copyWith(fontSize: 18.0, color: Theme.of(context).colorScheme.onSurface, fontWeight: FontWeight.w400),
                               ),
                             ),
                             ListView.builder(
@@ -166,7 +166,7 @@ class _CancelFacilityAppointmentReasonScreenState extends State<CancelFacilityAp
       contentPadding: const EdgeInsets.symmetric(horizontal: 5.0, vertical: 0),
       title: CustomTextView(
         label: model.cancelreason,
-        textStyle: Theme.of(context).textTheme.bodyMedium!.copyWith(fontSize: 18, fontWeight: FontWeight.w400, color: OQDOThemeData.greyColor),
+        textStyle: Theme.of(context).textTheme.bodyMedium!.copyWith(fontSize: 18, fontWeight: FontWeight.w400, color: Theme.of(context).colorScheme.onSurface),
       ),
       activeColor: Theme.of(context).colorScheme.primary,
       value: model.cancelReasonId.toString(),
@@ -199,7 +199,7 @@ class _CancelFacilityAppointmentReasonScreenState extends State<CancelFacilityAp
     //     ),
     //     CustomTextView(
     //       label: model.cancelreason,
-    //       textStyle: Theme.of(context).textTheme.bodyMedium!.copyWith(fontSize: 15, fontWeight: FontWeight.w400, color: OQDOThemeData.greyColor),
+    //       textStyle: Theme.of(context).textTheme.bodyMedium!.copyWith(fontSize: 15, fontWeight: FontWeight.w400, color: Theme.of(context).colorScheme.onSurface),
     //     ),
     //   ],
     // );
@@ -219,13 +219,13 @@ class _CancelFacilityAppointmentReasonScreenState extends State<CancelFacilityAp
       builder: (BuildContext context) => CupertinoAlertDialog(
         title: CustomTextView(
           label: '',
-          textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(fontWeight: FontWeight.w400, fontSize: 18.0, color: OQDOThemeData.greyColor),
+          textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(fontWeight: FontWeight.w400, fontSize: 18.0, color: Theme.of(context).colorScheme.onSurface),
         ),
         content: Center(
           child: CustomTextView(
             label: 'Are you sure you want to\ncancel this appointment?',
             maxLine: 2,
-            textStyle: Theme.of(context).textTheme.titleLarge!.copyWith(fontSize: 16.0, fontWeight: FontWeight.w600, color: OQDOThemeData.greyColor),
+            textStyle: Theme.of(context).textTheme.titleLarge!.copyWith(fontSize: 16.0, fontWeight: FontWeight.w600, color: Theme.of(context).colorScheme.onSurface),
           ),
         ),
         actions: [
@@ -236,7 +236,7 @@ class _CancelFacilityAppointmentReasonScreenState extends State<CancelFacilityAp
             },
             child: CustomTextView(
               label: 'No',
-              textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 16.0, fontWeight: FontWeight.w400, color: OQDOThemeData.dialogActionColor),
+              textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 16.0, fontWeight: FontWeight.w400, color: Theme.of(context).colorScheme.primary),
             ),
           ),
           CupertinoDialogAction(
@@ -247,7 +247,7 @@ class _CancelFacilityAppointmentReasonScreenState extends State<CancelFacilityAp
             },
             child: CustomTextView(
               label: 'Yes',
-              textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 16.0, fontWeight: FontWeight.w400, color: OQDOThemeData.dialogActionColor),
+              textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 16.0, fontWeight: FontWeight.w400, color: Theme.of(context).colorScheme.primary),
             ),
           )
         ],

--- a/lib/screens/appointment/coach_appointment_screen.dart
+++ b/lib/screens/appointment/coach_appointment_screen.dart
@@ -3,12 +3,12 @@
 import 'dart:convert';
 
 import 'package:flutter/material.dart';
+import 'package:oqdo_mobile_app/theme/custom_colors.dart';
 import 'package:intl/intl.dart';
 import 'package:oqdo_mobile_app/components/custom_app_bar.dart';
 import 'package:oqdo_mobile_app/components/my_button.dart';
 import 'package:oqdo_mobile_app/model/coach_appointments_response_model.dart';
 import 'package:oqdo_mobile_app/oqdo_application.dart';
-import 'package:oqdo_mobile_app/theme/oqdo_theme_data.dart';
 import 'package:oqdo_mobile_app/utils/constants.dart';
 import 'package:oqdo_mobile_app/utils/custom_text_view.dart';
 import 'package:oqdo_mobile_app/utils/network_interceptor.dart';
@@ -90,7 +90,7 @@ class _CoachAppointmentsScreenState extends State<CoachAppointmentsScreen> {
           }),
       body: SafeArea(
         child: Container(
-          color: OQDOThemeData.whiteColor,
+          color: Theme.of(context).extension<CustomColors>()!.white,
           width: MediaQuery.of(context).size.width,
           height: double.infinity,
           child: _endUserAppointmentResponseList.isNotEmpty
@@ -122,15 +122,15 @@ class _CoachAppointmentsScreenState extends State<CoachAppointmentsScreen> {
                                 child: Container(
                                   padding: const EdgeInsets.all(8),
                                   decoration: BoxDecoration(
-                                      color: const Color(0xFF006590),
-                                      border: Border.all(color: OQDOThemeData.dividerColor),
+                                      color: Theme.of(context).colorScheme.primary,
+                                      border: Border.all(color: Theme.of(context).colorScheme.primary),
                                       borderRadius: const BorderRadius.all(Radius.circular(10))),
                                   child: CustomTextView(
                                     label: _endUserAppointmentResponseList[index].date!.split('T')[0],
                                     textStyle: Theme.of(context)
                                         .textTheme
                                         .bodyMedium!
-                                        .copyWith(color: OQDOThemeData.whiteColor, fontSize: 18, fontWeight: FontWeight.w500),
+                                        .copyWith(color: Theme.of(context).extension<CustomColors>()!.white, fontSize: 18, fontWeight: FontWeight.w500),
                                   ),
                                 ),
                               ),
@@ -166,7 +166,7 @@ class _CoachAppointmentsScreenState extends State<CoachAppointmentsScreen> {
                                               Container(
                                                 decoration: BoxDecoration(
                                                   shape: BoxShape.rectangle,
-                                                  border: Border.all(width: 7.0, color: const Color.fromRGBO(0, 101, 144, 0.5)),
+                                                  border: Border.all(width: 7.0, color: Theme.of(context).colorScheme.primary.withOpacity(0.5)),
                                                 ),
                                               ),
                                               const SizedBox(width: 20.0),
@@ -175,7 +175,7 @@ class _CoachAppointmentsScreenState extends State<CoachAppointmentsScreen> {
                                                 textStyle: Theme.of(context)
                                                     .textTheme
                                                     .titleLarge!
-                                                    .copyWith(fontWeight: FontWeight.w500, fontSize: 20.0, color: OQDOThemeData.greyColor),
+                                                    .copyWith(fontWeight: FontWeight.w500, fontSize: 20.0, color: Theme.of(context).colorScheme.onSurface),
                                               ),
                                             ],
                                           ),
@@ -217,7 +217,7 @@ class _CoachAppointmentsScreenState extends State<CoachAppointmentsScreen> {
                   Container(
                     decoration: BoxDecoration(
                       shape: BoxShape.rectangle,
-                      border: Border.all(width: 7.0, color: const Color.fromRGBO(0, 101, 144, 0.5)),
+                      border: Border.all(width: 7.0, color: Theme.of(context).colorScheme.primary.withOpacity(0.5)),
                     ),
                   ),
                   const SizedBox(width: 20.0),
@@ -261,7 +261,7 @@ class _CoachAppointmentsScreenState extends State<CoachAppointmentsScreen> {
                         CustomTextView(
                           label: data[index].endUserName,
                           textStyle:
-                              Theme.of(context).textTheme.titleSmall!.copyWith(fontWeight: FontWeight.w500, fontSize: 18.0, color: OQDOThemeData.greyColor),
+                              Theme.of(context).textTheme.titleSmall!.copyWith(fontWeight: FontWeight.w500, fontSize: 18.0, color: Theme.of(context).colorScheme.onSurface),
                         ),
                         const SizedBox(
                           height: 5,
@@ -269,7 +269,7 @@ class _CoachAppointmentsScreenState extends State<CoachAppointmentsScreen> {
                         CustomTextView(
                           label: data[index].setupName,
                           textStyle:
-                              Theme.of(context).textTheme.titleSmall!.copyWith(fontWeight: FontWeight.w500, fontSize: 16.0, color: OQDOThemeData.greyColor),
+                              Theme.of(context).textTheme.titleSmall!.copyWith(fontWeight: FontWeight.w500, fontSize: 16.0, color: Theme.of(context).colorScheme.onSurface),
                         ),
                         const SizedBox(
                           height: 8.0,
@@ -279,7 +279,7 @@ class _CoachAppointmentsScreenState extends State<CoachAppointmentsScreen> {
                             CustomTextView(
                               label: '${data[index].startTime} - ${data[index].endTime}',
                               textStyle:
-                                  Theme.of(context).textTheme.titleSmall!.copyWith(fontSize: 14.0, fontWeight: FontWeight.w400, color: OQDOThemeData.greyColor),
+                                  Theme.of(context).textTheme.titleSmall!.copyWith(fontSize: 14.0, fontWeight: FontWeight.w400, color: Theme.of(context).colorScheme.onSurface),
                             ),
                             const SizedBox(
                               width: 15,
@@ -287,7 +287,7 @@ class _CoachAppointmentsScreenState extends State<CoachAppointmentsScreen> {
                             CustomTextView(
                               label: 'S\$ ${data[index].ratePerHour?.toStringAsFixed(2) ?? 0}/hour',
                               textStyle:
-                                  Theme.of(context).textTheme.titleSmall!.copyWith(fontSize: 14.0, fontWeight: FontWeight.w400, color: OQDOThemeData.greyColor),
+                                  Theme.of(context).textTheme.titleSmall!.copyWith(fontSize: 14.0, fontWeight: FontWeight.w400, color: Theme.of(context).colorScheme.onSurface),
                             ),
                           ],
                         ),
@@ -304,7 +304,7 @@ class _CoachAppointmentsScreenState extends State<CoachAppointmentsScreen> {
                                 textStyle: Theme.of(context)
                                     .textTheme
                                     .titleSmall!
-                                    .copyWith(fontSize: 14.0, fontWeight: FontWeight.w700, color: OQDOThemeData.errorColor)),
+                                    .copyWith(fontSize: 14.0, fontWeight: FontWeight.w700, color: Theme.of(context).colorScheme.error)),
                           ),
                         )
                       : const SizedBox(),
@@ -328,7 +328,7 @@ class _CoachAppointmentsScreenState extends State<CoachAppointmentsScreen> {
         children: [
           CustomTextView(
             label: monthStr,
-            textStyle: Theme.of(context).textTheme.titleLarge!.copyWith(fontSize: 20, fontWeight: FontWeight.w500, color: const Color(0xFF333333)),
+            textStyle: Theme.of(context).textTheme.titleLarge!.copyWith(fontSize: 20, fontWeight: FontWeight.w500, color: Theme.of(context).colorScheme.onSurface),
           ),
           const Spacer(),
           GestureDetector(
@@ -381,13 +381,13 @@ class _CoachAppointmentsScreenState extends State<CoachAppointmentsScreen> {
             headerVisible: false,
             daysOfWeekVisible: true,
             daysOfWeekStyle: const DaysOfWeekStyle(
-                weekdayStyle: TextStyle(color: Color(0xFF006590), fontWeight: FontWeight.w500),
-                weekendStyle: TextStyle(color: Color(0xFF006590), fontWeight: FontWeight.w500)),
+                weekdayStyle: TextStyle(color: Theme.of(context).colorScheme.primary, fontWeight: FontWeight.w500),
+                weekendStyle: TextStyle(color: Theme.of(context).colorScheme.primary, fontWeight: FontWeight.w500)),
             calendarStyle: CalendarStyle(
               isTodayHighlighted: false,
               outsideDaysVisible: false,
               selectedDecoration: BoxDecoration(color: Theme.of(context).colorScheme.primary, shape: BoxShape.circle),
-              defaultTextStyle: const TextStyle(fontSize: 15, fontWeight: FontWeight.w400, color: Colors.black),
+              defaultTextStyle: const TextStyle(fontSize: 15, fontWeight: FontWeight.w400, color: Theme.of(context).colorScheme.onBackground),
             ),
             onDaySelected: _onDaySelected,
             selectedDayPredicate: (DateTime date) {
@@ -568,7 +568,7 @@ class _CoachAppointmentsScreenState extends State<CoachAppointmentsScreen> {
     }
 
     return Container(
-      color: OQDOThemeData.whiteColor,
+      color: Theme.of(context).extension<CustomColors>()!.white,
       width: MediaQuery.of(context).size.width,
       height: MediaQuery.of(context).size.height / 1.2,
       child: SingleChildScrollView(
@@ -585,14 +585,14 @@ class _CoachAppointmentsScreenState extends State<CoachAppointmentsScreen> {
             ),
             CustomTextView(
               label: '${_currentDay.split("-")[0]} ${_currentDay.split('-')[1]} ${_currentDay.split('-')[2]}',
-              textStyle: Theme.of(context).textTheme.titleLarge!.copyWith(fontSize: 21, color: const Color(0xFF333333), fontWeight: FontWeight.w500),
+              textStyle: Theme.of(context).textTheme.titleLarge!.copyWith(fontSize: 21, color: Theme.of(context).colorScheme.onSurface, fontWeight: FontWeight.w500),
             ),
             const SizedBox(
               height: 3,
             ),
             CustomTextView(
               label: initSelectedDate,
-              textStyle: Theme.of(context).textTheme.titleLarge!.copyWith(fontSize: 21, color: const Color(0xFF333333), fontWeight: FontWeight.w500),
+              textStyle: Theme.of(context).textTheme.titleLarge!.copyWith(fontSize: 21, color: Theme.of(context).colorScheme.onSurface, fontWeight: FontWeight.w500),
             ),
             Padding(
               padding: const EdgeInsets.only(top: 40, left: 25, right: 25),
@@ -605,13 +605,13 @@ class _CoachAppointmentsScreenState extends State<CoachAppointmentsScreen> {
                 daysOfWeekVisible: true,
                 currentDay: kToday,
                 daysOfWeekStyle: const DaysOfWeekStyle(
-                    weekdayStyle: TextStyle(color: Color(0xFF006590), fontWeight: FontWeight.w500),
-                    weekendStyle: TextStyle(color: Color(0xFF006590), fontWeight: FontWeight.w500)),
+                    weekdayStyle: TextStyle(color: Theme.of(context).colorScheme.primary, fontWeight: FontWeight.w500),
+                    weekendStyle: TextStyle(color: Theme.of(context).colorScheme.primary, fontWeight: FontWeight.w500)),
                 calendarStyle: CalendarStyle(
                   isTodayHighlighted: true,
                   outsideDaysVisible: false,
                   selectedDecoration: BoxDecoration(color: Theme.of(context).colorScheme.primary, shape: BoxShape.circle),
-                  defaultTextStyle: const TextStyle(fontSize: 15, fontWeight: FontWeight.w400, color: Colors.black),
+                  defaultTextStyle: const TextStyle(fontSize: 15, fontWeight: FontWeight.w400, color: Theme.of(context).colorScheme.onBackground),
                 ),
                 onCalendarCreated: (controller) {
                   _pageController = controller;
@@ -668,14 +668,14 @@ class _CoachAppointmentsScreenState extends State<CoachAppointmentsScreen> {
             children: [
               CustomTextView(
                 label: headerText.split(' ')[0],
-                textStyle: Theme.of(context).textTheme.titleLarge!.copyWith(fontSize: 21, fontWeight: FontWeight.w700, color: const Color(0xFF333333)),
+                textStyle: Theme.of(context).textTheme.titleLarge!.copyWith(fontSize: 21, fontWeight: FontWeight.w700, color: Theme.of(context).colorScheme.onSurface),
               ),
               const SizedBox(
                 height: 5,
               ),
               CustomTextView(
                 label: headerText.split(' ')[1],
-                textStyle: Theme.of(context).textTheme.titleLarge!.copyWith(fontSize: 21, fontWeight: FontWeight.w700, color: const Color(0xFF333333)),
+                textStyle: Theme.of(context).textTheme.titleLarge!.copyWith(fontSize: 21, fontWeight: FontWeight.w700, color: Theme.of(context).colorScheme.onSurface),
               ),
             ],
           ),

--- a/lib/screens/appointment/coach_details_appointment_screen.dart
+++ b/lib/screens/appointment/coach_details_appointment_screen.dart
@@ -7,7 +7,6 @@ import 'package:oqdo_mobile_app/theme/custom_colors.dart';
 import 'package:intl/intl.dart';
 import 'package:oqdo_mobile_app/components/custom_app_bar.dart';
 import 'package:oqdo_mobile_app/model/coach_appointment_details_response_model.dart' as model;
-import 'package:oqdo_mobile_app/theme/oqdo_theme_data.dart';
 import 'package:oqdo_mobile_app/utils/constants.dart';
 import 'package:oqdo_mobile_app/utils/custom_text_view.dart';
 import 'package:oqdo_mobile_app/utils/network_interceptor.dart';
@@ -115,7 +114,7 @@ class _CoachDetailAppointmentScreenState extends State<CoachDetailAppointmentScr
                         child: CustomTextView(
                           label: 'Name: ${coachAppointmentDetailResponseModel!.endUserFirstName} ${coachAppointmentDetailResponseModel!.endUserLastName}',
                           textStyle:
-                              Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 14, color: const Color(0xFF818181), fontWeight: FontWeight.w400),
+                              Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 14, color: Theme.of(context).extension<CustomColors>()!.greyText, fontWeight: FontWeight.w400),
                         ),
                       ),
                       const SizedBox(
@@ -126,7 +125,7 @@ class _CoachDetailAppointmentScreenState extends State<CoachDetailAppointmentScr
                         child: CustomTextView(
                           label: 'Email ID: ${coachAppointmentDetailResponseModel!.endUserEmail}',
                           textStyle:
-                              Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 14, color: const Color(0xFF818181), fontWeight: FontWeight.w400),
+                              Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 14, color: Theme.of(context).extension<CustomColors>()!.greyText, fontWeight: FontWeight.w400),
                         ),
                       ),
                       const SizedBox(
@@ -137,7 +136,7 @@ class _CoachDetailAppointmentScreenState extends State<CoachDetailAppointmentScr
                         child: CustomTextView(
                           label: 'Phone number: ${coachAppointmentDetailResponseModel!.endUserMobileNumber}',
                           textStyle:
-                              Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 14, color: const Color(0xFF818181), fontWeight: FontWeight.w400),
+                              Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 14, color: Theme.of(context).extension<CustomColors>()!.greyText, fontWeight: FontWeight.w400),
                         ),
                       ),
                       const SizedBox(
@@ -148,7 +147,7 @@ class _CoachDetailAppointmentScreenState extends State<CoachDetailAppointmentScr
                         child: CustomTextView(
                           label: coachAppointmentDetailResponseModel!.bookingType == 'I' ? 'Booking For: Individual' : 'Booking For: Group',
                           textStyle:
-                              Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 14, color: const Color(0xFF818181), fontWeight: FontWeight.w400),
+                              Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 14, color: Theme.of(context).extension<CustomColors>()!.greyText, fontWeight: FontWeight.w400),
                         ),
                       ),
                       const SizedBox(
@@ -161,7 +160,7 @@ class _CoachDetailAppointmentScreenState extends State<CoachDetailAppointmentScr
                           maxLine: 3,
                           textOverFlow: TextOverflow.ellipsis,
                           textStyle:
-                              Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 14, color: const Color(0xFF818181), fontWeight: FontWeight.w400),
+                              Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 14, color: Theme.of(context).extension<CustomColors>()!.greyText, fontWeight: FontWeight.w400),
                         ),
                       ),
                       const SizedBox(
@@ -176,7 +175,7 @@ class _CoachDetailAppointmentScreenState extends State<CoachDetailAppointmentScr
                               maxLine: 3,
                               textOverFlow: TextOverflow.ellipsis,
                               textStyle:
-                                  Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 14, color: const Color(0xFF818181), fontWeight: FontWeight.w600),
+                                  Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 14, color: Theme.of(context).extension<CustomColors>()!.greyText, fontWeight: FontWeight.w600),
                             ),
                             CustomTextView(
                               label: '${coachAppointmentDetailResponseModel!.bookingNo}',
@@ -184,7 +183,7 @@ class _CoachDetailAppointmentScreenState extends State<CoachDetailAppointmentScr
                               textOverFlow: TextOverflow.ellipsis,
                               textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(
                                     fontSize: 14,
-                                    color: const Color(0xFF818181),
+                                    color: Theme.of(context).extension<CustomColors>()!.greyText,
                                     fontWeight: FontWeight.w400,
                                   ),
                             ),
@@ -229,14 +228,14 @@ class _CoachDetailAppointmentScreenState extends State<CoachDetailAppointmentScr
         //   textStyle: Theme.of(context)
         //       .textTheme
         //       .titleMedium!
-        //       .copyWith(fontWeight: FontWeight.w600, color: OQDOThemeData.greyColor, fontSize: 18.0),
+        //       .copyWith(fontWeight: FontWeight.w600, color: Theme.of(context).colorScheme.onSurface, fontSize: 18.0),
         // ),
         // const SizedBox(
         //   height: 10.0,
         // ),
         // CustomTextView(
         //   label: 'Order ID: ${coachAppointmentDetailResponseModel!.bookingNo}',
-        //   textStyle: Theme.of(context).textTheme.bodySmall!.copyWith(fontWeight: FontWeight.w500, color: OQDOThemeData.greyColor, fontSize: 18.0),
+        //   textStyle: Theme.of(context).textTheme.bodySmall!.copyWith(fontWeight: FontWeight.w500, color: Theme.of(context).colorScheme.onSurface, fontSize: 18.0),
         // ),
         // const SizedBox(
         //   height: 12.0,
@@ -246,11 +245,11 @@ class _CoachDetailAppointmentScreenState extends State<CoachDetailAppointmentScr
         //   children: [
         //     CustomTextView(
         //       label: 'Total Amount',
-        //       textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(fontWeight: FontWeight.w600, color: OQDOThemeData.greyColor, fontSize: 18.0),
+        //       textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(fontWeight: FontWeight.w600, color: Theme.of(context).colorScheme.onSurface, fontSize: 18.0),
         //     ),
         //     CustomTextView(
         //       label: 'S\$ ${coachAppointmentDetailResponseModel?.totalAmt?.toStringAsFixed(2) ?? 0.00}',
-        //       textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(fontWeight: FontWeight.w400, color: OQDOThemeData.greyColor, fontSize: 18.0),
+        //       textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(fontWeight: FontWeight.w400, color: Theme.of(context).colorScheme.onSurface, fontSize: 18.0),
         //     ),
         //   ],
         // ),
@@ -264,8 +263,8 @@ class _CoachDetailAppointmentScreenState extends State<CoachDetailAppointmentScr
   Widget _paymentSummaryView() {
     return Container(
       decoration: BoxDecoration(
-        color: OQDOThemeData.whiteColor,
-        border: Border.all(color: OQDOThemeData.otherTextColor),
+        color: Theme.of(context).extension<CustomColors>()!.white,
+        border: Border.all(color: Theme.of(context).extension<CustomColors>()!.greyText),
       ),
       padding: const EdgeInsets.all(8.0),
       child: Column(
@@ -276,7 +275,7 @@ class _CoachDetailAppointmentScreenState extends State<CoachDetailAppointmentScr
             textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(
                   fontSize: 16.0,
                   fontWeight: FontWeight.w600,
-                  color: OQDOThemeData.buttonColor,
+                  color: Theme.of(context).colorScheme.primary,
                 ),
           ),
           const SizedBox(
@@ -295,13 +294,13 @@ class _CoachDetailAppointmentScreenState extends State<CoachDetailAppointmentScr
             children: [
               CustomTextView(
                 label: "Total Amount : ",
-                textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 16.0, fontWeight: FontWeight.w600, color: OQDOThemeData.blackColor),
+                textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 16.0, fontWeight: FontWeight.w600, color: Theme.of(context).colorScheme.onBackground),
               ),
               Column(
                 children: [
                   CustomTextView(
                     label: 'S\$ ${totalAmount.toStringAsFixed(2)}',
-                    textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 14.0, fontWeight: FontWeight.w600, color: OQDOThemeData.blackColor),
+                    textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 14.0, fontWeight: FontWeight.w600, color: Theme.of(context).colorScheme.onBackground),
                   ),
                 ],
               ),
@@ -325,7 +324,7 @@ class _CoachDetailAppointmentScreenState extends State<CoachDetailAppointmentScr
                 children: [
                   CustomTextView(
                     label: title,
-                    textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 14.0, fontWeight: FontWeight.w600, color: OQDOThemeData.blackColor),
+                    textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 14.0, fontWeight: FontWeight.w600, color: Theme.of(context).colorScheme.onBackground),
                   ),
                   const SizedBox(
                     height: 3,
@@ -333,7 +332,7 @@ class _CoachDetailAppointmentScreenState extends State<CoachDetailAppointmentScr
                   CustomTextView(
                     label: details,
                     maxLine: 2,
-                    textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 12.0, fontWeight: FontWeight.w500, color: OQDOThemeData.greyColor),
+                    textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 12.0, fontWeight: FontWeight.w500, color: Theme.of(context).colorScheme.onSurface),
                   ),
                 ],
               ),
@@ -348,7 +347,7 @@ class _CoachDetailAppointmentScreenState extends State<CoachDetailAppointmentScr
                     label: 'S\$ $rate',
                     maxLine: 2,
                     textOverFlow: TextOverflow.ellipsis,
-                    textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 13.0, fontWeight: FontWeight.w600, color: OQDOThemeData.blackColor),
+                    textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 13.0, fontWeight: FontWeight.w600, color: Theme.of(context).colorScheme.onBackground),
                   ),
                 ],
               ),
@@ -359,7 +358,7 @@ class _CoachDetailAppointmentScreenState extends State<CoachDetailAppointmentScr
           height: 3,
         ),
         const Divider(
-          color: OQDOThemeData.greyColor,
+          color: Theme.of(context).colorScheme.onSurface,
         ),
       ],
     );
@@ -385,7 +384,7 @@ class _CoachDetailAppointmentScreenState extends State<CoachDetailAppointmentScr
                   CustomTextView(
                     label:
                         '${convertDateToString(coachAppointmentDetailResponseModel!.coachBookingSlotDates![index].bookingDate!).split(',')[1].split(' ')[2]} ${convertDateToString(coachAppointmentDetailResponseModel!.coachBookingSlotDates![index].bookingDate!).split(',')[1].split(' ')[1]} - ${convertDateToString(coachAppointmentDetailResponseModel!.coachBookingSlotDates![index].bookingDate!).split(',')[0]}',
-                    textStyle: Theme.of(context).textTheme.titleLarge!.copyWith(fontSize: 20.0, color: OQDOThemeData.greyColor, fontWeight: FontWeight.w500),
+                    textStyle: Theme.of(context).textTheme.titleLarge!.copyWith(fontSize: 20.0, color: Theme.of(context).colorScheme.onSurface, fontWeight: FontWeight.w500),
                   ),
                   const SizedBox(
                     height: 5.0,
@@ -398,7 +397,7 @@ class _CoachDetailAppointmentScreenState extends State<CoachDetailAppointmentScr
                         label:
                             '${coachAppointmentDetailResponseModel!.coachBookingSlotDates![index].startTime}-${coachAppointmentDetailResponseModel!.coachBookingSlotDates![index].endTime}',
                         textStyle:
-                            Theme.of(context).textTheme.titleLarge!.copyWith(fontSize: 16.0, color: OQDOThemeData.greyColor, fontWeight: FontWeight.w500),
+                            Theme.of(context).textTheme.titleLarge!.copyWith(fontSize: 16.0, color: Theme.of(context).colorScheme.onSurface, fontWeight: FontWeight.w500),
                       ),
                       const SizedBox(
                         width: 15,
@@ -406,7 +405,7 @@ class _CoachDetailAppointmentScreenState extends State<CoachDetailAppointmentScr
                       CustomTextView(
                         label: 'S\$ ${coachAppointmentDetailResponseModel!.coachBookingSlotDates![index].ratePerHour?.toStringAsFixed(2) ?? 0.00}/hour',
                         textStyle:
-                            Theme.of(context).textTheme.titleLarge!.copyWith(fontSize: 16.0, color: OQDOThemeData.greyColor, fontWeight: FontWeight.w500),
+                            Theme.of(context).textTheme.titleLarge!.copyWith(fontSize: 16.0, color: Theme.of(context).colorScheme.onSurface, fontWeight: FontWeight.w500),
                       ),
                     ],
                   ),
@@ -421,7 +420,7 @@ class _CoachDetailAppointmentScreenState extends State<CoachDetailAppointmentScr
                       ? CustomTextView(
                           label: 'Cancelled',
                           textStyle:
-                              Theme.of(context).textTheme.titleLarge!.copyWith(fontSize: 14.0, color: OQDOThemeData.errorColor, fontWeight: FontWeight.w500),
+                              Theme.of(context).textTheme.titleLarge!.copyWith(fontSize: 14.0, color: Theme.of(context).colorScheme.error, fontWeight: FontWeight.w500),
                         )
                       : const SizedBox(),
                   const SizedBox(
@@ -429,7 +428,7 @@ class _CoachDetailAppointmentScreenState extends State<CoachDetailAppointmentScr
                   ),
                   CustomTextView(
                     label: 'S\$ ${finalAmount.toStringAsFixed(2)}',
-                    textStyle: Theme.of(context).textTheme.titleLarge!.copyWith(fontSize: 20.0, color: OQDOThemeData.greyColor, fontWeight: FontWeight.w500),
+                    textStyle: Theme.of(context).textTheme.titleLarge!.copyWith(fontSize: 20.0, color: Theme.of(context).colorScheme.onSurface, fontWeight: FontWeight.w500),
                   ),
                 ],
               ),
@@ -437,7 +436,7 @@ class _CoachDetailAppointmentScreenState extends State<CoachDetailAppointmentScr
           ),
           const Divider(
             thickness: 1.0,
-            color: Color(0xFFEFEFEF),
+            color: Theme.of(context).extension<CustomColors>()!.greyButton,
           ),
         ],
       ),
@@ -468,7 +467,7 @@ class _CoachDetailAppointmentScreenState extends State<CoachDetailAppointmentScr
               Container(
                 decoration: BoxDecoration(
                   shape: BoxShape.rectangle,
-                  border: Border.all(width: 7.0, color: const Color.fromRGBO(0, 101, 144, 0.5)),
+                  border: Border.all(width: 7.0, color: Theme.of(context).colorScheme.primary.withOpacity(0.5)),
                 ),
               ),
               const SizedBox(width: 20.0),
@@ -478,14 +477,14 @@ class _CoachDetailAppointmentScreenState extends State<CoachDetailAppointmentScr
                 children: [
                   CustomTextView(
                     label: coachAppointmentDetailResponseModel!.setupName,
-                    textStyle: Theme.of(context).textTheme.titleSmall!.copyWith(fontWeight: FontWeight.w500, fontSize: 18.0, color: OQDOThemeData.greyColor),
+                    textStyle: Theme.of(context).textTheme.titleSmall!.copyWith(fontWeight: FontWeight.w500, fontSize: 18.0, color: Theme.of(context).colorScheme.onSurface),
                   ),
                   const SizedBox(
                     height: 10,
                   ),
                   CustomTextView(
                     label: '${coachAppointmentDetailResponseModel!.activityName} - ${coachAppointmentDetailResponseModel!.subActivityName}',
-                    textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 14, color: const Color(0xFF818181), fontWeight: FontWeight.w400),
+                    textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 14, color: Theme.of(context).extension<CustomColors>()!.greyText, fontWeight: FontWeight.w400),
                   ),
                 ],
               ),
@@ -494,7 +493,7 @@ class _CoachDetailAppointmentScreenState extends State<CoachDetailAppointmentScr
               //   padding: const EdgeInsets.only(right: 10.0),
               //   child: CustomTextView(
               //     label: 'Order ID: ${coachAppointmentDetailResponseModel!.bookingNo}',
-              //     textStyle: Theme.of(context).textTheme.bodySmall!.copyWith(fontWeight: FontWeight.w500, color: OQDOThemeData.greyColor, fontSize: 10.0),
+              //     textStyle: Theme.of(context).textTheme.bodySmall!.copyWith(fontWeight: FontWeight.w500, color: Theme.of(context).colorScheme.onSurface, fontSize: 10.0),
               //   ),
               // ),
             ],
@@ -607,7 +606,7 @@ class _CoachDetailAppointmentScreenState extends State<CoachDetailAppointmentScr
               padding: const EdgeInsets.only(left: 20.0),
               child: CustomTextView(
                 label: 'Transaction History',
-                textStyle: Theme.of(context).textTheme.titleLarge!.copyWith(fontSize: 20, color: OQDOThemeData.blackColor, fontWeight: FontWeight.w500),
+                textStyle: Theme.of(context).textTheme.titleLarge!.copyWith(fontSize: 20, color: Theme.of(context).colorScheme.onBackground, fontWeight: FontWeight.w500),
               ),
             ),
           ),
@@ -792,7 +791,7 @@ class _CoachDetailAppointmentScreenState extends State<CoachDetailAppointmentScr
                                   color: paymentTransaction[index].status == 'A'
                                       ? Theme.of(context).extension<CustomColors>()!.greenAmount
                                       : paymentTransaction[index].status == 'P'
-                                          ? Colors.yellow
+                                          ? Theme.of(context).extension<CustomColors>()!.yellowStatus
                                           : Theme.of(context).extension<CustomColors>()!.redAmount,
                                   fontWeight: FontWeight.w500),
                               overflow: TextOverflow.ellipsis,
@@ -991,7 +990,7 @@ class _CoachDetailAppointmentScreenState extends State<CoachDetailAppointmentScr
                 //                   color: paymentTransaction[index].status == 'A'
                 //                       ? Theme.of(context).extension<CustomColors>()!.greenAmount
                 //                       : paymentTransaction[index].status == 'P'
-                //                           ? Colors.yellow
+                //                           ? Theme.of(context).extension<CustomColors>()!.yellowStatus
                 //                           : Theme.of(context).extension<CustomColors>()!.redAmount,
                 //                   fontWeight: FontWeight.w500),
                 //               overflow: TextOverflow.ellipsis,

--- a/lib/screens/appointment/coach_enduser_verification_screen.dart
+++ b/lib/screens/appointment/coach_enduser_verification_screen.dart
@@ -3,13 +3,13 @@
 import 'dart:convert';
 
 import 'package:flutter/material.dart';
+import 'package:oqdo_mobile_app/theme/custom_colors.dart';
 import 'package:intl/intl.dart';
 import 'package:oqdo_mobile_app/components/custom_app_bar.dart';
 import 'package:oqdo_mobile_app/components/my_button.dart';
 import 'package:oqdo_mobile_app/helper/helpers.dart';
 import 'package:oqdo_mobile_app/model/CancelCoachAppointmentModel.dart';
 import 'package:oqdo_mobile_app/oqdo_application.dart';
-import 'package:oqdo_mobile_app/theme/oqdo_theme_data.dart';
 import 'package:oqdo_mobile_app/utils/constants.dart';
 import 'package:oqdo_mobile_app/utils/custom_text_view.dart';
 import 'package:oqdo_mobile_app/utils/network_interceptor.dart';
@@ -83,7 +83,7 @@ class _CoachEndUserVerificationScreenState extends State<CoachEndUserVerificatio
                       child: CustomTextView(
                         maxLine: 2,
                         label: '${widget.cancelCoachAppointmentModel!.coachAppointmentDetailResponseModel!.setupName}',
-                        textStyle: Theme.of(context).textTheme.titleLarge!.copyWith(fontSize: 20, color: OQDOThemeData.greyColor, fontWeight: FontWeight.w500),
+                        textStyle: Theme.of(context).textTheme.titleLarge!.copyWith(fontSize: 20, color: Theme.of(context).colorScheme.onSurface, fontWeight: FontWeight.w500),
                       ),
                     ),
                     const SizedBox(
@@ -95,7 +95,7 @@ class _CoachEndUserVerificationScreenState extends State<CoachEndUserVerificatio
                         maxLine: 2,
                         label:
                             '${widget.cancelCoachAppointmentModel!.coachAppointmentDetailResponseModel!.activityName} - ${widget.cancelCoachAppointmentModel!.coachAppointmentDetailResponseModel!.subActivityName}',
-                        textStyle: Theme.of(context).textTheme.titleLarge!.copyWith(fontSize: 17, color: OQDOThemeData.greyColor, fontWeight: FontWeight.w500),
+                        textStyle: Theme.of(context).textTheme.titleLarge!.copyWith(fontSize: 17, color: Theme.of(context).colorScheme.onSurface, fontWeight: FontWeight.w500),
                       ),
                     ),
                     const SizedBox(
@@ -111,7 +111,7 @@ class _CoachEndUserVerificationScreenState extends State<CoachEndUserVerificatio
                             textStyle: Theme.of(context)
                                 .textTheme
                                 .titleSmall!
-                                .copyWith(color: OQDOThemeData.otherTextColor, fontWeight: FontWeight.w600, fontSize: 12.0),
+                                .copyWith(color: Theme.of(context).extension<CustomColors>()!.greyText, fontWeight: FontWeight.w600, fontSize: 12.0),
                           ),
                         ],
                       ),
@@ -123,7 +123,7 @@ class _CoachEndUserVerificationScreenState extends State<CoachEndUserVerificatio
                       padding: const EdgeInsets.only(left: 20, right: 20),
                       child: CustomTextView(
                         label: 'Order ID: ${widget.cancelCoachAppointmentModel!.coachAppointmentDetailResponseModel!.bookingNo}',
-                        textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 14, color: const Color(0xFF818181), fontWeight: FontWeight.w400),
+                        textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 14, color: Theme.of(context).extension<CustomColors>()!.greyText, fontWeight: FontWeight.w400),
                       ),
                     ),
                     const SizedBox(
@@ -134,7 +134,7 @@ class _CoachEndUserVerificationScreenState extends State<CoachEndUserVerificatio
                       child: CustomTextView(
                         label:
                             'Name: ${widget.cancelCoachAppointmentModel!.coachAppointmentDetailResponseModel!.coachFirstName} ${widget.cancelCoachAppointmentModel!.coachAppointmentDetailResponseModel!.coachLastName}',
-                        textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 14, color: const Color(0xFF818181), fontWeight: FontWeight.w400),
+                        textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 14, color: Theme.of(context).extension<CustomColors>()!.greyText, fontWeight: FontWeight.w400),
                       ),
                     ),
                     const SizedBox(
@@ -144,7 +144,7 @@ class _CoachEndUserVerificationScreenState extends State<CoachEndUserVerificatio
                       padding: const EdgeInsets.only(left: 20, right: 20),
                       child: CustomTextView(
                         label: 'Email ID: ${widget.cancelCoachAppointmentModel!.coachAppointmentDetailResponseModel!.coachEmail}',
-                        textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 14, color: const Color(0xFF818181), fontWeight: FontWeight.w400),
+                        textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 14, color: Theme.of(context).extension<CustomColors>()!.greyText, fontWeight: FontWeight.w400),
                       ),
                     ),
                     const SizedBox(
@@ -154,7 +154,7 @@ class _CoachEndUserVerificationScreenState extends State<CoachEndUserVerificatio
                       padding: const EdgeInsets.only(left: 20, right: 20),
                       child: CustomTextView(
                         label: 'Phone number: ${widget.cancelCoachAppointmentModel!.coachAppointmentDetailResponseModel!.coachMobileNumber}',
-                        textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 14, color: const Color(0xFF818181), fontWeight: FontWeight.w400),
+                        textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 14, color: Theme.of(context).extension<CustomColors>()!.greyText, fontWeight: FontWeight.w400),
                       ),
                     ),
                     const SizedBox(
@@ -166,7 +166,7 @@ class _CoachEndUserVerificationScreenState extends State<CoachEndUserVerificatio
                         label: widget.cancelCoachAppointmentModel!.coachAppointmentDetailResponseModel!.bookingType == 'I'
                             ? 'Booking For: Individual'
                             : 'Booking For: Group',
-                        textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 14, color: const Color(0xFF818181), fontWeight: FontWeight.w400),
+                        textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 14, color: Theme.of(context).extension<CustomColors>()!.greyText, fontWeight: FontWeight.w400),
                       ),
                     ),
                     const SizedBox(
@@ -178,7 +178,7 @@ class _CoachEndUserVerificationScreenState extends State<CoachEndUserVerificatio
                         maxLine: 3,
                         textOverFlow: TextOverflow.ellipsis,
                         label: 'Address: $addressData',
-                        textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 14, color: const Color(0xFF818181), fontWeight: FontWeight.w400),
+                        textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 14, color: Theme.of(context).extension<CustomColors>()!.greyText, fontWeight: FontWeight.w400),
                       ),
                     ),
                     const SizedBox(
@@ -188,7 +188,7 @@ class _CoachEndUserVerificationScreenState extends State<CoachEndUserVerificatio
                       padding: const EdgeInsets.only(left: 20, right: 20),
                       child: CustomTextView(
                         label: 'Cancellation Reason: ${widget.cancelCoachAppointmentModel!.selectedReason}',
-                        textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 14, color: const Color(0xFF818181), fontWeight: FontWeight.w400),
+                        textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 14, color: Theme.of(context).extension<CustomColors>()!.greyText, fontWeight: FontWeight.w400),
                       ),
                     ),
                     const SizedBox(
@@ -196,7 +196,7 @@ class _CoachEndUserVerificationScreenState extends State<CoachEndUserVerificatio
                     ),
                     const Divider(
                       height: 1,
-                      color: Color(0xFFCACACA),
+                      color: Theme.of(context).colorScheme.outline,
                     ),
                     const SizedBox(
                       height: 20.0,
@@ -231,14 +231,14 @@ class _CoachEndUserVerificationScreenState extends State<CoachEndUserVerificatio
                                   textStyle: Theme.of(context)
                                       .textTheme
                                       .titleMedium!
-                                      .copyWith(fontSize: 16.0, fontWeight: FontWeight.w500, color: OQDOThemeData.greyColor),
+                                      .copyWith(fontSize: 16.0, fontWeight: FontWeight.w500, color: Theme.of(context).colorScheme.onSurface),
                                 ),
                                 CustomTextView(
                                   label: 'S\$ ${totalAmount.toStringAsFixed(2)}',
                                   textStyle: Theme.of(context)
                                       .textTheme
                                       .titleMedium!
-                                      .copyWith(fontSize: 16.0, fontWeight: FontWeight.w400, color: OQDOThemeData.greyColor),
+                                      .copyWith(fontSize: 16.0, fontWeight: FontWeight.w400, color: Theme.of(context).colorScheme.onSurface),
                                 )
                               ],
                             ),
@@ -255,14 +255,14 @@ class _CoachEndUserVerificationScreenState extends State<CoachEndUserVerificatio
                                         Navigator.of(context).pop();
                                       },
                                       style: ButtonStyle(
-                                        backgroundColor: MaterialStateProperty.all(OQDOThemeData.errorColor),
+                                        backgroundColor: MaterialStateProperty.all(Theme.of(context).colorScheme.error),
                                       ),
                                       child: CustomTextView(
                                         label: 'Cancel',
                                         textStyle: Theme.of(context)
                                             .textTheme
                                             .bodyMedium!
-                                            .copyWith(fontSize: 16, color: OQDOThemeData.whiteColor, fontWeight: FontWeight.w400),
+                                            .copyWith(fontSize: 16, color: Theme.of(context).extension<CustomColors>()!.white, fontWeight: FontWeight.w400),
                                       ),
                                     ),
                                   ),
@@ -278,14 +278,14 @@ class _CoachEndUserVerificationScreenState extends State<CoachEndUserVerificatio
                                         facilityCancelRequest(context);
                                       },
                                       style: ButtonStyle(
-                                        backgroundColor: MaterialStateProperty.all(OQDOThemeData.successColor),
+                                        backgroundColor: MaterialStateProperty.all(Theme.of(context).extension<CustomColors>()!.greenAmount),
                                       ),
                                       child: CustomTextView(
                                         label: 'Confirm',
                                         textStyle: Theme.of(context)
                                             .textTheme
                                             .bodyMedium!
-                                            .copyWith(fontSize: 16, color: OQDOThemeData.whiteColor, fontWeight: FontWeight.w400),
+                                            .copyWith(fontSize: 16, color: Theme.of(context).extension<CustomColors>()!.white, fontWeight: FontWeight.w400),
                                       ),
                                     ),
                                   ),
@@ -320,25 +320,25 @@ class _CoachEndUserVerificationScreenState extends State<CoachEndUserVerificatio
               CustomTextView(
                 label:
                     '${convertDateToString(finalBookingSlotList[index].bookingDate!).split(',')[1].split(' ')[2]} ${convertDateToString(finalBookingSlotList[index].bookingDate!).split(',')[1].split(' ')[1]} - ${convertDateToString(finalBookingSlotList[index].bookingDate!).split(',')[0]}',
-                textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 18.0, fontWeight: FontWeight.w500, color: OQDOThemeData.greyColor),
+                textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 18.0, fontWeight: FontWeight.w500, color: Theme.of(context).colorScheme.onSurface),
               ),
               const SizedBox(
                 height: 5.0,
               ),
               CustomTextView(
                 label: '${finalBookingSlotList[index].startTime} - ${finalBookingSlotList[index].endTime}',
-                textStyle: Theme.of(context).textTheme.titleSmall!.copyWith(fontSize: 12.0, fontWeight: FontWeight.w400, color: OQDOThemeData.greyColor),
+                textStyle: Theme.of(context).textTheme.titleSmall!.copyWith(fontSize: 12.0, fontWeight: FontWeight.w400, color: Theme.of(context).colorScheme.onSurface),
               ),
             ],
           ),
           const Spacer(),
           RichText(
-            text: TextSpan(text: 'Refund Amount: ', style: const TextStyle(color: Color(0xFF7D7D7D), fontWeight: FontWeight.w400, fontSize: 12), children: [
+            text: TextSpan(text: 'Refund Amount: ', style: const TextStyle(color: Theme.of(context).extension<CustomColors>()!.greyText, fontWeight: FontWeight.w400, fontSize: 12), children: [
               TextSpan(
                 text: 'S\$${finalBookingSlotList[index].refundedAmount?.toStringAsFixed(2) ?? 0.00}',
                 style: const TextStyle(
                   fontWeight: FontWeight.w500,
-                  color: Color(0xFF006590),
+                  color: Theme.of(context).colorScheme.primary,
                   fontSize: 14,
                 ),
               ),
@@ -389,7 +389,7 @@ class _CoachEndUserVerificationScreenState extends State<CoachEndUserVerificatio
                       children: [
                         const Icon(
                           Icons.check_circle,
-                          color: Colors.green,
+                          color: Theme.of(context).extension<CustomColors>()!.greenAmount,
                           size: 100.0,
                         ),
                         const SizedBox(height: 10.0),

--- a/lib/screens/appointment/copoun_screen.dart
+++ b/lib/screens/appointment/copoun_screen.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 
 import 'package:flutter/material.dart';
+import 'package:oqdo_mobile_app/theme/custom_colors.dart';
 import 'package:oqdo_mobile_app/components/custom_app_bar.dart';
 import 'package:oqdo_mobile_app/screens/appointment/intent/selected_coupon_intent.dart';
 import 'package:oqdo_mobile_app/screens/appointment/response/referral_coupon_response_model.dart';

--- a/lib/screens/appointment/enduser_appointment_screen.dart
+++ b/lib/screens/appointment/enduser_appointment_screen.dart
@@ -4,6 +4,7 @@ import 'dart:async';
 import 'dart:convert';
 
 import 'package:flutter/material.dart';
+import 'package:oqdo_mobile_app/theme/custom_colors.dart';
 import 'package:intl/intl.dart';
 import 'package:oqdo_mobile_app/components/custom_app_bar.dart';
 import 'package:oqdo_mobile_app/components/my_button.dart';
@@ -14,7 +15,6 @@ import 'package:oqdo_mobile_app/model/end_user_appoinments_model.dart';
 import 'package:oqdo_mobile_app/model/end_user_appointment_model_details.dart';
 import 'package:oqdo_mobile_app/model/facility_appointment_details_model.dart';
 import 'package:oqdo_mobile_app/oqdo_application.dart';
-import 'package:oqdo_mobile_app/theme/oqdo_theme_data.dart';
 import 'package:oqdo_mobile_app/utils/constants.dart';
 import 'package:oqdo_mobile_app/utils/custom_text_view.dart';
 import 'package:oqdo_mobile_app/utils/network_interceptor.dart';
@@ -91,7 +91,7 @@ class _EndUserAppointmentsScreenState extends State<EndUserAppointmentsScreen> {
           }),
       body: SafeArea(
         child: Container(
-          color: OQDOThemeData.whiteColor,
+          color: Theme.of(context).extension<CustomColors>()!.white,
           width: MediaQuery.of(context).size.width,
           height: double.infinity,
           child: _endUserAppointmentList.isNotEmpty
@@ -123,15 +123,15 @@ class _EndUserAppointmentsScreenState extends State<EndUserAppointmentsScreen> {
                                 child: Container(
                                   padding: const EdgeInsets.all(8),
                                   decoration: BoxDecoration(
-                                      color: const Color(0xFF006590),
-                                      border: Border.all(color: OQDOThemeData.dividerColor),
+                                      color: Theme.of(context).colorScheme.primary,
+                                      border: Border.all(color: Theme.of(context).colorScheme.primary),
                                       borderRadius: const BorderRadius.all(Radius.circular(10))),
                                   child: CustomTextView(
                                     label: _endUserAppointmentList[index].date!.split('T')[0],
                                     textStyle: Theme.of(context)
                                         .textTheme
                                         .bodyMedium!
-                                        .copyWith(color: OQDOThemeData.whiteColor, fontSize: 18, fontWeight: FontWeight.w500),
+                                        .copyWith(color: Theme.of(context).extension<CustomColors>()!.white, fontSize: 18, fontWeight: FontWeight.w500),
                                   ),
                                 ),
                               ),
@@ -167,7 +167,7 @@ class _EndUserAppointmentsScreenState extends State<EndUserAppointmentsScreen> {
                                               Container(
                                                 decoration: BoxDecoration(
                                                   shape: BoxShape.rectangle,
-                                                  border: Border.all(width: 7.0, color: const Color.fromRGBO(0, 101, 144, 0.5)),
+                                                  border: Border.all(width: 7.0, color: Theme.of(context).colorScheme.primary.withOpacity(0.5)),
                                                 ),
                                               ),
                                               const SizedBox(width: 20.0),
@@ -176,7 +176,7 @@ class _EndUserAppointmentsScreenState extends State<EndUserAppointmentsScreen> {
                                                 textStyle: Theme.of(context)
                                                     .textTheme
                                                     .titleLarge!
-                                                    .copyWith(fontWeight: FontWeight.w500, fontSize: 20.0, color: OQDOThemeData.greyColor),
+                                                    .copyWith(fontWeight: FontWeight.w500, fontSize: 20.0, color: Theme.of(context).colorScheme.onSurface),
                                               ),
                                             ],
                                           ),
@@ -235,7 +235,7 @@ class _EndUserAppointmentsScreenState extends State<EndUserAppointmentsScreen> {
                   Container(
                     decoration: BoxDecoration(
                       shape: BoxShape.rectangle,
-                      border: Border.all(width: 7.0, color: const Color.fromRGBO(0, 101, 144, 0.5)),
+                      border: Border.all(width: 7.0, color: Theme.of(context).colorScheme.primary.withOpacity(0.5)),
                     ),
                   ),
                   const SizedBox(width: 20.0),
@@ -281,7 +281,7 @@ class _EndUserAppointmentsScreenState extends State<EndUserAppointmentsScreen> {
                           maxLine: 2,
                           textOverFlow: TextOverflow.ellipsis,
                           textStyle:
-                              Theme.of(context).textTheme.titleSmall!.copyWith(fontWeight: FontWeight.w500, fontSize: 15.0, color: OQDOThemeData.greyColor),
+                              Theme.of(context).textTheme.titleSmall!.copyWith(fontWeight: FontWeight.w500, fontSize: 15.0, color: Theme.of(context).colorScheme.onSurface),
                         ),
                         const SizedBox(
                           height: 8.0,
@@ -291,7 +291,7 @@ class _EndUserAppointmentsScreenState extends State<EndUserAppointmentsScreen> {
                             CustomTextView(
                               label: '${data[index].startTime} - ${data[index].endTime}',
                               textStyle:
-                                  Theme.of(context).textTheme.titleSmall!.copyWith(fontSize: 14.0, fontWeight: FontWeight.w400, color: OQDOThemeData.greyColor),
+                                  Theme.of(context).textTheme.titleSmall!.copyWith(fontSize: 14.0, fontWeight: FontWeight.w400, color: Theme.of(context).colorScheme.onSurface),
                             ),
                             const SizedBox(
                               width: 15,
@@ -299,7 +299,7 @@ class _EndUserAppointmentsScreenState extends State<EndUserAppointmentsScreen> {
                             CustomTextView(
                               label: 'S\$ ${data[index].ratePerHour?.toStringAsFixed(2) ?? 0}/hour',
                               textStyle:
-                                  Theme.of(context).textTheme.titleSmall!.copyWith(fontSize: 14.0, fontWeight: FontWeight.w400, color: OQDOThemeData.greyColor),
+                                  Theme.of(context).textTheme.titleSmall!.copyWith(fontSize: 14.0, fontWeight: FontWeight.w400, color: Theme.of(context).colorScheme.onSurface),
                             ),
                           ],
                         ),
@@ -312,7 +312,7 @@ class _EndUserAppointmentsScreenState extends State<EndUserAppointmentsScreen> {
                           child: CustomTextView(
                             label: 'Cancelled',
                             textStyle:
-                                Theme.of(context).textTheme.titleSmall!.copyWith(fontSize: 14.0, fontWeight: FontWeight.w700, color: OQDOThemeData.errorColor),
+                                Theme.of(context).textTheme.titleSmall!.copyWith(fontSize: 14.0, fontWeight: FontWeight.w700, color: Theme.of(context).colorScheme.error),
                           ),
                         )
                       : data[index].isPastSlot!
@@ -379,7 +379,7 @@ class _EndUserAppointmentsScreenState extends State<EndUserAppointmentsScreen> {
         children: [
           CustomTextView(
             label: monthStr,
-            textStyle: Theme.of(context).textTheme.titleLarge!.copyWith(fontSize: 20, fontWeight: FontWeight.w500, color: const Color(0xFF333333)),
+            textStyle: Theme.of(context).textTheme.titleLarge!.copyWith(fontSize: 20, fontWeight: FontWeight.w500, color: Theme.of(context).colorScheme.onSurface),
           ),
           const Spacer(),
           GestureDetector(
@@ -432,13 +432,13 @@ class _EndUserAppointmentsScreenState extends State<EndUserAppointmentsScreen> {
             headerVisible: false,
             daysOfWeekVisible: true,
             daysOfWeekStyle: const DaysOfWeekStyle(
-                weekdayStyle: TextStyle(color: Color(0xFF006590), fontWeight: FontWeight.w500),
-                weekendStyle: TextStyle(color: Color(0xFF006590), fontWeight: FontWeight.w500)),
+                weekdayStyle: TextStyle(color: Theme.of(context).colorScheme.primary, fontWeight: FontWeight.w500),
+                weekendStyle: TextStyle(color: Theme.of(context).colorScheme.primary, fontWeight: FontWeight.w500)),
             calendarStyle: CalendarStyle(
               isTodayHighlighted: false,
               outsideDaysVisible: false,
               selectedDecoration: BoxDecoration(color: Theme.of(context).colorScheme.primary, shape: BoxShape.circle),
-              defaultTextStyle: const TextStyle(fontSize: 15, fontWeight: FontWeight.w400, color: Colors.black),
+              defaultTextStyle: const TextStyle(fontSize: 15, fontWeight: FontWeight.w400, color: Theme.of(context).colorScheme.onBackground),
             ),
             onDaySelected: _onDaySelected,
             selectedDayPredicate: (DateTime date) {
@@ -659,7 +659,7 @@ class _EndUserAppointmentsScreenState extends State<EndUserAppointmentsScreen> {
     }
 
     return Container(
-      color: OQDOThemeData.whiteColor,
+      color: Theme.of(context).extension<CustomColors>()!.white,
       width: MediaQuery.of(context).size.width,
       height: MediaQuery.of(context).size.height / 1.2,
       child: SingleChildScrollView(
@@ -676,14 +676,14 @@ class _EndUserAppointmentsScreenState extends State<EndUserAppointmentsScreen> {
             ),
             CustomTextView(
               label: '${_currentDay.split("-")[0]} ${_currentDay.split('-')[1]} ${_currentDay.split('-')[2]}',
-              textStyle: Theme.of(context).textTheme.titleLarge!.copyWith(fontSize: 21, color: const Color(0xFF333333), fontWeight: FontWeight.w500),
+              textStyle: Theme.of(context).textTheme.titleLarge!.copyWith(fontSize: 21, color: Theme.of(context).colorScheme.onSurface, fontWeight: FontWeight.w500),
             ),
             const SizedBox(
               height: 3,
             ),
             CustomTextView(
               label: initSelectedDate,
-              textStyle: Theme.of(context).textTheme.titleLarge!.copyWith(fontSize: 21, color: const Color(0xFF333333), fontWeight: FontWeight.w500),
+              textStyle: Theme.of(context).textTheme.titleLarge!.copyWith(fontSize: 21, color: Theme.of(context).colorScheme.onSurface, fontWeight: FontWeight.w500),
             ),
             Padding(
               padding: const EdgeInsets.only(top: 40, left: 25, right: 25),
@@ -696,13 +696,13 @@ class _EndUserAppointmentsScreenState extends State<EndUserAppointmentsScreen> {
                 daysOfWeekVisible: true,
                 currentDay: kToday,
                 daysOfWeekStyle: const DaysOfWeekStyle(
-                    weekdayStyle: TextStyle(color: Color(0xFF006590), fontWeight: FontWeight.w500),
-                    weekendStyle: TextStyle(color: Color(0xFF006590), fontWeight: FontWeight.w500)),
+                    weekdayStyle: TextStyle(color: Theme.of(context).colorScheme.primary, fontWeight: FontWeight.w500),
+                    weekendStyle: TextStyle(color: Theme.of(context).colorScheme.primary, fontWeight: FontWeight.w500)),
                 calendarStyle: CalendarStyle(
                   isTodayHighlighted: true,
                   outsideDaysVisible: false,
                   selectedDecoration: BoxDecoration(color: Theme.of(context).colorScheme.primary, shape: BoxShape.circle),
-                  defaultTextStyle: const TextStyle(fontSize: 15, fontWeight: FontWeight.w400, color: Colors.black),
+                  defaultTextStyle: const TextStyle(fontSize: 15, fontWeight: FontWeight.w400, color: Theme.of(context).colorScheme.onBackground),
                 ),
                 onCalendarCreated: (controller) {
                   _pageController = controller;
@@ -759,14 +759,14 @@ class _EndUserAppointmentsScreenState extends State<EndUserAppointmentsScreen> {
             children: [
               CustomTextView(
                 label: headerText.split(' ')[0],
-                textStyle: Theme.of(context).textTheme.titleLarge!.copyWith(fontSize: 21, fontWeight: FontWeight.w700, color: const Color(0xFF333333)),
+                textStyle: Theme.of(context).textTheme.titleLarge!.copyWith(fontSize: 21, fontWeight: FontWeight.w700, color: Theme.of(context).colorScheme.onSurface),
               ),
               const SizedBox(
                 height: 5,
               ),
               CustomTextView(
                 label: headerText.split(' ')[1],
-                textStyle: Theme.of(context).textTheme.titleLarge!.copyWith(fontSize: 21, fontWeight: FontWeight.w700, color: const Color(0xFF333333)),
+                textStyle: Theme.of(context).textTheme.titleLarge!.copyWith(fontSize: 21, fontWeight: FontWeight.w700, color: Theme.of(context).colorScheme.onSurface),
               ),
             ],
           ),
@@ -999,7 +999,7 @@ class _EndUserAppointmentsScreenState extends State<EndUserAppointmentsScreen> {
                     padding: const EdgeInsets.only(left: 20.0),
                     child: CustomTextView(
                       label: '${_facilityAppointmentDetailModel!.facilitySetupTitle} - ${_facilityAppointmentDetailModel!.facilitySetupSubTitle}',
-                      textStyle: Theme.of(context).textTheme.titleLarge!.copyWith(fontSize: 20, color: OQDOThemeData.greyColor, fontWeight: FontWeight.w500),
+                      textStyle: Theme.of(context).textTheme.titleLarge!.copyWith(fontSize: 20, color: Theme.of(context).colorScheme.onSurface, fontWeight: FontWeight.w500),
                     ),
                   ),
                 ),
@@ -1014,7 +1014,7 @@ class _EndUserAppointmentsScreenState extends State<EndUserAppointmentsScreen> {
                       CustomTextView(
                         label: 'Details',
                         textStyle:
-                            Theme.of(context).textTheme.titleSmall!.copyWith(color: OQDOThemeData.otherTextColor, fontWeight: FontWeight.w600, fontSize: 12.0),
+                            Theme.of(context).textTheme.titleSmall!.copyWith(color: Theme.of(context).extension<CustomColors>()!.greyText, fontWeight: FontWeight.w600, fontSize: 12.0),
                       ),
                     ],
                   ),
@@ -1026,7 +1026,7 @@ class _EndUserAppointmentsScreenState extends State<EndUserAppointmentsScreen> {
                   padding: const EdgeInsets.only(left: 20, right: 20),
                   child: CustomTextView(
                     label: 'Order ID: ${_facilityAppointmentDetailModel!.bookingNo}',
-                    textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 14, color: const Color(0xFF818181), fontWeight: FontWeight.w400),
+                    textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 14, color: Theme.of(context).extension<CustomColors>()!.greyText, fontWeight: FontWeight.w400),
                   ),
                 ),
                 const SizedBox(
@@ -1036,7 +1036,7 @@ class _EndUserAppointmentsScreenState extends State<EndUserAppointmentsScreen> {
                   padding: const EdgeInsets.only(left: 20, right: 20),
                   child: CustomTextView(
                     label: 'Name: ${_facilityAppointmentDetailModel!.facilityName}',
-                    textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 14, color: const Color(0xFF818181), fontWeight: FontWeight.w400),
+                    textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 14, color: Theme.of(context).extension<CustomColors>()!.greyText, fontWeight: FontWeight.w400),
                   ),
                 ),
                 const SizedBox(
@@ -1046,7 +1046,7 @@ class _EndUserAppointmentsScreenState extends State<EndUserAppointmentsScreen> {
                   padding: const EdgeInsets.only(left: 20, right: 20),
                   child: CustomTextView(
                     label: 'Email ID: ${_facilityAppointmentDetailModel!.facilityEmail}',
-                    textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 14, color: const Color(0xFF818181), fontWeight: FontWeight.w400),
+                    textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 14, color: Theme.of(context).extension<CustomColors>()!.greyText, fontWeight: FontWeight.w400),
                   ),
                 ),
                 const SizedBox(
@@ -1056,7 +1056,7 @@ class _EndUserAppointmentsScreenState extends State<EndUserAppointmentsScreen> {
                   padding: const EdgeInsets.only(left: 20, right: 20),
                   child: CustomTextView(
                     label: 'Phone number: ${_facilityAppointmentDetailModel!.facilityMobileNumber}',
-                    textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 14, color: const Color(0xFF818181), fontWeight: FontWeight.w400),
+                    textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 14, color: Theme.of(context).extension<CustomColors>()!.greyText, fontWeight: FontWeight.w400),
                   ),
                 ),
                 const SizedBox(
@@ -1066,7 +1066,7 @@ class _EndUserAppointmentsScreenState extends State<EndUserAppointmentsScreen> {
                   padding: const EdgeInsets.only(left: 20, right: 20),
                   child: CustomTextView(
                     label: _facilityAppointmentDetailModel!.bookingType == 'I' ? 'Booking For: Individual' : 'Booking For: Group',
-                    textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 14, color: const Color(0xFF818181), fontWeight: FontWeight.w400),
+                    textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 14, color: Theme.of(context).extension<CustomColors>()!.greyText, fontWeight: FontWeight.w400),
                   ),
                 ),
                 const SizedBox(
@@ -1074,7 +1074,7 @@ class _EndUserAppointmentsScreenState extends State<EndUserAppointmentsScreen> {
                 ),
                 const Divider(
                   height: 1,
-                  color: Color(0xFFCACACA),
+                  color: Theme.of(context).colorScheme.outline,
                 ),
                 const SizedBox(
                   height: 20.0,
@@ -1083,7 +1083,7 @@ class _EndUserAppointmentsScreenState extends State<EndUserAppointmentsScreen> {
                   padding: const EdgeInsets.only(left: 10.0),
                   child: CustomTextView(
                     label: 'Cancel Reason',
-                    textStyle: Theme.of(context).textTheme.bodyMedium!.copyWith(fontSize: 15, fontWeight: FontWeight.w400, color: OQDOThemeData.greyColor),
+                    textStyle: Theme.of(context).textTheme.bodyMedium!.copyWith(fontSize: 15, fontWeight: FontWeight.w400, color: Theme.of(context).colorScheme.onSurface),
                   ),
                 ),
                 const SizedBox(
@@ -1165,7 +1165,7 @@ class _EndUserAppointmentsScreenState extends State<EndUserAppointmentsScreen> {
       contentPadding: const EdgeInsets.symmetric(horizontal: 5.0, vertical: 0),
       title: CustomTextView(
         label: model.cancelreason,
-        textStyle: Theme.of(context).textTheme.bodyMedium!.copyWith(fontSize: 18, fontWeight: FontWeight.w400, color: OQDOThemeData.greyColor),
+        textStyle: Theme.of(context).textTheme.bodyMedium!.copyWith(fontSize: 18, fontWeight: FontWeight.w400, color: Theme.of(context).colorScheme.onSurface),
       ),
       activeColor: Theme.of(context).colorScheme.primary,
       value: model.cancelReasonId.toString(),
@@ -1226,7 +1226,7 @@ class _EndUserAppointmentsScreenState extends State<EndUserAppointmentsScreen> {
                     padding: const EdgeInsets.only(left: 20.0),
                     child: CustomTextView(
                       label: '${coachAppointmentDetailResponseModel.coachFirstName} - ${coachAppointmentDetailResponseModel.coachLastName}',
-                      textStyle: Theme.of(context).textTheme.titleLarge!.copyWith(fontSize: 20, color: OQDOThemeData.greyColor, fontWeight: FontWeight.w500),
+                      textStyle: Theme.of(context).textTheme.titleLarge!.copyWith(fontSize: 20, color: Theme.of(context).colorScheme.onSurface, fontWeight: FontWeight.w500),
                     ),
                   ),
                 ),
@@ -1241,7 +1241,7 @@ class _EndUserAppointmentsScreenState extends State<EndUserAppointmentsScreen> {
                       CustomTextView(
                         label: 'Details',
                         textStyle:
-                            Theme.of(context).textTheme.titleSmall!.copyWith(color: OQDOThemeData.otherTextColor, fontWeight: FontWeight.w600, fontSize: 12.0),
+                            Theme.of(context).textTheme.titleSmall!.copyWith(color: Theme.of(context).extension<CustomColors>()!.greyText, fontWeight: FontWeight.w600, fontSize: 12.0),
                       ),
                     ],
                   ),
@@ -1253,7 +1253,7 @@ class _EndUserAppointmentsScreenState extends State<EndUserAppointmentsScreen> {
                   padding: const EdgeInsets.only(left: 20, right: 20),
                   child: CustomTextView(
                     label: 'Order ID: ${coachAppointmentDetailResponseModel.bookingNo}',
-                    textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 14, color: const Color(0xFF818181), fontWeight: FontWeight.w400),
+                    textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 14, color: Theme.of(context).extension<CustomColors>()!.greyText, fontWeight: FontWeight.w400),
                   ),
                 ),
                 const SizedBox(
@@ -1263,7 +1263,7 @@ class _EndUserAppointmentsScreenState extends State<EndUserAppointmentsScreen> {
                   padding: const EdgeInsets.only(left: 20, right: 20),
                   child: CustomTextView(
                     label: 'Name: ${coachAppointmentDetailResponseModel.coachFirstName} ${coachAppointmentDetailResponseModel.coachLastName}',
-                    textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 14, color: const Color(0xFF818181), fontWeight: FontWeight.w400),
+                    textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 14, color: Theme.of(context).extension<CustomColors>()!.greyText, fontWeight: FontWeight.w400),
                   ),
                 ),
                 const SizedBox(
@@ -1273,7 +1273,7 @@ class _EndUserAppointmentsScreenState extends State<EndUserAppointmentsScreen> {
                   padding: const EdgeInsets.only(left: 20, right: 20),
                   child: CustomTextView(
                     label: 'Email ID: ${coachAppointmentDetailResponseModel.coachEmail}',
-                    textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 14, color: const Color(0xFF818181), fontWeight: FontWeight.w400),
+                    textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 14, color: Theme.of(context).extension<CustomColors>()!.greyText, fontWeight: FontWeight.w400),
                   ),
                 ),
                 const SizedBox(
@@ -1283,7 +1283,7 @@ class _EndUserAppointmentsScreenState extends State<EndUserAppointmentsScreen> {
                   padding: const EdgeInsets.only(left: 20, right: 20),
                   child: CustomTextView(
                     label: 'Phone number: ${coachAppointmentDetailResponseModel.coachMobileNumber}',
-                    textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 14, color: const Color(0xFF818181), fontWeight: FontWeight.w400),
+                    textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 14, color: Theme.of(context).extension<CustomColors>()!.greyText, fontWeight: FontWeight.w400),
                   ),
                 ),
                 const SizedBox(
@@ -1293,7 +1293,7 @@ class _EndUserAppointmentsScreenState extends State<EndUserAppointmentsScreen> {
                   padding: const EdgeInsets.only(left: 20, right: 20),
                   child: CustomTextView(
                     label: coachAppointmentDetailResponseModel.bookingType == 'I' ? 'Booking For: Individual' : 'Booking For: Group',
-                    textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 14, color: const Color(0xFF818181), fontWeight: FontWeight.w400),
+                    textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 14, color: Theme.of(context).extension<CustomColors>()!.greyText, fontWeight: FontWeight.w400),
                   ),
                 ),
                 const SizedBox(
@@ -1305,7 +1305,7 @@ class _EndUserAppointmentsScreenState extends State<EndUserAppointmentsScreen> {
                     label: 'Address: $addressData',
                     maxLine: 2,
                     textOverFlow: TextOverflow.ellipsis,
-                    textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 14, color: const Color(0xFF818181), fontWeight: FontWeight.w400),
+                    textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 14, color: Theme.of(context).extension<CustomColors>()!.greyText, fontWeight: FontWeight.w400),
                   ),
                 ),
                 const SizedBox(
@@ -1313,7 +1313,7 @@ class _EndUserAppointmentsScreenState extends State<EndUserAppointmentsScreen> {
                 ),
                 const Divider(
                   height: 1,
-                  color: Color(0xFFCACACA),
+                  color: Theme.of(context).colorScheme.outline,
                 ),
                 const SizedBox(
                   height: 20.0,
@@ -1322,7 +1322,7 @@ class _EndUserAppointmentsScreenState extends State<EndUserAppointmentsScreen> {
                   padding: const EdgeInsets.only(left: 10.0),
                   child: CustomTextView(
                     label: 'Cancel Reason',
-                    textStyle: Theme.of(context).textTheme.bodyMedium!.copyWith(fontSize: 15, fontWeight: FontWeight.w400, color: OQDOThemeData.greyColor),
+                    textStyle: Theme.of(context).textTheme.bodyMedium!.copyWith(fontSize: 15, fontWeight: FontWeight.w400, color: Theme.of(context).colorScheme.onSurface),
                   ),
                 ),
                 const SizedBox(
@@ -1674,7 +1674,6 @@ class _EndUserAppointmentsScreenState extends State<EndUserAppointmentsScreen> {
 // import 'package:oqdo_mobile_app/model/end_user_appointment_model_details.dart';
 // import 'package:oqdo_mobile_app/model/facility_appointment_details_model.dart';
 // import 'package:oqdo_mobile_app/oqdo_application.dart';
-// import 'package:oqdo_mobile_app/theme/oqdo_theme_data.dart';
 // import 'package:oqdo_mobile_app/utils/constants.dart';
 // import 'package:oqdo_mobile_app/utils/custom_text_view.dart';
 // import 'package:oqdo_mobile_app/utils/utilities.dart';
@@ -1757,12 +1756,12 @@ class _EndUserAppointmentsScreenState extends State<EndUserAppointmentsScreen> {
 //           textStyle: Theme.of(context)
 //               .textTheme
 //               .titleMedium!
-//               .copyWith(fontWeight: FontWeight.w400, color: OQDOThemeData.greyColor, fontSize: 16.0),
+//               .copyWith(fontWeight: FontWeight.w400, color: Theme.of(context).colorScheme.onSurface, fontSize: 16.0),
 //         ),
 //       ),
 //       body: SafeArea(
 //         child: Container(
-//           color: OQDOThemeData.whiteColor,
+//           color: Theme.of(context).extension<CustomColors>()!.white,
 //           width: MediaQuery.of(context).size.width,
 //           height: double.infinity,
 //           child: _endUserAppointmentList.isNotEmpty
@@ -1794,15 +1793,15 @@ class _EndUserAppointmentsScreenState extends State<EndUserAppointmentsScreen> {
 //                                 child: Container(
 //                                   padding: const EdgeInsets.all(8),
 //                                   decoration: BoxDecoration(
-//                                       color: const Color(0xFF006590),
-//                                       border: Border.all(color: OQDOThemeData.dividerColor),
+//                                       color: Theme.of(context).colorScheme.primary,
+//                                       border: Border.all(color: Theme.of(context).colorScheme.primary),
 //                                       borderRadius: const BorderRadius.all(Radius.circular(10))),
 //                                   child: CustomTextView(
 //                                     label: _endUserAppointmentList[index].date!.split('T')[0],
 //                                     textStyle: Theme.of(context)
 //                                         .textTheme
 //                                         .bodyMedium!
-//                                         .copyWith(color: OQDOThemeData.whiteColor, fontSize: 18, fontWeight: FontWeight.w500),
+//                                         .copyWith(color: Theme.of(context).extension<CustomColors>()!.white, fontSize: 18, fontWeight: FontWeight.w500),
 //                                   ),
 //                                 ),
 //                               ),
@@ -1838,7 +1837,7 @@ class _EndUserAppointmentsScreenState extends State<EndUserAppointmentsScreen> {
 //                                               Container(
 //                                                 decoration: BoxDecoration(
 //                                                   shape: BoxShape.rectangle,
-//                                                   border: Border.all(width: 7.0, color: const Color.fromRGBO(0, 101, 144, 0.5)),
+//                                                   border: Border.all(width: 7.0, color: Theme.of(context).colorScheme.primary.withOpacity(0.5)),
 //                                                 ),
 //                                               ),
 //                                               const SizedBox(width: 20.0),
@@ -1847,7 +1846,7 @@ class _EndUserAppointmentsScreenState extends State<EndUserAppointmentsScreen> {
 //                                                 textStyle: Theme.of(context)
 //                                                     .textTheme
 //                                                     .titleLarge!
-//                                                     .copyWith(fontWeight: FontWeight.w500, fontSize: 20.0, color: OQDOThemeData.greyColor),
+//                                                     .copyWith(fontWeight: FontWeight.w500, fontSize: 20.0, color: Theme.of(context).colorScheme.onSurface),
 //                                               ),
 //                                             ],
 //                                           ),
@@ -1907,7 +1906,7 @@ class _EndUserAppointmentsScreenState extends State<EndUserAppointmentsScreen> {
 //                   Container(
 //                     decoration: BoxDecoration(
 //                       shape: BoxShape.rectangle,
-//                       border: Border.all(width: 7.0, color: const Color.fromRGBO(0, 101, 144, 0.5)),
+//                       border: Border.all(width: 7.0, color: Theme.of(context).colorScheme.primary.withOpacity(0.5)),
 //                     ),
 //                   ),
 //                   const SizedBox(width: 20.0),
@@ -1955,7 +1954,7 @@ class _EndUserAppointmentsScreenState extends State<EndUserAppointmentsScreen> {
 //                           textStyle: Theme.of(context)
 //                               .textTheme
 //                               .titleSmall!
-//                               .copyWith(fontWeight: FontWeight.w500, fontSize: 15.0, color: OQDOThemeData.greyColor),
+//                               .copyWith(fontWeight: FontWeight.w500, fontSize: 15.0, color: Theme.of(context).colorScheme.onSurface),
 //                         ),
 //                         const SizedBox(
 //                           height: 8.0,
@@ -1965,7 +1964,7 @@ class _EndUserAppointmentsScreenState extends State<EndUserAppointmentsScreen> {
 //                           textStyle: Theme.of(context)
 //                               .textTheme
 //                               .titleSmall!
-//                               .copyWith(fontSize: 14.0, fontWeight: FontWeight.w400, color: OQDOThemeData.greyColor),
+//                               .copyWith(fontSize: 14.0, fontWeight: FontWeight.w400, color: Theme.of(context).colorScheme.onSurface),
 //                         )
 //                       ],
 //                     ),
@@ -1979,7 +1978,7 @@ class _EndUserAppointmentsScreenState extends State<EndUserAppointmentsScreen> {
 //                                 textStyle: Theme.of(context)
 //                                     .textTheme
 //                                     .titleSmall!
-//                                     .copyWith(fontSize: 14.0, fontWeight: FontWeight.w700, color: OQDOThemeData.errorColor),
+//                                     .copyWith(fontSize: 14.0, fontWeight: FontWeight.w700, color: Theme.of(context).colorScheme.error),
 //                               ),
 //                             )
 //                           : data[index].isPastSlot!
@@ -1993,7 +1992,7 @@ class _EndUserAppointmentsScreenState extends State<EndUserAppointmentsScreen> {
 //                                 textStyle: Theme.of(context)
 //                                     .textTheme
 //                                     .titleSmall!
-//                                     .copyWith(fontSize: 14.0, fontWeight: FontWeight.w700, color: OQDOThemeData.errorColor),
+//                                     .copyWith(fontSize: 14.0, fontWeight: FontWeight.w700, color: Theme.of(context).colorScheme.error),
 //                               ),
 //                             ):
 //                                   GestureDetector(
@@ -2062,7 +2061,7 @@ class _EndUserAppointmentsScreenState extends State<EndUserAppointmentsScreen> {
 //           CustomTextView(
 //             label: monthStr,
 //             textStyle:
-//                 Theme.of(context).textTheme.titleLarge!.copyWith(fontSize: 20, fontWeight: FontWeight.w500, color: const Color(0xFF333333)),
+//                 Theme.of(context).textTheme.titleLarge!.copyWith(fontSize: 20, fontWeight: FontWeight.w500, color: Theme.of(context).colorScheme.onSurface),
 //           ),
 //           const Spacer(),
 //           GestureDetector(
@@ -2115,13 +2114,13 @@ class _EndUserAppointmentsScreenState extends State<EndUserAppointmentsScreen> {
 //             headerVisible: false,
 //             daysOfWeekVisible: true,
 //             daysOfWeekStyle: const DaysOfWeekStyle(
-//                 weekdayStyle: TextStyle(color: Color(0xFF006590), fontWeight: FontWeight.w500),
-//                 weekendStyle: TextStyle(color: Color(0xFF006590), fontWeight: FontWeight.w500)),
+//                 weekdayStyle: TextStyle(color: Theme.of(context).colorScheme.primary, fontWeight: FontWeight.w500),
+//                 weekendStyle: TextStyle(color: Theme.of(context).colorScheme.primary, fontWeight: FontWeight.w500)),
 //             calendarStyle: CalendarStyle(
 //               isTodayHighlighted: false,
 //               outsideDaysVisible: false,
 //               selectedDecoration: BoxDecoration(color: Theme.of(context).colorScheme.primary, shape: BoxShape.circle),
-//               defaultTextStyle: const TextStyle(fontSize: 15, fontWeight: FontWeight.w400, color: Colors.black),
+//               defaultTextStyle: const TextStyle(fontSize: 15, fontWeight: FontWeight.w400, color: Theme.of(context).colorScheme.onBackground),
 //             ),
 //             onDaySelected: _onDaySelected,
 //             selectedDayPredicate: (DateTime date) {
@@ -2341,7 +2340,7 @@ class _EndUserAppointmentsScreenState extends State<EndUserAppointmentsScreen> {
 //     }
 
 //     return Container(
-//       color: OQDOThemeData.whiteColor,
+//       color: Theme.of(context).extension<CustomColors>()!.white,
 //       width: MediaQuery.of(context).size.width,
 //       height: MediaQuery.of(context).size.height / 1.2,
 //       child: SingleChildScrollView(
@@ -2361,7 +2360,7 @@ class _EndUserAppointmentsScreenState extends State<EndUserAppointmentsScreen> {
 //               textStyle: Theme.of(context)
 //                   .textTheme
 //                   .titleLarge!
-//                   .copyWith(fontSize: 21, color: const Color(0xFF333333), fontWeight: FontWeight.w500),
+//                   .copyWith(fontSize: 21, color: Theme.of(context).colorScheme.onSurface, fontWeight: FontWeight.w500),
 //             ),
 //             const SizedBox(
 //               height: 3,
@@ -2371,7 +2370,7 @@ class _EndUserAppointmentsScreenState extends State<EndUserAppointmentsScreen> {
 //               textStyle: Theme.of(context)
 //                   .textTheme
 //                   .titleLarge!
-//                   .copyWith(fontSize: 21, color: const Color(0xFF333333), fontWeight: FontWeight.w500),
+//                   .copyWith(fontSize: 21, color: Theme.of(context).colorScheme.onSurface, fontWeight: FontWeight.w500),
 //             ),
 //             Padding(
 //               padding: const EdgeInsets.only(top: 40, left: 25, right: 25),
@@ -2384,13 +2383,13 @@ class _EndUserAppointmentsScreenState extends State<EndUserAppointmentsScreen> {
 //                 daysOfWeekVisible: true,
 //                 currentDay: kToday,
 //                 daysOfWeekStyle: const DaysOfWeekStyle(
-//                     weekdayStyle: TextStyle(color: Color(0xFF006590), fontWeight: FontWeight.w500),
-//                     weekendStyle: TextStyle(color: Color(0xFF006590), fontWeight: FontWeight.w500)),
+//                     weekdayStyle: TextStyle(color: Theme.of(context).colorScheme.primary, fontWeight: FontWeight.w500),
+//                     weekendStyle: TextStyle(color: Theme.of(context).colorScheme.primary, fontWeight: FontWeight.w500)),
 //                 calendarStyle: CalendarStyle(
 //                   isTodayHighlighted: true,
 //                   outsideDaysVisible: false,
 //                   selectedDecoration: BoxDecoration(color: Theme.of(context).colorScheme.primary, shape: BoxShape.circle),
-//                   defaultTextStyle: const TextStyle(fontSize: 15, fontWeight: FontWeight.w400, color: Colors.black),
+//                   defaultTextStyle: const TextStyle(fontSize: 15, fontWeight: FontWeight.w400, color: Theme.of(context).colorScheme.onBackground),
 //                 ),
 //                 onCalendarCreated: (controller) {
 //                   _pageController = controller;
@@ -2450,7 +2449,7 @@ class _EndUserAppointmentsScreenState extends State<EndUserAppointmentsScreen> {
 //                 textStyle: Theme.of(context)
 //                     .textTheme
 //                     .titleLarge!
-//                     .copyWith(fontSize: 21, fontWeight: FontWeight.w700, color: const Color(0xFF333333)),
+//                     .copyWith(fontSize: 21, fontWeight: FontWeight.w700, color: Theme.of(context).colorScheme.onSurface),
 //               ),
 //               const SizedBox(
 //                 height: 5,
@@ -2460,7 +2459,7 @@ class _EndUserAppointmentsScreenState extends State<EndUserAppointmentsScreen> {
 //                 textStyle: Theme.of(context)
 //                     .textTheme
 //                     .titleLarge!
-//                     .copyWith(fontSize: 21, fontWeight: FontWeight.w700, color: const Color(0xFF333333)),
+//                     .copyWith(fontSize: 21, fontWeight: FontWeight.w700, color: Theme.of(context).colorScheme.onSurface),
 //               ),
 //             ],
 //           ),
@@ -2663,7 +2662,7 @@ class _EndUserAppointmentsScreenState extends State<EndUserAppointmentsScreen> {
 //                       textStyle: Theme.of(context)
 //                           .textTheme
 //                           .titleLarge!
-//                           .copyWith(fontSize: 20, color: OQDOThemeData.greyColor, fontWeight: FontWeight.w500),
+//                           .copyWith(fontSize: 20, color: Theme.of(context).colorScheme.onSurface, fontWeight: FontWeight.w500),
 //                     ),
 //                   ),
 //                 ),
@@ -2680,7 +2679,7 @@ class _EndUserAppointmentsScreenState extends State<EndUserAppointmentsScreen> {
 //                         textStyle: Theme.of(context)
 //                             .textTheme
 //                             .titleSmall!
-//                             .copyWith(color: OQDOThemeData.otherTextColor, fontWeight: FontWeight.w600, fontSize: 12.0),
+//                             .copyWith(color: Theme.of(context).extension<CustomColors>()!.greyText, fontWeight: FontWeight.w600, fontSize: 12.0),
 //                       ),
 //                     ],
 //                   ),
@@ -2695,7 +2694,7 @@ class _EndUserAppointmentsScreenState extends State<EndUserAppointmentsScreen> {
 //                     textStyle: Theme.of(context)
 //                         .textTheme
 //                         .titleMedium!
-//                         .copyWith(fontSize: 14, color: const Color(0xFF818181), fontWeight: FontWeight.w400),
+//                         .copyWith(fontSize: 14, color: Theme.of(context).extension<CustomColors>()!.greyText, fontWeight: FontWeight.w400),
 //                   ),
 //                 ),
 //                 const SizedBox(
@@ -2708,7 +2707,7 @@ class _EndUserAppointmentsScreenState extends State<EndUserAppointmentsScreen> {
 //                     textStyle: Theme.of(context)
 //                         .textTheme
 //                         .titleMedium!
-//                         .copyWith(fontSize: 14, color: const Color(0xFF818181), fontWeight: FontWeight.w400),
+//                         .copyWith(fontSize: 14, color: Theme.of(context).extension<CustomColors>()!.greyText, fontWeight: FontWeight.w400),
 //                   ),
 //                 ),
 //                 const SizedBox(
@@ -2721,7 +2720,7 @@ class _EndUserAppointmentsScreenState extends State<EndUserAppointmentsScreen> {
 //                     textStyle: Theme.of(context)
 //                         .textTheme
 //                         .titleMedium!
-//                         .copyWith(fontSize: 14, color: const Color(0xFF818181), fontWeight: FontWeight.w400),
+//                         .copyWith(fontSize: 14, color: Theme.of(context).extension<CustomColors>()!.greyText, fontWeight: FontWeight.w400),
 //                   ),
 //                 ),
 //                 const SizedBox(
@@ -2734,7 +2733,7 @@ class _EndUserAppointmentsScreenState extends State<EndUserAppointmentsScreen> {
 //                     textStyle: Theme.of(context)
 //                         .textTheme
 //                         .titleMedium!
-//                         .copyWith(fontSize: 14, color: const Color(0xFF818181), fontWeight: FontWeight.w400),
+//                         .copyWith(fontSize: 14, color: Theme.of(context).extension<CustomColors>()!.greyText, fontWeight: FontWeight.w400),
 //                   ),
 //                 ),
 //                 const SizedBox(
@@ -2747,7 +2746,7 @@ class _EndUserAppointmentsScreenState extends State<EndUserAppointmentsScreen> {
 //                     textStyle: Theme.of(context)
 //                         .textTheme
 //                         .titleMedium!
-//                         .copyWith(fontSize: 14, color: const Color(0xFF818181), fontWeight: FontWeight.w400),
+//                         .copyWith(fontSize: 14, color: Theme.of(context).extension<CustomColors>()!.greyText, fontWeight: FontWeight.w400),
 //                   ),
 //                 ),
 //                 const SizedBox(
@@ -2755,7 +2754,7 @@ class _EndUserAppointmentsScreenState extends State<EndUserAppointmentsScreen> {
 //                 ),
 //                 const Divider(
 //                   height: 1,
-//                   color: Color(0xFFCACACA),
+//                   color: Theme.of(context).colorScheme.outline,
 //                 ),
 //                 const SizedBox(
 //                   height: 20.0,
@@ -2767,7 +2766,7 @@ class _EndUserAppointmentsScreenState extends State<EndUserAppointmentsScreen> {
 //                     textStyle: Theme.of(context)
 //                         .textTheme
 //                         .bodyMedium!
-//                         .copyWith(fontSize: 15, fontWeight: FontWeight.w400, color: OQDOThemeData.greyColor),
+//                         .copyWith(fontSize: 15, fontWeight: FontWeight.w400, color: Theme.of(context).colorScheme.onSurface),
 //                   ),
 //                 ),
 //                 const SizedBox(
@@ -2796,7 +2795,7 @@ class _EndUserAppointmentsScreenState extends State<EndUserAppointmentsScreen> {
 //                       textStyle: Theme.of(context)
 //                           .textTheme
 //                           .bodyMedium!
-//                           .copyWith(fontSize: 15, fontWeight: FontWeight.w400, color: OQDOThemeData.greyColor),
+//                           .copyWith(fontSize: 15, fontWeight: FontWeight.w400, color: Theme.of(context).colorScheme.onSurface),
 //                     ),
 //                   ],
 //                 ),
@@ -2897,7 +2896,7 @@ class _EndUserAppointmentsScreenState extends State<EndUserAppointmentsScreen> {
 //                       textStyle: Theme.of(context)
 //                           .textTheme
 //                           .titleLarge!
-//                           .copyWith(fontSize: 20, color: OQDOThemeData.greyColor, fontWeight: FontWeight.w500),
+//                           .copyWith(fontSize: 20, color: Theme.of(context).colorScheme.onSurface, fontWeight: FontWeight.w500),
 //                     ),
 //                   ),
 //                 ),
@@ -2914,7 +2913,7 @@ class _EndUserAppointmentsScreenState extends State<EndUserAppointmentsScreen> {
 //                         textStyle: Theme.of(context)
 //                             .textTheme
 //                             .titleSmall!
-//                             .copyWith(color: OQDOThemeData.otherTextColor, fontWeight: FontWeight.w600, fontSize: 12.0),
+//                             .copyWith(color: Theme.of(context).extension<CustomColors>()!.greyText, fontWeight: FontWeight.w600, fontSize: 12.0),
 //                       ),
 //                     ],
 //                   ),
@@ -2929,7 +2928,7 @@ class _EndUserAppointmentsScreenState extends State<EndUserAppointmentsScreen> {
 //                     textStyle: Theme.of(context)
 //                         .textTheme
 //                         .titleMedium!
-//                         .copyWith(fontSize: 14, color: const Color(0xFF818181), fontWeight: FontWeight.w400),
+//                         .copyWith(fontSize: 14, color: Theme.of(context).extension<CustomColors>()!.greyText, fontWeight: FontWeight.w400),
 //                   ),
 //                 ),
 //                 const SizedBox(
@@ -2943,7 +2942,7 @@ class _EndUserAppointmentsScreenState extends State<EndUserAppointmentsScreen> {
 //                     textStyle: Theme.of(context)
 //                         .textTheme
 //                         .titleMedium!
-//                         .copyWith(fontSize: 14, color: const Color(0xFF818181), fontWeight: FontWeight.w400),
+//                         .copyWith(fontSize: 14, color: Theme.of(context).extension<CustomColors>()!.greyText, fontWeight: FontWeight.w400),
 //                   ),
 //                 ),
 //                 const SizedBox(
@@ -2956,7 +2955,7 @@ class _EndUserAppointmentsScreenState extends State<EndUserAppointmentsScreen> {
 //                     textStyle: Theme.of(context)
 //                         .textTheme
 //                         .titleMedium!
-//                         .copyWith(fontSize: 14, color: const Color(0xFF818181), fontWeight: FontWeight.w400),
+//                         .copyWith(fontSize: 14, color: Theme.of(context).extension<CustomColors>()!.greyText, fontWeight: FontWeight.w400),
 //                   ),
 //                 ),
 //                 const SizedBox(
@@ -2969,7 +2968,7 @@ class _EndUserAppointmentsScreenState extends State<EndUserAppointmentsScreen> {
 //                     textStyle: Theme.of(context)
 //                         .textTheme
 //                         .titleMedium!
-//                         .copyWith(fontSize: 14, color: const Color(0xFF818181), fontWeight: FontWeight.w400),
+//                         .copyWith(fontSize: 14, color: Theme.of(context).extension<CustomColors>()!.greyText, fontWeight: FontWeight.w400),
 //                   ),
 //                 ),
 //                 const SizedBox(
@@ -2982,7 +2981,7 @@ class _EndUserAppointmentsScreenState extends State<EndUserAppointmentsScreen> {
 //                     textStyle: Theme.of(context)
 //                         .textTheme
 //                         .titleMedium!
-//                         .copyWith(fontSize: 14, color: const Color(0xFF818181), fontWeight: FontWeight.w400),
+//                         .copyWith(fontSize: 14, color: Theme.of(context).extension<CustomColors>()!.greyText, fontWeight: FontWeight.w400),
 //                   ),
 //                 ),
 //                 const SizedBox(
@@ -2997,7 +2996,7 @@ class _EndUserAppointmentsScreenState extends State<EndUserAppointmentsScreen> {
 //                     textStyle: Theme.of(context)
 //                         .textTheme
 //                         .titleMedium!
-//                         .copyWith(fontSize: 14, color: const Color(0xFF818181), fontWeight: FontWeight.w400),
+//                         .copyWith(fontSize: 14, color: Theme.of(context).extension<CustomColors>()!.greyText, fontWeight: FontWeight.w400),
 //                   ),
 //                 ),
 //                 const SizedBox(
@@ -3005,7 +3004,7 @@ class _EndUserAppointmentsScreenState extends State<EndUserAppointmentsScreen> {
 //                 ),
 //                 const Divider(
 //                   height: 1,
-//                   color: Color(0xFFCACACA),
+//                   color: Theme.of(context).colorScheme.outline,
 //                 ),
 //                 const SizedBox(
 //                   height: 20.0,
@@ -3017,7 +3016,7 @@ class _EndUserAppointmentsScreenState extends State<EndUserAppointmentsScreen> {
 //                     textStyle: Theme.of(context)
 //                         .textTheme
 //                         .bodyMedium!
-//                         .copyWith(fontSize: 15, fontWeight: FontWeight.w400, color: OQDOThemeData.greyColor),
+//                         .copyWith(fontSize: 15, fontWeight: FontWeight.w400, color: Theme.of(context).colorScheme.onSurface),
 //                   ),
 //                 ),
 //                 const SizedBox(
@@ -3046,7 +3045,7 @@ class _EndUserAppointmentsScreenState extends State<EndUserAppointmentsScreen> {
 //                       textStyle: Theme.of(context)
 //                           .textTheme
 //                           .bodyMedium!
-//                           .copyWith(fontSize: 15, fontWeight: FontWeight.w400, color: OQDOThemeData.greyColor),
+//                           .copyWith(fontSize: 15, fontWeight: FontWeight.w400, color: Theme.of(context).colorScheme.onSurface),
 //                     ),
 //                   ],
 //                 ),

--- a/lib/screens/appointment/facility_appointment_details_screen.dart
+++ b/lib/screens/appointment/facility_appointment_details_screen.dart
@@ -7,7 +7,6 @@ import 'package:oqdo_mobile_app/theme/custom_colors.dart';
 import 'package:intl/intl.dart';
 import 'package:oqdo_mobile_app/components/custom_app_bar.dart';
 import 'package:oqdo_mobile_app/model/facility_appointment_details_model.dart';
-import 'package:oqdo_mobile_app/theme/oqdo_theme_data.dart';
 import 'package:oqdo_mobile_app/utils/constants.dart';
 import 'package:oqdo_mobile_app/utils/custom_text_view.dart';
 import 'package:oqdo_mobile_app/utils/network_interceptor.dart';
@@ -117,7 +116,7 @@ class _FacilityAppointmentDetailsScreenState extends State<FacilityAppointmentDe
                         child: CustomTextView(
                           label: 'Name: ${_facilityAppointmentDetailModel!.endUserFirstName} ${_facilityAppointmentDetailModel!.endUserLastName}',
                           textStyle:
-                              Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 14, color: const Color(0xFF818181), fontWeight: FontWeight.w400),
+                              Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 14, color: Theme.of(context).extension<CustomColors>()!.greyText, fontWeight: FontWeight.w400),
                         ),
                       ),
                       const SizedBox(
@@ -128,7 +127,7 @@ class _FacilityAppointmentDetailsScreenState extends State<FacilityAppointmentDe
                         child: CustomTextView(
                           label: 'Email ID: ${_facilityAppointmentDetailModel!.endUserEmail}',
                           textStyle:
-                              Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 14, color: const Color(0xFF818181), fontWeight: FontWeight.w400),
+                              Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 14, color: Theme.of(context).extension<CustomColors>()!.greyText, fontWeight: FontWeight.w400),
                         ),
                       ),
                       const SizedBox(
@@ -139,7 +138,7 @@ class _FacilityAppointmentDetailsScreenState extends State<FacilityAppointmentDe
                         child: CustomTextView(
                           label: 'Phone number: ${_facilityAppointmentDetailModel!.endUserMobileNumber}',
                           textStyle:
-                              Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 14, color: const Color(0xFF818181), fontWeight: FontWeight.w400),
+                              Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 14, color: Theme.of(context).extension<CustomColors>()!.greyText, fontWeight: FontWeight.w400),
                         ),
                       ),
                       const SizedBox(
@@ -150,7 +149,7 @@ class _FacilityAppointmentDetailsScreenState extends State<FacilityAppointmentDe
                         child: CustomTextView(
                           label: _facilityAppointmentDetailModel!.bookingType == 'I' ? 'Booking For: Individual' : 'Booking For: Group',
                           textStyle:
-                              Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 14, color: const Color(0xFF818181), fontWeight: FontWeight.w400),
+                              Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 14, color: Theme.of(context).extension<CustomColors>()!.greyText, fontWeight: FontWeight.w400),
                         ),
                       ),
                       const SizedBox(
@@ -163,7 +162,7 @@ class _FacilityAppointmentDetailsScreenState extends State<FacilityAppointmentDe
                           maxLine: 3,
                           textOverFlow: TextOverflow.ellipsis,
                           textStyle:
-                              Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 14, color: const Color(0xFF818181), fontWeight: FontWeight.w400),
+                              Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 14, color: Theme.of(context).extension<CustomColors>()!.greyText, fontWeight: FontWeight.w400),
                         ),
                       ),
                       const SizedBox(
@@ -178,14 +177,14 @@ class _FacilityAppointmentDetailsScreenState extends State<FacilityAppointmentDe
                               maxLine: 3,
                               textOverFlow: TextOverflow.ellipsis,
                               textStyle:
-                                  Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 14, color: const Color(0xFF818181), fontWeight: FontWeight.w600),
+                                  Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 14, color: Theme.of(context).extension<CustomColors>()!.greyText, fontWeight: FontWeight.w600),
                             ),
                             CustomTextView(
                               label: '${_facilityAppointmentDetailModel!.bookingNo}',
                               maxLine: 3,
                               textOverFlow: TextOverflow.ellipsis,
                               textStyle:
-                                  Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 14, color: const Color(0xFF818181), fontWeight: FontWeight.w400),
+                                  Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 14, color: Theme.of(context).extension<CustomColors>()!.greyText, fontWeight: FontWeight.w400),
                             ),
                           ],
                         ),
@@ -227,7 +226,7 @@ class _FacilityAppointmentDetailsScreenState extends State<FacilityAppointmentDe
         //   textStyle: Theme.of(context)
         //       .textTheme
         //       .titleMedium!
-        //       .copyWith(fontWeight: FontWeight.w600, color: OQDOThemeData.greyColor, fontSize: 18.0),
+        //       .copyWith(fontWeight: FontWeight.w600, color: Theme.of(context).colorScheme.onSurface, fontSize: 18.0),
         // ),
         // const SizedBox(
         //   height: 10.0,
@@ -235,7 +234,7 @@ class _FacilityAppointmentDetailsScreenState extends State<FacilityAppointmentDe
         // CustomTextView(
         //   label: 'Order ID: ${_facilityAppointmentDetailModel!.bookingNo}',
         //   textStyle:
-        //       Theme.of(context).textTheme.bodySmall!.copyWith(fontWeight: FontWeight.w500, color: OQDOThemeData.greyColor, fontSize: 18.0),
+        //       Theme.of(context).textTheme.bodySmall!.copyWith(fontWeight: FontWeight.w500, color: Theme.of(context).colorScheme.onSurface, fontSize: 18.0),
         // ),
         // const SizedBox(
         //   height: 12.0,
@@ -248,14 +247,14 @@ class _FacilityAppointmentDetailsScreenState extends State<FacilityAppointmentDe
         //       textStyle: Theme.of(context)
         //           .textTheme
         //           .titleMedium!
-        //           .copyWith(fontWeight: FontWeight.w600, color: OQDOThemeData.greyColor, fontSize: 18.0),
+        //           .copyWith(fontWeight: FontWeight.w600, color: Theme.of(context).colorScheme.onSurface, fontSize: 18.0),
         //     ),
         //     CustomTextView(
         //       label: 'S\$ ${_facilityAppointmentDetailModel!.totalAmt}',
         //       textStyle: Theme.of(context)
         //           .textTheme
         //           .titleMedium!
-        //           .copyWith(fontWeight: FontWeight.w400, color: OQDOThemeData.greyColor, fontSize: 18.0),
+        //           .copyWith(fontWeight: FontWeight.w400, color: Theme.of(context).colorScheme.onSurface, fontSize: 18.0),
         //     ),
         //   ],
         // ),
@@ -286,7 +285,7 @@ class _FacilityAppointmentDetailsScreenState extends State<FacilityAppointmentDe
                   CustomTextView(
                     label:
                         '${convertDateToString(_facilityAppointmentDetailModel!.facilityBookingSlotDates![index].bookingDate!).split(',')[1].split(' ')[2]} ${convertDateToString(_facilityAppointmentDetailModel!.facilityBookingSlotDates![index].bookingDate!).split(',')[1].split(' ')[1]} - ${convertDateToString(_facilityAppointmentDetailModel!.facilityBookingSlotDates![index].bookingDate!).split(',')[0]}',
-                    textStyle: Theme.of(context).textTheme.titleLarge!.copyWith(fontSize: 20.0, color: OQDOThemeData.greyColor, fontWeight: FontWeight.w500),
+                    textStyle: Theme.of(context).textTheme.titleLarge!.copyWith(fontSize: 20.0, color: Theme.of(context).colorScheme.onSurface, fontWeight: FontWeight.w500),
                   ),
                   const SizedBox(
                     height: 5.0,
@@ -299,7 +298,7 @@ class _FacilityAppointmentDetailsScreenState extends State<FacilityAppointmentDe
                         label:
                             '${_facilityAppointmentDetailModel!.facilityBookingSlotDates![index].startTime}-${_facilityAppointmentDetailModel!.facilityBookingSlotDates![index].endTime}',
                         textStyle:
-                            Theme.of(context).textTheme.titleLarge!.copyWith(fontSize: 16.0, color: OQDOThemeData.greyColor, fontWeight: FontWeight.w500),
+                            Theme.of(context).textTheme.titleLarge!.copyWith(fontSize: 16.0, color: Theme.of(context).colorScheme.onSurface, fontWeight: FontWeight.w500),
                       ),
                       const SizedBox(
                         width: 15,
@@ -307,7 +306,7 @@ class _FacilityAppointmentDetailsScreenState extends State<FacilityAppointmentDe
                       CustomTextView(
                         label: 'S\$ ${_facilityAppointmentDetailModel!.facilityBookingSlotDates![index].ratePerHour}/hour',
                         textStyle:
-                            Theme.of(context).textTheme.titleLarge!.copyWith(fontSize: 16.0, color: OQDOThemeData.greyColor, fontWeight: FontWeight.w500),
+                            Theme.of(context).textTheme.titleLarge!.copyWith(fontSize: 16.0, color: Theme.of(context).colorScheme.onSurface, fontWeight: FontWeight.w500),
                       ),
                     ],
                   ),
@@ -322,7 +321,7 @@ class _FacilityAppointmentDetailsScreenState extends State<FacilityAppointmentDe
                       ? CustomTextView(
                           label: 'Cancelled',
                           textStyle:
-                              Theme.of(context).textTheme.titleLarge!.copyWith(fontSize: 14.0, color: OQDOThemeData.errorColor, fontWeight: FontWeight.w500),
+                              Theme.of(context).textTheme.titleLarge!.copyWith(fontSize: 14.0, color: Theme.of(context).colorScheme.error, fontWeight: FontWeight.w500),
                         )
                       : const SizedBox(),
                   const SizedBox(
@@ -330,7 +329,7 @@ class _FacilityAppointmentDetailsScreenState extends State<FacilityAppointmentDe
                   ),
                   CustomTextView(
                     label: 'S\$ ${finalAmount.toStringAsFixed(2)}',
-                    textStyle: Theme.of(context).textTheme.titleLarge!.copyWith(fontSize: 20.0, color: OQDOThemeData.greyColor, fontWeight: FontWeight.w500),
+                    textStyle: Theme.of(context).textTheme.titleLarge!.copyWith(fontSize: 20.0, color: Theme.of(context).colorScheme.onSurface, fontWeight: FontWeight.w500),
                   ),
                 ],
               ),
@@ -338,7 +337,7 @@ class _FacilityAppointmentDetailsScreenState extends State<FacilityAppointmentDe
           ),
           const Divider(
             thickness: 1.0,
-            color: Color(0xFFEFEFEF),
+            color: Theme.of(context).extension<CustomColors>()!.greyButton,
           ),
         ],
       ),
@@ -355,8 +354,8 @@ class _FacilityAppointmentDetailsScreenState extends State<FacilityAppointmentDe
   Widget _paymentSummaryView() {
     return Container(
       decoration: BoxDecoration(
-        color: OQDOThemeData.whiteColor,
-        border: Border.all(color: OQDOThemeData.otherTextColor),
+        color: Theme.of(context).extension<CustomColors>()!.white,
+        border: Border.all(color: Theme.of(context).extension<CustomColors>()!.greyText),
       ),
       padding: const EdgeInsets.all(8.0),
       child: Column(
@@ -367,7 +366,7 @@ class _FacilityAppointmentDetailsScreenState extends State<FacilityAppointmentDe
             textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(
                   fontSize: 16.0,
                   fontWeight: FontWeight.w600,
-                  color: OQDOThemeData.buttonColor,
+                  color: Theme.of(context).colorScheme.primary,
                 ),
           ),
           const SizedBox(
@@ -386,13 +385,13 @@ class _FacilityAppointmentDetailsScreenState extends State<FacilityAppointmentDe
             children: [
               CustomTextView(
                 label: "Total Amount : ",
-                textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 16.0, fontWeight: FontWeight.w600, color: OQDOThemeData.blackColor),
+                textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 16.0, fontWeight: FontWeight.w600, color: Theme.of(context).colorScheme.onBackground),
               ),
               Column(
                 children: [
                   CustomTextView(
                     label: 'S\$ ${totalAmount.toStringAsFixed(2)}',
-                    textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 14.0, fontWeight: FontWeight.w600, color: OQDOThemeData.blackColor),
+                    textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 14.0, fontWeight: FontWeight.w600, color: Theme.of(context).colorScheme.onBackground),
                   ),
                 ],
               ),
@@ -416,7 +415,7 @@ class _FacilityAppointmentDetailsScreenState extends State<FacilityAppointmentDe
                 children: [
                   CustomTextView(
                     label: title,
-                    textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 14.0, fontWeight: FontWeight.w600, color: OQDOThemeData.blackColor),
+                    textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 14.0, fontWeight: FontWeight.w600, color: Theme.of(context).colorScheme.onBackground),
                   ),
                   const SizedBox(
                     height: 3,
@@ -424,7 +423,7 @@ class _FacilityAppointmentDetailsScreenState extends State<FacilityAppointmentDe
                   CustomTextView(
                     label: details,
                     maxLine: 2,
-                    textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 12.0, fontWeight: FontWeight.w500, color: OQDOThemeData.greyColor),
+                    textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 12.0, fontWeight: FontWeight.w500, color: Theme.of(context).colorScheme.onSurface),
                   ),
                 ],
               ),
@@ -439,7 +438,7 @@ class _FacilityAppointmentDetailsScreenState extends State<FacilityAppointmentDe
                     label: 'S\$ $rate',
                     maxLine: 2,
                     textOverFlow: TextOverflow.ellipsis,
-                    textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 13.0, fontWeight: FontWeight.w600, color: OQDOThemeData.blackColor),
+                    textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 13.0, fontWeight: FontWeight.w600, color: Theme.of(context).colorScheme.onBackground),
                   ),
                 ],
               ),
@@ -450,7 +449,7 @@ class _FacilityAppointmentDetailsScreenState extends State<FacilityAppointmentDe
           height: 3,
         ),
         const Divider(
-          color: OQDOThemeData.greyColor,
+          color: Theme.of(context).colorScheme.onSurface,
         ),
       ],
     );
@@ -467,7 +466,7 @@ class _FacilityAppointmentDetailsScreenState extends State<FacilityAppointmentDe
   //             children: [
   //               CustomTextView(
   //                 label: title,
-  //                 textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 14.0, fontWeight: FontWeight.w600, color: OQDOThemeData.blackColor),
+  //                 textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 14.0, fontWeight: FontWeight.w600, color: Theme.of(context).colorScheme.onBackground),
   //               ),
   //               const SizedBox(
   //                 height: 3,
@@ -475,7 +474,7 @@ class _FacilityAppointmentDetailsScreenState extends State<FacilityAppointmentDe
   //               CustomTextView(
   //                 label: details,
   //                 maxLine: 2,
-  //                 textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 12.0, fontWeight: FontWeight.w500, color: OQDOThemeData.greyColor),
+  //                 textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 12.0, fontWeight: FontWeight.w500, color: Theme.of(context).colorScheme.onSurface),
   //               ),
   //             ],
   //           ),
@@ -483,7 +482,7 @@ class _FacilityAppointmentDetailsScreenState extends State<FacilityAppointmentDe
   //             children: [
   //               CustomTextView(
   //                 label: 'S\$ $rate',
-  //                 textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 13.0, fontWeight: FontWeight.w600, color: OQDOThemeData.blackColor),
+  //                 textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 13.0, fontWeight: FontWeight.w600, color: Theme.of(context).colorScheme.onBackground),
   //               ),
   //             ],
   //           ),
@@ -493,7 +492,7 @@ class _FacilityAppointmentDetailsScreenState extends State<FacilityAppointmentDe
   //         height: 3,
   //       ),
   //       const Divider(
-  //         color: OQDOThemeData.greyColor,
+  //         color: Theme.of(context).colorScheme.onSurface,
   //       ),
   //     ],
   //   );
@@ -514,7 +513,7 @@ class _FacilityAppointmentDetailsScreenState extends State<FacilityAppointmentDe
               Container(
                 decoration: BoxDecoration(
                   shape: BoxShape.rectangle,
-                  border: Border.all(width: 7.0, color: const Color.fromRGBO(0, 101, 144, 0.5)),
+                  border: Border.all(width: 7.0, color: Theme.of(context).colorScheme.primary.withOpacity(0.5)),
                 ),
               ),
               const SizedBox(
@@ -526,7 +525,7 @@ class _FacilityAppointmentDetailsScreenState extends State<FacilityAppointmentDe
                 children: [
                   // CustomTextView(
                   //   label: '${_facilityAppointmentDetailModel!.facilityName}',
-                  //   textStyle: Theme.of(context).textTheme.titleSmall!.copyWith(fontWeight: FontWeight.w500, fontSize: 18.0, color: OQDOThemeData.greyColor),
+                  //   textStyle: Theme.of(context).textTheme.titleSmall!.copyWith(fontWeight: FontWeight.w500, fontSize: 18.0, color: Theme.of(context).colorScheme.onSurface),
                   // ),
                   // const SizedBox(
                   //   height: 8.0,
@@ -535,14 +534,14 @@ class _FacilityAppointmentDetailsScreenState extends State<FacilityAppointmentDe
                     label: '${_facilityAppointmentDetailModel!.facilitySetupTitle!.trim()}\n${_facilityAppointmentDetailModel!.facilitySetupSubTitle!.trim()}',
                     maxLine: 3,
                     textOverFlow: TextOverflow.ellipsis,
-                    textStyle: Theme.of(context).textTheme.titleSmall!.copyWith(fontWeight: FontWeight.w500, fontSize: 16.0, color: OQDOThemeData.greyColor),
+                    textStyle: Theme.of(context).textTheme.titleSmall!.copyWith(fontWeight: FontWeight.w500, fontSize: 16.0, color: Theme.of(context).colorScheme.onSurface),
                   ),
                   const SizedBox(
                     height: 8.0,
                   ),
                   CustomTextView(
                     label: '${_facilityAppointmentDetailModel!.activityName} - ${_facilityAppointmentDetailModel!.subActivityName}',
-                    textStyle: Theme.of(context).textTheme.titleSmall!.copyWith(fontSize: 14.0, fontWeight: FontWeight.w400, color: OQDOThemeData.greyColor),
+                    textStyle: Theme.of(context).textTheme.titleSmall!.copyWith(fontSize: 14.0, fontWeight: FontWeight.w400, color: Theme.of(context).colorScheme.onSurface),
                   )
                 ],
               )
@@ -568,7 +567,7 @@ class _FacilityAppointmentDetailsScreenState extends State<FacilityAppointmentDe
   //             Container(
   //               decoration: BoxDecoration(
   //                 shape: BoxShape.rectangle,
-  //                 border: Border.all(width: 7.0, color: const Color.fromRGBO(0, 101, 144, 0.5)),
+  //                 border: Border.all(width: 7.0, color: Theme.of(context).colorScheme.primary.withOpacity(0.5)),
   //               ),
   //             ),
   //             const SizedBox(width: 20.0),
@@ -582,7 +581,7 @@ class _FacilityAppointmentDetailsScreenState extends State<FacilityAppointmentDe
   //                   textStyle: Theme.of(context)
   //                       .textTheme
   //                       .titleSmall!
-  //                       .copyWith(fontWeight: FontWeight.w500, fontSize: 16.0, color: OQDOThemeData.greyColor),
+  //                       .copyWith(fontWeight: FontWeight.w500, fontSize: 16.0, color: Theme.of(context).colorScheme.onSurface),
   //                 ),
   //                 const SizedBox(
   //                   height: 8.0,
@@ -594,7 +593,7 @@ class _FacilityAppointmentDetailsScreenState extends State<FacilityAppointmentDe
   //                   textStyle: Theme.of(context)
   //                       .textTheme
   //                       .titleMedium!
-  //                       .copyWith(fontSize: 12, color: OQDOThemeData.greyColor, fontWeight: FontWeight.w400),
+  //                       .copyWith(fontSize: 12, color: Theme.of(context).colorScheme.onSurface, fontWeight: FontWeight.w400),
   //                 ),
   //                 const SizedBox(
   //                   height: 5,
@@ -606,7 +605,7 @@ class _FacilityAppointmentDetailsScreenState extends State<FacilityAppointmentDe
   //                   textStyle: Theme.of(context)
   //                       .textTheme
   //                       .titleMedium!
-  //                       .copyWith(fontSize: 12, color: OQDOThemeData.greyColor, fontWeight: FontWeight.w400),
+  //                       .copyWith(fontSize: 12, color: Theme.of(context).colorScheme.onSurface, fontWeight: FontWeight.w400),
   //                 ),
   //               ],
   //             ),
@@ -618,7 +617,7 @@ class _FacilityAppointmentDetailsScreenState extends State<FacilityAppointmentDe
   //                 textStyle: Theme.of(context)
   //                     .textTheme
   //                     .bodySmall!
-  //                     .copyWith(fontWeight: FontWeight.w500, color: OQDOThemeData.greyColor, fontSize: 15.0),
+  //                     .copyWith(fontWeight: FontWeight.w500, color: Theme.of(context).colorScheme.onSurface, fontSize: 15.0),
   //               ),
   //             ),
   //           ],
@@ -715,7 +714,7 @@ class _FacilityAppointmentDetailsScreenState extends State<FacilityAppointmentDe
               padding: const EdgeInsets.only(left: 20.0),
               child: CustomTextView(
                 label: 'Transaction History',
-                textStyle: Theme.of(context).textTheme.titleLarge!.copyWith(fontSize: 20, color: OQDOThemeData.blackColor, fontWeight: FontWeight.w500),
+                textStyle: Theme.of(context).textTheme.titleLarge!.copyWith(fontSize: 20, color: Theme.of(context).colorScheme.onBackground, fontWeight: FontWeight.w500),
               ),
             ),
           ),
@@ -900,7 +899,7 @@ class _FacilityAppointmentDetailsScreenState extends State<FacilityAppointmentDe
                                   color: paymentTransaction[index].status == 'A'
                                       ? Theme.of(context).extension<CustomColors>()!.greenAmount
                                       : paymentTransaction[index].status == 'P'
-                                          ? Colors.yellow
+                                          ? Theme.of(context).extension<CustomColors>()!.yellowStatus
                                           : Theme.of(context).extension<CustomColors>()!.redAmount,
                                   fontWeight: FontWeight.w500),
                               overflow: TextOverflow.ellipsis,
@@ -1086,7 +1085,7 @@ class _FacilityAppointmentDetailsScreenState extends State<FacilityAppointmentDe
                 //                   color: paymentTransaction[index].status == 'A'
                 //                       ? Theme.of(context).extension<CustomColors>()!.greenAmount
                 //                       : paymentTransaction[index].status == 'P'
-                //                           ? Colors.yellow
+                //                           ? Theme.of(context).extension<CustomColors>()!.yellowStatus
                 //                           : Theme.of(context).extension<CustomColors>()!.redAmount,
                 //                   fontWeight: FontWeight.w500),
                 //               overflow: TextOverflow.ellipsis,

--- a/lib/screens/appointment/facility_appointment_screen.dart
+++ b/lib/screens/appointment/facility_appointment_screen.dart
@@ -3,12 +3,12 @@
 import 'dart:convert';
 
 import 'package:flutter/material.dart';
+import 'package:oqdo_mobile_app/theme/custom_colors.dart';
 import 'package:intl/intl.dart';
 import 'package:oqdo_mobile_app/components/custom_app_bar.dart';
 import 'package:oqdo_mobile_app/components/my_button.dart';
 import 'package:oqdo_mobile_app/model/facility_appointment_resopnse_model.dart';
 import 'package:oqdo_mobile_app/oqdo_application.dart';
-import 'package:oqdo_mobile_app/theme/oqdo_theme_data.dart';
 import 'package:oqdo_mobile_app/utils/constants.dart';
 import 'package:oqdo_mobile_app/utils/custom_text_view.dart';
 import 'package:oqdo_mobile_app/utils/network_interceptor.dart';
@@ -90,7 +90,7 @@ class _FacilityAppointmentsScreenState extends State<FacilityAppointmentsScreen>
           }),
       body: SafeArea(
         child: Container(
-          color: OQDOThemeData.whiteColor,
+          color: Theme.of(context).extension<CustomColors>()!.white,
           width: MediaQuery.of(context).size.width,
           height: double.infinity,
           child: _endUserAppointmentResponseList.isNotEmpty
@@ -122,15 +122,15 @@ class _FacilityAppointmentsScreenState extends State<FacilityAppointmentsScreen>
                                 child: Container(
                                   padding: const EdgeInsets.all(8),
                                   decoration: BoxDecoration(
-                                      color: const Color(0xFF006590),
-                                      border: Border.all(color: OQDOThemeData.dividerColor),
+                                      color: Theme.of(context).colorScheme.primary,
+                                      border: Border.all(color: Theme.of(context).colorScheme.primary),
                                       borderRadius: const BorderRadius.all(Radius.circular(10))),
                                   child: CustomTextView(
                                     label: _endUserAppointmentResponseList[index].date!.split('T')[0],
                                     textStyle: Theme.of(context)
                                         .textTheme
                                         .bodyMedium!
-                                        .copyWith(color: OQDOThemeData.whiteColor, fontSize: 18, fontWeight: FontWeight.w500),
+                                        .copyWith(color: Theme.of(context).extension<CustomColors>()!.white, fontSize: 18, fontWeight: FontWeight.w500),
                                   ),
                                 ),
                               ),
@@ -166,7 +166,7 @@ class _FacilityAppointmentsScreenState extends State<FacilityAppointmentsScreen>
                                               Container(
                                                 decoration: BoxDecoration(
                                                   shape: BoxShape.rectangle,
-                                                  border: Border.all(width: 7.0, color: const Color.fromRGBO(0, 101, 144, 0.5)),
+                                                  border: Border.all(width: 7.0, color: Theme.of(context).colorScheme.primary.withOpacity(0.5)),
                                                 ),
                                               ),
                                               const SizedBox(width: 20.0),
@@ -175,7 +175,7 @@ class _FacilityAppointmentsScreenState extends State<FacilityAppointmentsScreen>
                                                 textStyle: Theme.of(context)
                                                     .textTheme
                                                     .titleLarge!
-                                                    .copyWith(fontWeight: FontWeight.w500, fontSize: 20.0, color: OQDOThemeData.greyColor),
+                                                    .copyWith(fontWeight: FontWeight.w500, fontSize: 20.0, color: Theme.of(context).colorScheme.onSurface),
                                               ),
                                             ],
                                           ),
@@ -217,7 +217,7 @@ class _FacilityAppointmentsScreenState extends State<FacilityAppointmentsScreen>
                   Container(
                     decoration: BoxDecoration(
                       shape: BoxShape.rectangle,
-                      border: Border.all(width: 7.0, color: const Color.fromRGBO(0, 101, 144, 0.5)),
+                      border: Border.all(width: 7.0, color: Theme.of(context).colorScheme.primary.withOpacity(0.5)),
                     ),
                   ),
                   const SizedBox(width: 20.0),
@@ -261,7 +261,7 @@ class _FacilityAppointmentsScreenState extends State<FacilityAppointmentsScreen>
                         CustomTextView(
                           label: data[index].endUserName,
                           textStyle:
-                              Theme.of(context).textTheme.titleSmall!.copyWith(fontWeight: FontWeight.w500, fontSize: 18.0, color: OQDOThemeData.greyColor),
+                              Theme.of(context).textTheme.titleSmall!.copyWith(fontWeight: FontWeight.w500, fontSize: 18.0, color: Theme.of(context).colorScheme.onSurface),
                         ),
                         const SizedBox(
                           height: 5,
@@ -269,7 +269,7 @@ class _FacilityAppointmentsScreenState extends State<FacilityAppointmentsScreen>
                         CustomTextView(
                           label: data[index].setupName,
                           textStyle:
-                              Theme.of(context).textTheme.titleSmall!.copyWith(fontWeight: FontWeight.w500, fontSize: 16.0, color: OQDOThemeData.greyColor),
+                              Theme.of(context).textTheme.titleSmall!.copyWith(fontWeight: FontWeight.w500, fontSize: 16.0, color: Theme.of(context).colorScheme.onSurface),
                         ),
                         const SizedBox(
                           height: 8.0,
@@ -279,7 +279,7 @@ class _FacilityAppointmentsScreenState extends State<FacilityAppointmentsScreen>
                             CustomTextView(
                               label: '${data[index].startTime} - ${data[index].endTime}',
                               textStyle:
-                                  Theme.of(context).textTheme.titleSmall!.copyWith(fontSize: 14.0, fontWeight: FontWeight.w400, color: OQDOThemeData.greyColor),
+                                  Theme.of(context).textTheme.titleSmall!.copyWith(fontSize: 14.0, fontWeight: FontWeight.w400, color: Theme.of(context).colorScheme.onSurface),
                             ),
                             const SizedBox(
                               width: 15,
@@ -287,7 +287,7 @@ class _FacilityAppointmentsScreenState extends State<FacilityAppointmentsScreen>
                             CustomTextView(
                               label: 'S\$ ${data[index].ratePerHour?.toStringAsFixed(2) ?? 0}/hour',
                               textStyle:
-                                  Theme.of(context).textTheme.titleSmall!.copyWith(fontSize: 14.0, fontWeight: FontWeight.w400, color: OQDOThemeData.greyColor),
+                                  Theme.of(context).textTheme.titleSmall!.copyWith(fontSize: 14.0, fontWeight: FontWeight.w400, color: Theme.of(context).colorScheme.onSurface),
                             ),
                           ],
                         ),
@@ -304,7 +304,7 @@ class _FacilityAppointmentsScreenState extends State<FacilityAppointmentsScreen>
                                 textStyle: Theme.of(context)
                                     .textTheme
                                     .titleSmall!
-                                    .copyWith(fontSize: 14.0, fontWeight: FontWeight.w700, color: OQDOThemeData.errorColor)),
+                                    .copyWith(fontSize: 14.0, fontWeight: FontWeight.w700, color: Theme.of(context).colorScheme.error)),
                           ),
                         )
                       : const SizedBox(),
@@ -328,7 +328,7 @@ class _FacilityAppointmentsScreenState extends State<FacilityAppointmentsScreen>
         children: [
           CustomTextView(
             label: monthStr,
-            textStyle: Theme.of(context).textTheme.titleLarge!.copyWith(fontSize: 20, fontWeight: FontWeight.w500, color: const Color(0xFF333333)),
+            textStyle: Theme.of(context).textTheme.titleLarge!.copyWith(fontSize: 20, fontWeight: FontWeight.w500, color: Theme.of(context).colorScheme.onSurface),
           ),
           const Spacer(),
           GestureDetector(
@@ -382,13 +382,13 @@ class _FacilityAppointmentsScreenState extends State<FacilityAppointmentsScreen>
             headerVisible: false,
             daysOfWeekVisible: true,
             daysOfWeekStyle: const DaysOfWeekStyle(
-                weekdayStyle: TextStyle(color: Color(0xFF006590), fontWeight: FontWeight.w500),
-                weekendStyle: TextStyle(color: Color(0xFF006590), fontWeight: FontWeight.w500)),
+                weekdayStyle: TextStyle(color: Theme.of(context).colorScheme.primary, fontWeight: FontWeight.w500),
+                weekendStyle: TextStyle(color: Theme.of(context).colorScheme.primary, fontWeight: FontWeight.w500)),
             calendarStyle: CalendarStyle(
               isTodayHighlighted: false,
               outsideDaysVisible: false,
               selectedDecoration: BoxDecoration(color: Theme.of(context).colorScheme.primary, shape: BoxShape.circle),
-              defaultTextStyle: const TextStyle(fontSize: 15, fontWeight: FontWeight.w400, color: Colors.black),
+              defaultTextStyle: const TextStyle(fontSize: 15, fontWeight: FontWeight.w400, color: Theme.of(context).colorScheme.onBackground),
             ),
             onDaySelected: _onDaySelected,
             selectedDayPredicate: (DateTime date) {
@@ -569,7 +569,7 @@ class _FacilityAppointmentsScreenState extends State<FacilityAppointmentsScreen>
     }
 
     return Container(
-      color: OQDOThemeData.whiteColor,
+      color: Theme.of(context).extension<CustomColors>()!.white,
       width: MediaQuery.of(context).size.width,
       height: MediaQuery.of(context).size.height / 1.2,
       child: SingleChildScrollView(
@@ -586,14 +586,14 @@ class _FacilityAppointmentsScreenState extends State<FacilityAppointmentsScreen>
             ),
             CustomTextView(
               label: '${_currentDay.split("-")[0]} ${_currentDay.split('-')[1]} ${_currentDay.split('-')[2]}',
-              textStyle: Theme.of(context).textTheme.titleLarge!.copyWith(fontSize: 21, color: const Color(0xFF333333), fontWeight: FontWeight.w500),
+              textStyle: Theme.of(context).textTheme.titleLarge!.copyWith(fontSize: 21, color: Theme.of(context).colorScheme.onSurface, fontWeight: FontWeight.w500),
             ),
             const SizedBox(
               height: 3,
             ),
             CustomTextView(
               label: initSelectedDate,
-              textStyle: Theme.of(context).textTheme.titleLarge!.copyWith(fontSize: 21, color: const Color(0xFF333333), fontWeight: FontWeight.w500),
+              textStyle: Theme.of(context).textTheme.titleLarge!.copyWith(fontSize: 21, color: Theme.of(context).colorScheme.onSurface, fontWeight: FontWeight.w500),
             ),
             Padding(
               padding: const EdgeInsets.only(top: 40, left: 25, right: 25),
@@ -606,13 +606,13 @@ class _FacilityAppointmentsScreenState extends State<FacilityAppointmentsScreen>
                 daysOfWeekVisible: true,
                 currentDay: kToday,
                 daysOfWeekStyle: const DaysOfWeekStyle(
-                    weekdayStyle: TextStyle(color: Color(0xFF006590), fontWeight: FontWeight.w500),
-                    weekendStyle: TextStyle(color: Color(0xFF006590), fontWeight: FontWeight.w500)),
+                    weekdayStyle: TextStyle(color: Theme.of(context).colorScheme.primary, fontWeight: FontWeight.w500),
+                    weekendStyle: TextStyle(color: Theme.of(context).colorScheme.primary, fontWeight: FontWeight.w500)),
                 calendarStyle: CalendarStyle(
                   isTodayHighlighted: true,
                   outsideDaysVisible: false,
                   selectedDecoration: BoxDecoration(color: Theme.of(context).colorScheme.primary, shape: BoxShape.circle),
-                  defaultTextStyle: const TextStyle(fontSize: 15, fontWeight: FontWeight.w400, color: Colors.black),
+                  defaultTextStyle: const TextStyle(fontSize: 15, fontWeight: FontWeight.w400, color: Theme.of(context).colorScheme.onBackground),
                 ),
                 onCalendarCreated: (controller) {
                   _pageController = controller;
@@ -669,14 +669,14 @@ class _FacilityAppointmentsScreenState extends State<FacilityAppointmentsScreen>
             children: [
               CustomTextView(
                 label: headerText.split(' ')[0],
-                textStyle: Theme.of(context).textTheme.titleLarge!.copyWith(fontSize: 21, fontWeight: FontWeight.w700, color: const Color(0xFF333333)),
+                textStyle: Theme.of(context).textTheme.titleLarge!.copyWith(fontSize: 21, fontWeight: FontWeight.w700, color: Theme.of(context).colorScheme.onSurface),
               ),
               const SizedBox(
                 height: 5,
               ),
               CustomTextView(
                 label: headerText.split(' ')[1],
-                textStyle: Theme.of(context).textTheme.titleLarge!.copyWith(fontSize: 21, fontWeight: FontWeight.w700, color: const Color(0xFF333333)),
+                textStyle: Theme.of(context).textTheme.titleLarge!.copyWith(fontSize: 21, fontWeight: FontWeight.w700, color: Theme.of(context).colorScheme.onSurface),
               ),
             ],
           ),

--- a/lib/screens/appointment/facility_enduser_verification_screen.dart
+++ b/lib/screens/appointment/facility_enduser_verification_screen.dart
@@ -3,6 +3,7 @@
 import 'dart:convert';
 
 import 'package:flutter/material.dart';
+import 'package:oqdo_mobile_app/theme/custom_colors.dart';
 import 'package:intl/intl.dart';
 import 'package:oqdo_mobile_app/components/custom_app_bar.dart';
 import 'package:oqdo_mobile_app/components/my_button.dart';
@@ -17,7 +18,6 @@ import 'package:oqdo_mobile_app/viewmodels/appointment_view_model.dart';
 import 'package:progress_dialog_null_safe/progress_dialog_null_safe.dart';
 import 'package:provider/provider.dart';
 
-import '../../theme/oqdo_theme_data.dart';
 
 class FacilityEndUserCancelAppointmentVerificationScreen extends StatefulWidget {
   CancelFacilityAppointmentModel? cancelFacilityAppointmentModel;
@@ -74,7 +74,7 @@ class _FacilityEndUserCancelAppointmentVerificationScreenState extends State<Fac
                       child: CustomTextView(
                         label:
                             '${widget.cancelFacilityAppointmentModel!.facilityAppointmentDetailModel!.facilitySetupTitle!.trim()} - ${widget.cancelFacilityAppointmentModel!.facilityAppointmentDetailModel!.facilitySetupSubTitle!.trim()}',
-                        textStyle: Theme.of(context).textTheme.titleLarge!.copyWith(fontSize: 20, color: OQDOThemeData.greyColor, fontWeight: FontWeight.w500),
+                        textStyle: Theme.of(context).textTheme.titleLarge!.copyWith(fontSize: 20, color: Theme.of(context).colorScheme.onSurface, fontWeight: FontWeight.w500),
                       ),
                     ),
                     const SizedBox(
@@ -85,7 +85,7 @@ class _FacilityEndUserCancelAppointmentVerificationScreenState extends State<Fac
                       child: CustomTextView(
                         label:
                             '${widget.cancelFacilityAppointmentModel!.facilityAppointmentDetailModel!.activityName} - ${widget.cancelFacilityAppointmentModel!.facilityAppointmentDetailModel!.subActivityName}',
-                        textStyle: Theme.of(context).textTheme.titleLarge!.copyWith(fontSize: 17, color: OQDOThemeData.greyColor, fontWeight: FontWeight.w500),
+                        textStyle: Theme.of(context).textTheme.titleLarge!.copyWith(fontSize: 17, color: Theme.of(context).colorScheme.onSurface, fontWeight: FontWeight.w500),
                       ),
                     ),
                     const SizedBox(
@@ -101,7 +101,7 @@ class _FacilityEndUserCancelAppointmentVerificationScreenState extends State<Fac
                             textStyle: Theme.of(context)
                                 .textTheme
                                 .titleSmall!
-                                .copyWith(color: OQDOThemeData.otherTextColor, fontWeight: FontWeight.w600, fontSize: 12.0),
+                                .copyWith(color: Theme.of(context).extension<CustomColors>()!.greyText, fontWeight: FontWeight.w600, fontSize: 12.0),
                           ),
                         ],
                       ),
@@ -113,7 +113,7 @@ class _FacilityEndUserCancelAppointmentVerificationScreenState extends State<Fac
                       padding: const EdgeInsets.only(left: 20, right: 20),
                       child: CustomTextView(
                         label: 'Order ID: ${widget.cancelFacilityAppointmentModel!.facilityAppointmentDetailModel!.bookingNo}',
-                        textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 14, color: const Color(0xFF818181), fontWeight: FontWeight.w400),
+                        textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 14, color: Theme.of(context).extension<CustomColors>()!.greyText, fontWeight: FontWeight.w400),
                       ),
                     ),
                     const SizedBox(
@@ -124,7 +124,7 @@ class _FacilityEndUserCancelAppointmentVerificationScreenState extends State<Fac
                       child: CustomTextView(
                         maxLine: 2,
                         label: 'Name: ${widget.cancelFacilityAppointmentModel!.facilityAppointmentDetailModel!.facilityName}',
-                        textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 14, color: const Color(0xFF818181), fontWeight: FontWeight.w400),
+                        textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 14, color: Theme.of(context).extension<CustomColors>()!.greyText, fontWeight: FontWeight.w400),
                       ),
                     ),
                     const SizedBox(
@@ -134,7 +134,7 @@ class _FacilityEndUserCancelAppointmentVerificationScreenState extends State<Fac
                       padding: const EdgeInsets.only(left: 20, right: 20),
                       child: CustomTextView(
                         label: 'Email ID: ${widget.cancelFacilityAppointmentModel!.facilityAppointmentDetailModel!.facilityEmail}',
-                        textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 14, color: const Color(0xFF818181), fontWeight: FontWeight.w400),
+                        textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 14, color: Theme.of(context).extension<CustomColors>()!.greyText, fontWeight: FontWeight.w400),
                       ),
                     ),
                     const SizedBox(
@@ -144,7 +144,7 @@ class _FacilityEndUserCancelAppointmentVerificationScreenState extends State<Fac
                       padding: const EdgeInsets.only(left: 20, right: 20),
                       child: CustomTextView(
                         label: 'Phone number: ${widget.cancelFacilityAppointmentModel!.facilityAppointmentDetailModel!.facilityMobileNumber}',
-                        textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 14, color: const Color(0xFF818181), fontWeight: FontWeight.w400),
+                        textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 14, color: Theme.of(context).extension<CustomColors>()!.greyText, fontWeight: FontWeight.w400),
                       ),
                     ),
                     const SizedBox(
@@ -156,7 +156,7 @@ class _FacilityEndUserCancelAppointmentVerificationScreenState extends State<Fac
                         label: widget.cancelFacilityAppointmentModel!.facilityAppointmentDetailModel!.bookingType == 'I'
                             ? 'Booking For: Individual'
                             : 'Booking For: Group',
-                        textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 14, color: const Color(0xFF818181), fontWeight: FontWeight.w400),
+                        textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 14, color: Theme.of(context).extension<CustomColors>()!.greyText, fontWeight: FontWeight.w400),
                       ),
                     ),
                     const SizedBox(
@@ -168,7 +168,7 @@ class _FacilityEndUserCancelAppointmentVerificationScreenState extends State<Fac
                         label: 'Address: ${widget.cancelFacilityAppointmentModel!.facilityAppointmentDetailModel!.address}',
                         maxLine: 3,
                         textOverFlow: TextOverflow.ellipsis,
-                        textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 14, color: const Color(0xFF818181), fontWeight: FontWeight.w400),
+                        textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 14, color: Theme.of(context).extension<CustomColors>()!.greyText, fontWeight: FontWeight.w400),
                       ),
                     ),
                     const SizedBox(
@@ -178,7 +178,7 @@ class _FacilityEndUserCancelAppointmentVerificationScreenState extends State<Fac
                       padding: const EdgeInsets.only(left: 20, right: 20),
                       child: CustomTextView(
                         label: 'Cancellation Reason: ${widget.cancelFacilityAppointmentModel!.selectedReason}',
-                        textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 14, color: const Color(0xFF818181), fontWeight: FontWeight.w400),
+                        textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 14, color: Theme.of(context).extension<CustomColors>()!.greyText, fontWeight: FontWeight.w400),
                       ),
                     ),
                     const SizedBox(
@@ -186,7 +186,7 @@ class _FacilityEndUserCancelAppointmentVerificationScreenState extends State<Fac
                     ),
                     const Divider(
                       height: 1,
-                      color: Color(0xFFCACACA),
+                      color: Theme.of(context).colorScheme.outline,
                     ),
                     const SizedBox(
                       height: 20.0,
@@ -221,14 +221,14 @@ class _FacilityEndUserCancelAppointmentVerificationScreenState extends State<Fac
                                   textStyle: Theme.of(context)
                                       .textTheme
                                       .titleMedium!
-                                      .copyWith(fontSize: 16.0, fontWeight: FontWeight.w500, color: OQDOThemeData.greyColor),
+                                      .copyWith(fontSize: 16.0, fontWeight: FontWeight.w500, color: Theme.of(context).colorScheme.onSurface),
                                 ),
                                 CustomTextView(
                                   label: 'S\$ ${totalAmount.toStringAsFixed(2)}',
                                   textStyle: Theme.of(context)
                                       .textTheme
                                       .titleMedium!
-                                      .copyWith(fontSize: 16.0, fontWeight: FontWeight.w400, color: OQDOThemeData.greyColor),
+                                      .copyWith(fontSize: 16.0, fontWeight: FontWeight.w400, color: Theme.of(context).colorScheme.onSurface),
                                 )
                               ],
                             ),
@@ -245,14 +245,14 @@ class _FacilityEndUserCancelAppointmentVerificationScreenState extends State<Fac
                                         Navigator.of(context).pop();
                                       },
                                       style: ButtonStyle(
-                                        backgroundColor: MaterialStateProperty.all(OQDOThemeData.errorColor),
+                                        backgroundColor: MaterialStateProperty.all(Theme.of(context).colorScheme.error),
                                       ),
                                       child: CustomTextView(
                                         label: 'Cancel',
                                         textStyle: Theme.of(context)
                                             .textTheme
                                             .bodyMedium!
-                                            .copyWith(fontSize: 16, color: OQDOThemeData.whiteColor, fontWeight: FontWeight.w400),
+                                            .copyWith(fontSize: 16, color: Theme.of(context).extension<CustomColors>()!.white, fontWeight: FontWeight.w400),
                                       ),
                                     ),
                                   ),
@@ -268,14 +268,14 @@ class _FacilityEndUserCancelAppointmentVerificationScreenState extends State<Fac
                                         facilityCancelRequest(context);
                                       },
                                       style: ButtonStyle(
-                                        backgroundColor: MaterialStateProperty.all(OQDOThemeData.successColor),
+                                        backgroundColor: MaterialStateProperty.all(Theme.of(context).extension<CustomColors>()!.greenAmount),
                                       ),
                                       child: CustomTextView(
                                         label: 'Confirm',
                                         textStyle: Theme.of(context)
                                             .textTheme
                                             .bodyMedium!
-                                            .copyWith(fontSize: 16, color: OQDOThemeData.whiteColor, fontWeight: FontWeight.w400),
+                                            .copyWith(fontSize: 16, color: Theme.of(context).extension<CustomColors>()!.white, fontWeight: FontWeight.w400),
                                       ),
                                     ),
                                   ),
@@ -310,25 +310,25 @@ class _FacilityEndUserCancelAppointmentVerificationScreenState extends State<Fac
               CustomTextView(
                 label:
                     '${convertDateToString(finalList[index].bookingDate!).split(',')[1].split(' ')[2]} ${convertDateToString(finalList[index].bookingDate!).split(',')[1].split(' ')[1]} - ${convertDateToString(finalList[index].bookingDate!).split(',')[0]}',
-                textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 18.0, fontWeight: FontWeight.w500, color: OQDOThemeData.greyColor),
+                textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 18.0, fontWeight: FontWeight.w500, color: Theme.of(context).colorScheme.onSurface),
               ),
               const SizedBox(
                 height: 5.0,
               ),
               CustomTextView(
                 label: '${finalList[index].startTime} - ${finalList[index].endTime}',
-                textStyle: Theme.of(context).textTheme.titleSmall!.copyWith(fontSize: 12.0, fontWeight: FontWeight.w400, color: OQDOThemeData.greyColor),
+                textStyle: Theme.of(context).textTheme.titleSmall!.copyWith(fontSize: 12.0, fontWeight: FontWeight.w400, color: Theme.of(context).colorScheme.onSurface),
               ),
             ],
           ),
           const Spacer(),
           RichText(
-            text: TextSpan(text: 'Refund Amount: ', style: const TextStyle(color: Color(0xFF7D7D7D), fontWeight: FontWeight.w400, fontSize: 12), children: [
+            text: TextSpan(text: 'Refund Amount: ', style: const TextStyle(color: Theme.of(context).extension<CustomColors>()!.greyText, fontWeight: FontWeight.w400, fontSize: 12), children: [
               TextSpan(
                 text: 'S\$${finalList[index].refundedAmount?.toStringAsFixed(2) ?? 0.00}',
                 style: const TextStyle(
                   fontWeight: FontWeight.w500,
-                  color: Color(0xFF006590),
+                  color: Theme.of(context).colorScheme.primary,
                   fontSize: 14,
                 ),
               ),
@@ -380,7 +380,7 @@ class _FacilityEndUserCancelAppointmentVerificationScreenState extends State<Fac
                       children: [
                         const Icon(
                           Icons.check_circle,
-                          color: Colors.green,
+                          color: Theme.of(context).extension<CustomColors>()!.greenAmount,
                           size: 100.0,
                         ),
                         const SizedBox(height: 10.0),

--- a/lib/screens/appointment/review_appointment_screen.dart
+++ b/lib/screens/appointment/review_appointment_screen.dart
@@ -26,7 +26,6 @@ import 'package:provider/provider.dart';
 
 import '../../components/my_button.dart';
 import '../../helper/helpers.dart';
-import '../../theme/oqdo_theme_data.dart';
 import '../../utils/custom_text_view.dart';
 
 class ReviewAppointmentScreen extends StatefulWidget {
@@ -138,7 +137,7 @@ class _ReviewAppointmentScreenState extends State<ReviewAppointmentScreen> {
                                     textStyle: Theme.of(context)
                                         .textTheme
                                         .titleLarge!
-                                        .copyWith(fontSize: 20, color: OQDOThemeData.greyColor, fontWeight: FontWeight.w500),
+                                        .copyWith(fontSize: 20, color: Theme.of(context).colorScheme.onSurface, fontWeight: FontWeight.w500),
                                   ),
                                 ),
                                 const SizedBox(height: 15.0),
@@ -152,7 +151,7 @@ class _ReviewAppointmentScreenState extends State<ReviewAppointmentScreen> {
                                           label: 'Slots',
                                           textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(
                                                 fontSize: 16,
-                                                color: OQDOThemeData.otherTextColor.withOpacity(0.6),
+                                                color: Theme.of(context).extension<CustomColors>()!.greyText.withOpacity(0.6),
                                                 fontWeight: FontWeight.w500,
                                                 decoration: TextDecoration.underline,
                                               ),
@@ -166,7 +165,7 @@ class _ReviewAppointmentScreenState extends State<ReviewAppointmentScreen> {
                                         isStrikeThrough: true,
                                         textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(
                                               fontSize: 16,
-                                              color: OQDOThemeData.otherTextColor.withOpacity(0.6),
+                                              color: Theme.of(context).extension<CustomColors>()!.greyText.withOpacity(0.6),
                                               fontWeight: FontWeight.w500,
                                               decoration: TextDecoration.underline,
                                             ),
@@ -197,9 +196,9 @@ class _ReviewAppointmentScreenState extends State<ReviewAppointmentScreen> {
                                         },
                                         child: Container(
                                           decoration: BoxDecoration(
-                                            color: const Color(0xFF0099FA).withOpacity(0.1),
+                                            color: Theme.of(context).extension<CustomColors>()!.accentBlue.withOpacity(0.1),
                                             borderRadius: BorderRadius.circular(8),
-                                            border: Border.all(color: const Color(0xFF0099FA).withOpacity(0.5), width: 2),
+                                            border: Border.all(color: Theme.of(context).extension<CustomColors>()!.accentBlue.withOpacity(0.5), width: 2),
                                           ),
                                           padding: const EdgeInsets.all(15.0),
                                           margin: const EdgeInsets.all(10.0),
@@ -215,7 +214,7 @@ class _ReviewAppointmentScreenState extends State<ReviewAppointmentScreen> {
                                                 'View All Coupons',
                                                 style: TextStyle(
                                                   fontSize: 16.0,
-                                                  color: Color(0xFF0099FA),
+                                                  color: Theme.of(context).extension<CustomColors>()!.accentBlue,
                                                   fontWeight: FontWeight.w600,
                                                 ),
                                               ),
@@ -257,7 +256,7 @@ class _ReviewAppointmentScreenState extends State<ReviewAppointmentScreen> {
                                     textStyle: Theme.of(context)
                                         .textTheme
                                         .titleSmall!
-                                        .copyWith(fontSize: 16.0, fontWeight: FontWeight.w400, color: OQDOThemeData.greyColor),
+                                        .copyWith(fontSize: 16.0, fontWeight: FontWeight.w400, color: Theme.of(context).colorScheme.onSurface),
                                   ),
                                 ),
                                 const SizedBox(height: 100.0), // Bottom padding for scrollable content
@@ -269,10 +268,10 @@ class _ReviewAppointmentScreenState extends State<ReviewAppointmentScreen> {
                       // Fixed bottom section
                       Container(
                         decoration: BoxDecoration(
-                          color: Colors.white,
+                          color: Theme.of(context).extension<CustomColors>()!.white,
                           boxShadow: [
                             BoxShadow(
-                              color: Colors.black.withOpacity(0.1),
+                              color: Theme.of(context).colorScheme.onBackground.withOpacity(0.1),
                               spreadRadius: 1,
                               blurRadius: 5,
                               offset: const Offset(0, -3),
@@ -290,7 +289,7 @@ class _ReviewAppointmentScreenState extends State<ReviewAppointmentScreen> {
                                     textStyle: Theme.of(context)
                                         .textTheme
                                         .titleMedium!
-                                        .copyWith(color: OQDOThemeData.greyColor, fontSize: 16, fontWeight: FontWeight.w400),
+                                        .copyWith(color: Theme.of(context).colorScheme.onSurface, fontSize: 16, fontWeight: FontWeight.w400),
                                   )
                                 : CustomTextView(
                                     maxLine: 2,
@@ -298,7 +297,7 @@ class _ReviewAppointmentScreenState extends State<ReviewAppointmentScreen> {
                                     textStyle: Theme.of(context)
                                         .textTheme
                                         .titleMedium!
-                                        .copyWith(fontWeight: FontWeight.w700, color: OQDOThemeData.errorColor, fontSize: 20),
+                                        .copyWith(fontWeight: FontWeight.w700, color: Theme.of(context).colorScheme.error, fontSize: 20),
                                   ),
                             const SizedBox(height: 20.0),
                             !isHomeVisible
@@ -423,7 +422,7 @@ class _ReviewAppointmentScreenState extends State<ReviewAppointmentScreen> {
                         label:
                             '${convertDateToString(_facilityBookingListModelResponse!.facilityBookingFreezeSlots![index].bookingDate!).split(',')[1].split(' ')[2]} ${convertDateToString(_facilityBookingListModelResponse!.facilityBookingFreezeSlots![index].bookingDate!).split(',')[1].split(' ')[1]} - ${convertDateToString(_facilityBookingListModelResponse!.facilityBookingFreezeSlots![index].bookingDate!).split(',')[0]}',
                         textStyle:
-                            Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 18.0, fontWeight: FontWeight.w500, color: OQDOThemeData.greyColor),
+                            Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 18.0, fontWeight: FontWeight.w500, color: Theme.of(context).colorScheme.onSurface),
                       ),
                       const SizedBox(
                         height: 5.0,
@@ -434,7 +433,7 @@ class _ReviewAppointmentScreenState extends State<ReviewAppointmentScreen> {
                             label:
                                 '${_facilityBookingListModelResponse!.facilityBookingFreezeSlots![index].startTime} - ${_facilityBookingListModelResponse!.facilityBookingFreezeSlots![index].endTime}',
                             textStyle:
-                                Theme.of(context).textTheme.titleSmall!.copyWith(fontSize: 12.0, fontWeight: FontWeight.w400, color: OQDOThemeData.greyColor),
+                                Theme.of(context).textTheme.titleSmall!.copyWith(fontSize: 12.0, fontWeight: FontWeight.w400, color: Theme.of(context).colorScheme.onSurface),
                           ),
                           const SizedBox(
                             width: 20,
@@ -442,7 +441,7 @@ class _ReviewAppointmentScreenState extends State<ReviewAppointmentScreen> {
                           CustomTextView(
                             label: 'S\$ ${_facilityBookingListModelResponse?.facilityBookingFreezeSlots?[index].ratePerHour?.toStringAsFixed(2) ?? 0.00}/hour',
                             textStyle:
-                                Theme.of(context).textTheme.titleSmall!.copyWith(fontSize: 12.0, fontWeight: FontWeight.w400, color: OQDOThemeData.greyColor),
+                                Theme.of(context).textTheme.titleSmall!.copyWith(fontSize: 12.0, fontWeight: FontWeight.w400, color: Theme.of(context).colorScheme.onSurface),
                           ),
                         ],
                       ),
@@ -457,7 +456,7 @@ class _ReviewAppointmentScreenState extends State<ReviewAppointmentScreen> {
             child: Center(
               child: CustomTextView(
                 label: 'S\$ ${_facilityBookingListModelResponse?.facilityBookingFreezeSlots?[index].amount?.toStringAsFixed(2) ?? 0.00}',
-                textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 16.0, fontWeight: FontWeight.w500, color: OQDOThemeData.greyColor),
+                textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 16.0, fontWeight: FontWeight.w500, color: Theme.of(context).colorScheme.onSurface),
               ),
             ),
           ),
@@ -665,10 +664,10 @@ class _ReviewAppointmentScreenState extends State<ReviewAppointmentScreen> {
                   googlePay: gpay,
                   applePay: const PaymentSheetApplePay(merchantCountryCode: 'SG', buttonType: PlatformButtonType.buy),
                   appearance: const PaymentSheetAppearance(
-                      colors: PaymentSheetAppearanceColors(primary: OQDOThemeData.dividerColor),
+                      colors: PaymentSheetAppearanceColors(primary: Theme.of(context).colorScheme.primary),
                       primaryButton: PaymentSheetPrimaryButtonAppearance(
                           colors: PaymentSheetPrimaryButtonTheme(
-                              light: PaymentSheetPrimaryButtonThemeColors(background: OQDOThemeData.dividerColor, text: Colors.white)))),
+                              light: PaymentSheetPrimaryButtonThemeColors(background: Theme.of(context).colorScheme.primary, text: Theme.of(context).extension<CustomColors>()!.white)))),
                   merchantDisplayName: 'OQDO'))
           .then((value) {});
 
@@ -776,7 +775,7 @@ class _ReviewAppointmentScreenState extends State<ReviewAppointmentScreen> {
                       children: [
                         const Icon(
                           Icons.check_circle,
-                          color: Colors.green,
+                          color: Theme.of(context).extension<CustomColors>()!.greenAmount,
                           size: 100.0,
                         ),
                         const SizedBox(height: 10.0),
@@ -861,7 +860,7 @@ class _ReviewAppointmentScreenState extends State<ReviewAppointmentScreen> {
                       children: [
                         const Icon(
                           Icons.cancel,
-                          color: Colors.red,
+                          color: Theme.of(context).colorScheme.error,
                           size: 100.0,
                         ),
                         const SizedBox(height: 10.0),
@@ -924,8 +923,8 @@ class _ReviewAppointmentScreenState extends State<ReviewAppointmentScreen> {
             padding: const EdgeInsets.symmetric(horizontal: 10.0),
             child: Container(
               decoration: BoxDecoration(
-                color: OQDOThemeData.whiteColor,
-                border: Border.all(color: OQDOThemeData.otherTextColor),
+                color: Theme.of(context).extension<CustomColors>()!.white,
+                border: Border.all(color: Theme.of(context).extension<CustomColors>()!.greyText),
               ),
               padding: const EdgeInsets.all(10.0),
               child: Column(
@@ -936,7 +935,7 @@ class _ReviewAppointmentScreenState extends State<ReviewAppointmentScreen> {
                     textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(
                           fontSize: 16.0,
                           fontWeight: FontWeight.w600,
-                          color: OQDOThemeData.buttonColor,
+                          color: Theme.of(context).colorScheme.primary,
                         ),
                   ),
                   const SizedBox(
@@ -957,14 +956,14 @@ class _ReviewAppointmentScreenState extends State<ReviewAppointmentScreen> {
                       CustomTextView(
                         label: "Total Amount : ",
                         textStyle:
-                            Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 16.0, fontWeight: FontWeight.w600, color: OQDOThemeData.blackColor),
+                            Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 16.0, fontWeight: FontWeight.w600, color: Theme.of(context).colorScheme.onBackground),
                       ),
                       Column(
                         children: [
                           CustomTextView(
                             label: 'S\$ ${totalAmount.toStringAsFixed(2)}',
                             textStyle:
-                                Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 14.0, fontWeight: FontWeight.w600, color: OQDOThemeData.blackColor),
+                                Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 14.0, fontWeight: FontWeight.w600, color: Theme.of(context).colorScheme.onBackground),
                           ),
                         ],
                       ),
@@ -974,7 +973,7 @@ class _ReviewAppointmentScreenState extends State<ReviewAppointmentScreen> {
                     height: 10,
                   ),
                   const Divider(
-                    color: OQDOThemeData.greyColor,
+                    color: Theme.of(context).colorScheme.onSurface,
                   ),
                   const SizedBox(
                     height: 10,
@@ -994,7 +993,7 @@ class _ReviewAppointmentScreenState extends State<ReviewAppointmentScreen> {
                                   textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(
                                       fontSize: 14.0,
                                       fontWeight: FontWeight.w600,
-                                      color: !isCouponSelected ? OQDOThemeData.blackColor : Theme.of(context).colorScheme.secondaryContainer),
+                                      color: !isCouponSelected ? Theme.of(context).colorScheme.onBackground : Theme.of(context).colorScheme.secondaryContainer),
                                 ),
                                 const SizedBox(
                                   height: 3,
@@ -1005,7 +1004,7 @@ class _ReviewAppointmentScreenState extends State<ReviewAppointmentScreen> {
                                   textStyle: Theme.of(context)
                                       .textTheme
                                       .titleMedium!
-                                      .copyWith(fontSize: 12.0, fontWeight: FontWeight.w500, color: OQDOThemeData.greyColor),
+                                      .copyWith(fontSize: 12.0, fontWeight: FontWeight.w500, color: Theme.of(context).colorScheme.onSurface),
                                 ).visible(isCouponSelected),
                               ],
                             ),
@@ -1023,7 +1022,7 @@ class _ReviewAppointmentScreenState extends State<ReviewAppointmentScreen> {
                                   textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(
                                       fontSize: 13.0,
                                       fontWeight: FontWeight.w600,
-                                      color: !isCouponSelected ? OQDOThemeData.blackColor : Theme.of(context).colorScheme.secondaryContainer),
+                                      color: !isCouponSelected ? Theme.of(context).colorScheme.onBackground : Theme.of(context).colorScheme.secondaryContainer),
                                 ),
                               ],
                             ),
@@ -1055,7 +1054,7 @@ class _ReviewAppointmentScreenState extends State<ReviewAppointmentScreen> {
                 children: [
                   CustomTextView(
                     label: title,
-                    textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 14.0, fontWeight: FontWeight.w600, color: OQDOThemeData.blackColor),
+                    textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 14.0, fontWeight: FontWeight.w600, color: Theme.of(context).colorScheme.onBackground),
                   ),
                   const SizedBox(
                     height: 3,
@@ -1063,7 +1062,7 @@ class _ReviewAppointmentScreenState extends State<ReviewAppointmentScreen> {
                   CustomTextView(
                     label: details,
                     maxLine: 2,
-                    textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 12.0, fontWeight: FontWeight.w500, color: OQDOThemeData.greyColor),
+                    textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 12.0, fontWeight: FontWeight.w500, color: Theme.of(context).colorScheme.onSurface),
                   ),
                 ],
               ),
@@ -1078,7 +1077,7 @@ class _ReviewAppointmentScreenState extends State<ReviewAppointmentScreen> {
                     label: 'S\$ $rate',
                     maxLine: 2,
                     textOverFlow: TextOverflow.ellipsis,
-                    textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 13.0, fontWeight: FontWeight.w600, color: OQDOThemeData.blackColor),
+                    textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 13.0, fontWeight: FontWeight.w600, color: Theme.of(context).colorScheme.onBackground),
                   ),
                 ],
               ),
@@ -1089,7 +1088,7 @@ class _ReviewAppointmentScreenState extends State<ReviewAppointmentScreen> {
           height: 3,
         ),
         const Divider(
-          color: OQDOThemeData.greyColor,
+          color: Theme.of(context).colorScheme.onSurface,
         ),
       ],
     );
@@ -1108,7 +1107,7 @@ class _ReviewAppointmentScreenState extends State<ReviewAppointmentScreen> {
 //               children: [
 //                 CustomTextView(
 //                   label: title,
-//                   textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 14.0, fontWeight: FontWeight.w600, color: OQDOThemeData.blackColor),
+//                   textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 14.0, fontWeight: FontWeight.w600, color: Theme.of(context).colorScheme.onBackground),
 //                 ),
 //                 const SizedBox(
 //                   height: 3,
@@ -1116,7 +1115,7 @@ class _ReviewAppointmentScreenState extends State<ReviewAppointmentScreen> {
 //                 CustomTextView(
 //                   label: details,
 //                   maxLine: 2,
-//                   textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 12.0, fontWeight: FontWeight.w500, color: OQDOThemeData.greyColor),
+//                   textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 12.0, fontWeight: FontWeight.w500, color: Theme.of(context).colorScheme.onSurface),
 //                 ),
 //               ],
 //             ),
@@ -1130,7 +1129,7 @@ class _ReviewAppointmentScreenState extends State<ReviewAppointmentScreen> {
 //                   label: 'S\$ $rate',
 //                   maxLine: 2,
 //                   textOverFlow: TextOverflow.ellipsis,
-//                   textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 13.0, fontWeight: FontWeight.w600, color: OQDOThemeData.blackColor),
+//                   textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 13.0, fontWeight: FontWeight.w600, color: Theme.of(context).colorScheme.onBackground),
 //                 ),
 //               ],
 //             ),
@@ -1141,7 +1140,7 @@ class _ReviewAppointmentScreenState extends State<ReviewAppointmentScreen> {
 //         height: 3,
 //       ),
 //       const Divider(
-//         color: OQDOThemeData.greyColor,
+//         color: Theme.of(context).colorScheme.onSurface,
 //       ),
 //     ],
 //   );

--- a/lib/screens/appointment/views/appointment_btn_view.dart
+++ b/lib/screens/appointment/views/appointment_btn_view.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:oqdo_mobile_app/theme/custom_colors.dart';
 import 'package:oqdo_mobile_app/utils/custom_text_view.dart';
 
 class AppointmentButton extends StatelessWidget {

--- a/lib/screens/appointment/views/discount_coupon.dart
+++ b/lib/screens/appointment/views/discount_coupon.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:oqdo_mobile_app/theme/custom_colors.dart';
 import 'package:oqdo_mobile_app/utils/custom_text_view.dart';
 
 class DiscountCoupon extends StatelessWidget {


### PR DESCRIPTION
## Summary
- refactor appointment screens to use theme colorScheme and CustomColors
- drop legacy `OQDOThemeData` imports
- prepare screens for light and dark themes

## Testing
- `flutter analyze` *(fails: command not found)*
- `dart format lib/screens/appointment` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bfe4efb75883329e7c36c586f6e7a2