### PR TITLE
refactor: enable theme support for slot management

### DIFF
--- a/lib/screens/slot_management/cancel_slot_reson_screen.dart
+++ b/lib/screens/slot_management/cancel_slot_reson_screen.dart
@@ -8,7 +8,7 @@ import 'package:oqdo_mobile_app/model/cancel_reason_list_response_model.dart';
 import 'package:oqdo_mobile_app/model/cancel_reason_view_model.dart';
 import 'package:oqdo_mobile_app/model/coach_cancel_slot_response_model.dart';
 import 'package:oqdo_mobile_app/repository/facility_slot_cancel_response_model.dart';
-import 'package:oqdo_mobile_app/theme/oqdo_theme_data.dart';
+import 'package:oqdo_mobile_app/theme/custom_colors.dart';
 import 'package:oqdo_mobile_app/utils/constants.dart';
 import 'package:oqdo_mobile_app/utils/custom_text_view.dart';
 import 'package:oqdo_mobile_app/utils/network_interceptor.dart';
@@ -52,7 +52,7 @@ class _CancelReasonScreenState extends State<CancelReasonScreen> {
       ),
       body: SafeArea(
         child: Container(
-          color: OQDOThemeData.whiteColor,
+          color: Theme.of(context).extension<CustomColors>()!.white,
           width: double.infinity,
           height: double.infinity,
           child: Column(
@@ -143,7 +143,10 @@ class _CancelReasonScreenState extends State<CancelReasonScreen> {
         ),
         CustomTextView(
           label: model.cancelreason,
-          textStyle: Theme.of(context).textTheme.bodyMedium!.copyWith(fontSize: 15, fontWeight: FontWeight.w400, color: OQDOThemeData.greyColor),
+          textStyle: Theme.of(context)
+              .textTheme
+              .bodyMedium!
+              .copyWith(fontSize: 15, fontWeight: FontWeight.w400, color: Theme.of(context).colorScheme.onSurface),
         ),
       ],
     );

--- a/lib/screens/slot_management/coach_cancel_slot_management_screen.dart
+++ b/lib/screens/slot_management/coach_cancel_slot_management_screen.dart
@@ -11,7 +11,7 @@ import 'package:oqdo_mobile_app/model/coach_available_slots_by_date_response_mod
 import 'package:oqdo_mobile_app/model/coach_get_21_days_slot_response_model.dart';
 import 'package:oqdo_mobile_app/model/coach_slot_booking_model.dart';
 import 'package:oqdo_mobile_app/oqdo_application.dart';
-import 'package:oqdo_mobile_app/theme/oqdo_theme_data.dart';
+import 'package:oqdo_mobile_app/theme/custom_colors.dart';
 import 'package:oqdo_mobile_app/utils/constants.dart';
 import 'package:oqdo_mobile_app/utils/custom_text_view.dart';
 import 'package:oqdo_mobile_app/utils/network_interceptor.dart';
@@ -84,7 +84,7 @@ class _CoachCancelSlotScreenState extends State<CoachCancelSlotScreen> {
       ),
       body: SafeArea(
         child: Container(
-          color: OQDOThemeData.whiteColor,
+          color: Theme.of(context).extension<CustomColors>()!.white,
           width: MediaQuery.of(context).size.width,
           height: double.infinity,
           child: Column(
@@ -112,7 +112,7 @@ class _CoachCancelSlotScreenState extends State<CoachCancelSlotScreen> {
                                       textStyle: Theme.of(context)
                                           .textTheme
                                           .titleMedium!
-                                          .copyWith(fontSize: 20, fontWeight: FontWeight.w500, color: const Color(0xFF333333)),
+                                          .copyWith(fontSize: 20, fontWeight: FontWeight.w500, color: Theme.of(context).colorScheme.onSurface),
                                     ),
                                     const Spacer(),
                                     CustomTextView(
@@ -120,7 +120,7 @@ class _CoachCancelSlotScreenState extends State<CoachCancelSlotScreen> {
                                       textStyle: Theme.of(context)
                                           .textTheme
                                           .titleMedium!
-                                          .copyWith(fontSize: 15, fontWeight: FontWeight.w500, color: const Color(0xFFABABAB)),
+                                          .copyWith(fontSize: 15, fontWeight: FontWeight.w500, color: Theme.of(context).extension<CustomColors>()!.greyText),
                                     ),
                                   ],
                                 ),
@@ -161,10 +161,10 @@ class _CoachCancelSlotScreenState extends State<CoachCancelSlotScreen> {
                               ),
                               CustomTextView(
                                 label: 'Slot not available',
-                                textStyle: Theme.of(context)
-                                    .textTheme
-                                    .titleMedium!
-                                    .copyWith(fontSize: 16, color: OQDOThemeData.greyColor, fontWeight: FontWeight.w500),
+                                      textStyle: Theme.of(context)
+                                          .textTheme
+                                          .titleMedium!
+                                          .copyWith(fontSize: 16, color: Theme.of(context).colorScheme.onSurface, fontWeight: FontWeight.w500),
                               ),
                             ],
                           ),
@@ -183,8 +183,10 @@ class _CoachCancelSlotScreenState extends State<CoachCancelSlotScreen> {
                           ),
                           CustomTextView(
                             label: 'Slot not available',
-                            textStyle:
-                                Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 16, color: OQDOThemeData.greyColor, fontWeight: FontWeight.w500),
+                            textStyle: Theme.of(context)
+                                .textTheme
+                                .titleMedium!
+                                .copyWith(fontSize: 16, color: Theme.of(context).colorScheme.onSurface, fontWeight: FontWeight.w500),
                           ),
                         ],
                       ),
@@ -223,7 +225,10 @@ class _CoachCancelSlotScreenState extends State<CoachCancelSlotScreen> {
                             maxLine: 3,
                             textOverFlow: TextOverflow.ellipsis,
                             textStyle:
-                                Theme.of(context).textTheme.titleMedium!.copyWith(color: OQDOThemeData.errorColor, fontSize: 16, fontWeight: FontWeight.w400),
+                                Theme.of(context)
+                                    .textTheme
+                                    .titleMedium!
+                                    .copyWith(color: Theme.of(context).colorScheme.error, fontSize: 16, fontWeight: FontWeight.w400),
                           ),
                         ),
                       ],
@@ -243,7 +248,10 @@ class _CoachCancelSlotScreenState extends State<CoachCancelSlotScreen> {
         children: [
           CustomTextView(
             label: monthStr,
-            textStyle: Theme.of(context).textTheme.titleLarge!.copyWith(fontSize: 20, fontWeight: FontWeight.w500, color: const Color(0xFF333333)),
+            textStyle: Theme.of(context)
+                .textTheme
+                .titleLarge!
+                .copyWith(fontSize: 20, fontWeight: FontWeight.w500, color: Theme.of(context).colorScheme.onSurface),
           ),
           const Spacer(),
           GestureDetector(
@@ -295,14 +303,17 @@ class _CoachCancelSlotScreenState extends State<CoachCancelSlotScreen> {
             calendarFormat: _calendarFormat,
             headerVisible: false,
             daysOfWeekVisible: true,
-            daysOfWeekStyle: const DaysOfWeekStyle(
-                weekdayStyle: TextStyle(color: Color(0xFF006590), fontWeight: FontWeight.w500),
-                weekendStyle: TextStyle(color: Color(0xFF006590), fontWeight: FontWeight.w500)),
+                    daysOfWeekStyle: DaysOfWeekStyle(
+                        weekdayStyle: TextStyle(color: Theme.of(context).colorScheme.primary, fontWeight: FontWeight.w500),
+                        weekendStyle: TextStyle(color: Theme.of(context).colorScheme.primary, fontWeight: FontWeight.w500)),
             calendarStyle: CalendarStyle(
               isTodayHighlighted: false,
               outsideDaysVisible: false,
               selectedDecoration: BoxDecoration(color: Theme.of(context).colorScheme.primary, shape: BoxShape.circle),
-              defaultTextStyle: const TextStyle(fontSize: 15, fontWeight: FontWeight.w400, color: Colors.black),
+                      defaultTextStyle: TextStyle(
+                          fontSize: 15,
+                          fontWeight: FontWeight.w400,
+                          color: Theme.of(context).colorScheme.onSurface),
             ),
             onDaySelected: _onDaySelected,
             selectedDayPredicate: (DateTime date) {
@@ -342,13 +353,16 @@ class _CoachCancelSlotScreenState extends State<CoachCancelSlotScreen> {
                       border: Border.all(
                         color: Theme.of(context).colorScheme.primary,
                       ),
-                      color: const Color(0xFFCCCCCC),
+                      color: Theme.of(context).colorScheme.outline,
                     ),
                     child: Center(
                       child: CustomTextView(
                         label: '${_singleFacilityDatesList[0].listOfSlots![index].startTime} - ${_singleFacilityDatesList[0].listOfSlots![index].endTime}',
                         type: styleSubTitle,
-                        textStyle: Theme.of(context).textTheme.titleSmall!.copyWith(color: OQDOThemeData.greyColor),
+                        textStyle: Theme.of(context)
+                            .textTheme
+                            .titleSmall!
+                            .copyWith(color: Theme.of(context).colorScheme.onSurface),
                       ),
                     ),
                   ),
@@ -366,7 +380,10 @@ class _CoachCancelSlotScreenState extends State<CoachCancelSlotScreen> {
                         CustomTextView(
                           label: _singleFacilityDatesList[0].listOfSlots![index].bookedSeat.toString(),
                           textStyle:
-                              Theme.of(context).textTheme.titleSmall!.copyWith(fontSize: 14, color: OQDOThemeData.blackColor, fontWeight: FontWeight.w300),
+                              Theme.of(context)
+                                  .textTheme
+                                  .titleSmall!
+                                  .copyWith(fontSize: 14, color: Theme.of(context).colorScheme.onSurface, fontWeight: FontWeight.w300),
                         ),
                         const SizedBox(
                           width: 5,
@@ -380,7 +397,10 @@ class _CoachCancelSlotScreenState extends State<CoachCancelSlotScreen> {
                     ),
                     CustomTextView(
                       label: 'Booked',
-                      textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 10, fontWeight: FontWeight.w500, color: const Color(0xFF333333)),
+                      textStyle: Theme.of(context)
+                          .textTheme
+                          .titleMedium!
+                          .copyWith(fontSize: 10, fontWeight: FontWeight.w500, color: Theme.of(context).colorScheme.onSurface),
                     ),
                     const SizedBox(
                       height: 5,
@@ -400,13 +420,16 @@ class _CoachCancelSlotScreenState extends State<CoachCancelSlotScreen> {
                           border: Border.all(
                             color: Theme.of(context).colorScheme.primary,
                           ),
-                          color: const Color(0xFFCCCCCC),
+                          color: Theme.of(context).colorScheme.outline,
                         ),
                         child: Center(
                           child: CustomTextView(
                             label: '${_singleFacilityDatesList[0].listOfSlots![index].startTime} - ${_singleFacilityDatesList[0].listOfSlots![index].endTime}',
                             type: styleSubTitle,
-                            textStyle: Theme.of(context).textTheme.titleSmall!.copyWith(color: OQDOThemeData.greyColor),
+                            textStyle: Theme.of(context)
+                                .textTheme
+                                .titleSmall!
+                                .copyWith(color: Theme.of(context).colorScheme.onSurface),
                           ),
                         ),
                       ),
@@ -424,7 +447,10 @@ class _CoachCancelSlotScreenState extends State<CoachCancelSlotScreen> {
                             CustomTextView(
                               label: _singleFacilityDatesList[0].listOfSlots![index].bookedSeat.toString(),
                               textStyle:
-                                  Theme.of(context).textTheme.titleSmall!.copyWith(fontSize: 14, color: OQDOThemeData.blackColor, fontWeight: FontWeight.w300),
+                                  Theme.of(context)
+                                      .textTheme
+                                      .titleSmall!
+                                      .copyWith(fontSize: 14, color: Theme.of(context).colorScheme.onSurface, fontWeight: FontWeight.w300),
                             ),
                             const SizedBox(
                               width: 5,
@@ -439,7 +465,10 @@ class _CoachCancelSlotScreenState extends State<CoachCancelSlotScreen> {
                         CustomTextView(
                           label: 'Booked',
                           textStyle:
-                              Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 10, fontWeight: FontWeight.w500, color: const Color(0xFF333333)),
+                              Theme.of(context)
+                                  .textTheme
+                                  .titleMedium!
+                                  .copyWith(fontSize: 10, fontWeight: FontWeight.w500, color: Theme.of(context).colorScheme.onSurface),
                         ),
                         const SizedBox(
                           height: 5,
@@ -456,15 +485,22 @@ class _CoachCancelSlotScreenState extends State<CoachCancelSlotScreen> {
                       child: Container(
                         decoration: BoxDecoration(
                           border: Border.all(
-                            color: _singleFacilityDatesList[0].listOfSlots![index].isSlotSelected ? Colors.green : Colors.blue,
+                            color: _singleFacilityDatesList[0].listOfSlots![index].isSlotSelected
+                                ? Theme.of(context).extension<CustomColors>()!.greenAmount
+                                : Theme.of(context).colorScheme.primary,
                           ),
-                          color: _singleFacilityDatesList[0].listOfSlots![index].isSlotSelected ? Colors.green : Colors.blue,
+                          color: _singleFacilityDatesList[0].listOfSlots![index].isSlotSelected
+                              ? Theme.of(context).extension<CustomColors>()!.greenAmount
+                              : Theme.of(context).colorScheme.primary,
                         ),
                         child: Center(
                           child: CustomTextView(
                             label: '${_singleFacilityDatesList[0].listOfSlots![index].startTime} - ${_singleFacilityDatesList[0].listOfSlots![index].endTime}',
                             type: styleSubTitle,
-                            textStyle: Theme.of(context).textTheme.titleSmall!.copyWith(color: OQDOThemeData.whiteColor),
+                            textStyle: Theme.of(context)
+                                .textTheme
+                                .titleSmall!
+                                .copyWith(color: Theme.of(context).extension<CustomColors>()!.white),
                           ),
                         ),
                       ),
@@ -482,7 +518,10 @@ class _CoachCancelSlotScreenState extends State<CoachCancelSlotScreen> {
                             CustomTextView(
                               label: _singleFacilityDatesList[0].listOfSlots![index].bookedSeat.toString(),
                               textStyle:
-                                  Theme.of(context).textTheme.titleSmall!.copyWith(fontSize: 14, color: OQDOThemeData.blackColor, fontWeight: FontWeight.w300),
+                                  Theme.of(context)
+                                      .textTheme
+                                      .titleSmall!
+                                      .copyWith(fontSize: 14, color: Theme.of(context).colorScheme.onSurface, fontWeight: FontWeight.w300),
                             ),
                             const SizedBox(
                               width: 5,
@@ -497,7 +536,10 @@ class _CoachCancelSlotScreenState extends State<CoachCancelSlotScreen> {
                         CustomTextView(
                           label: 'Booked',
                           textStyle:
-                              Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 10, fontWeight: FontWeight.w500, color: const Color(0xFF333333)),
+                              Theme.of(context)
+                                  .textTheme
+                                  .titleMedium!
+                                  .copyWith(fontSize: 10, fontWeight: FontWeight.w500, color: Theme.of(context).colorScheme.onSurface),
                         ),
                         const SizedBox(
                           height: 5,
@@ -760,7 +802,7 @@ class _CoachCancelSlotScreenState extends State<CoachCancelSlotScreen> {
     }
 
     return Container(
-      color: OQDOThemeData.whiteColor,
+      color: Theme.of(context).extension<CustomColors>()!.white,
       width: MediaQuery.of(context).size.width,
       height: MediaQuery.of(context).size.height / 1.2,
       child: SingleChildScrollView(
@@ -777,14 +819,20 @@ class _CoachCancelSlotScreenState extends State<CoachCancelSlotScreen> {
             ),
             CustomTextView(
               label: '${_currentDay.split("-")[0]} ${_currentDay.split('-')[1]} ${_currentDay.split('-')[2]}',
-              textStyle: Theme.of(context).textTheme.titleLarge!.copyWith(fontSize: 21, color: const Color(0xFF333333), fontWeight: FontWeight.w500),
+              textStyle: Theme.of(context)
+                  .textTheme
+                  .titleLarge!
+                  .copyWith(fontSize: 21, color: Theme.of(context).colorScheme.onSurface, fontWeight: FontWeight.w500),
             ),
             const SizedBox(
               height: 3,
             ),
             CustomTextView(
               label: initSelectedDate,
-              textStyle: Theme.of(context).textTheme.titleLarge!.copyWith(fontSize: 21, color: const Color(0xFF333333), fontWeight: FontWeight.w500),
+              textStyle: Theme.of(context)
+                  .textTheme
+                  .titleLarge!
+                  .copyWith(fontSize: 21, color: Theme.of(context).colorScheme.onSurface, fontWeight: FontWeight.w500),
             ),
             Padding(
               padding: const EdgeInsets.only(top: 40, left: 25, right: 25),
@@ -797,13 +845,16 @@ class _CoachCancelSlotScreenState extends State<CoachCancelSlotScreen> {
                 daysOfWeekVisible: true,
                 currentDay: kToday,
                 daysOfWeekStyle: const DaysOfWeekStyle(
-                    weekdayStyle: TextStyle(color: Color(0xFF006590), fontWeight: FontWeight.w500),
-                    weekendStyle: TextStyle(color: Color(0xFF006590), fontWeight: FontWeight.w500)),
+                    weekdayStyle: TextStyle(color: Theme.of(context).colorScheme.primary, fontWeight: FontWeight.w500),
+                    weekendStyle: TextStyle(color: Theme.of(context).colorScheme.primary, fontWeight: FontWeight.w500)),
                 calendarStyle: CalendarStyle(
                   isTodayHighlighted: true,
                   outsideDaysVisible: false,
                   selectedDecoration: BoxDecoration(color: Theme.of(context).colorScheme.primary, shape: BoxShape.circle),
-                  defaultTextStyle: const TextStyle(fontSize: 15, fontWeight: FontWeight.w400, color: Colors.black),
+                  defaultTextStyle: TextStyle(
+                      fontSize: 15,
+                      fontWeight: FontWeight.w400,
+                      color: Theme.of(context).colorScheme.onSurface),
                 ),
                 onCalendarCreated: (controller) {
                   _pageController = controller;
@@ -860,14 +911,20 @@ class _CoachCancelSlotScreenState extends State<CoachCancelSlotScreen> {
             children: [
               CustomTextView(
                 label: headerText.split(' ')[0],
-                textStyle: Theme.of(context).textTheme.titleLarge!.copyWith(fontSize: 21, fontWeight: FontWeight.w700, color: const Color(0xFF333333)),
+                textStyle: Theme.of(context)
+                    .textTheme
+                    .titleLarge!
+                    .copyWith(fontSize: 21, fontWeight: FontWeight.w700, color: Theme.of(context).colorScheme.onSurface),
               ),
               const SizedBox(
                 height: 5,
               ),
               CustomTextView(
                 label: headerText.split(' ')[1],
-                textStyle: Theme.of(context).textTheme.titleLarge!.copyWith(fontSize: 21, fontWeight: FontWeight.w700, color: const Color(0xFF333333)),
+                textStyle: Theme.of(context)
+                    .textTheme
+                    .titleLarge!
+                    .copyWith(fontSize: 21, fontWeight: FontWeight.w700, color: Theme.of(context).colorScheme.onSurface),
               ),
             ],
           ),

--- a/lib/screens/slot_management/coach_slot_selection_screen.dart
+++ b/lib/screens/slot_management/coach_slot_selection_screen.dart
@@ -15,7 +15,7 @@ import 'package:oqdo_mobile_app/model/coach_get_21_days_slot_response_model.dart
 import 'package:oqdo_mobile_app/model/coach_slot_booking_model.dart';
 import 'package:oqdo_mobile_app/model/freeze_coach_response_model.dart';
 import 'package:oqdo_mobile_app/oqdo_application.dart';
-import 'package:oqdo_mobile_app/theme/oqdo_theme_data.dart';
+import 'package:oqdo_mobile_app/theme/custom_colors.dart';
 import 'package:oqdo_mobile_app/utils/constants.dart';
 import 'package:oqdo_mobile_app/utils/coutdown_timer.dart';
 import 'package:oqdo_mobile_app/utils/custom_text_view.dart';
@@ -162,7 +162,7 @@ class _CoachSlotSelectionScreenState extends State<CoachSlotSelectionScreen> {
         ),
         body: SafeArea(
           child: Container(
-            color: OQDOThemeData.whiteColor,
+            color: Theme.of(context).extension<CustomColors>()!.white,
             width: MediaQuery.of(context).size.width,
             height: double.infinity,
             child: Column(
@@ -189,8 +189,8 @@ class _CoachSlotSelectionScreenState extends State<CoachSlotSelectionScreen> {
                                   ),
                                   CustomTextView(
                                     label: 'Minimum Slot : ${_calendarViewModel.coachDetailsResponseModel!.minumumSlot}',
-                                    color: Colors.black,
-                                    textStyle: const TextStyle(fontSize: 16.0, color: OQDOThemeData.blackColor, fontWeight: FontWeight.bold),
+                                    color: Theme.of(context).colorScheme.onSurface,
+                                    textStyle: const TextStyle(fontSize: 16.0, color: Theme.of(context).colorScheme.onSurface, fontWeight: FontWeight.bold),
                                   ),
                                   const SizedBox(
                                     height: 20,
@@ -202,7 +202,7 @@ class _CoachSlotSelectionScreenState extends State<CoachSlotSelectionScreen> {
                                         textStyle: Theme.of(context)
                                             .textTheme
                                             .titleMedium!
-                                            .copyWith(fontSize: 20, fontWeight: FontWeight.w500, color: const Color(0xFF333333)),
+                                            .copyWith(fontSize: 20, fontWeight: FontWeight.w500, color: Theme.of(context).colorScheme.onSurface),
                                       ),
                                     ],
                                   ),
@@ -239,8 +239,8 @@ class _CoachSlotSelectionScreenState extends State<CoachSlotSelectionScreen> {
                                   padding: const EdgeInsets.only(left: 20, right: 20),
                                   child: CustomTextView(
                                     label: 'Minimum Slot : ${_calendarViewModel.coachDetailsResponseModel!.minumumSlot}',
-                                    color: Colors.black,
-                                    textStyle: const TextStyle(fontSize: 16.0, color: OQDOThemeData.blackColor, fontWeight: FontWeight.bold),
+                                    color: Theme.of(context).colorScheme.onSurface,
+                                    textStyle: const TextStyle(fontSize: 16.0, color: Theme.of(context).colorScheme.onSurface, fontWeight: FontWeight.bold),
                                   ),
                                 ),
                                 const SizedBox(
@@ -262,7 +262,7 @@ class _CoachSlotSelectionScreenState extends State<CoachSlotSelectionScreen> {
                                     textStyle: Theme.of(context)
                                         .textTheme
                                         .titleMedium!
-                                        .copyWith(fontSize: 16, color: OQDOThemeData.greyColor, fontWeight: FontWeight.w500),
+                                        .copyWith(fontSize: 16, color: Theme.of(context).colorScheme.onSurface, fontWeight: FontWeight.w500),
                                   ),
                                 ),
                               ],
@@ -280,14 +280,14 @@ class _CoachSlotSelectionScreenState extends State<CoachSlotSelectionScreen> {
                             CustomTextView(
                               label: 'Total Amount',
                               textStyle:
-                                  Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 18, color: OQDOThemeData.greyColor, fontWeight: FontWeight.w500),
+                                  Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 18, color: Theme.of(context).colorScheme.onSurface, fontWeight: FontWeight.w500),
                             ),
                             const Spacer(),
                             CustomTextView(
                               label: 'S\$ ${totalAmount.toStringAsFixed(2)}',
                               textStyle: Theme.of(context).textTheme.titleLarge!.copyWith(
                                     fontWeight: FontWeight.w400,
-                                    color: OQDOThemeData.greyColor,
+                                    color: Theme.of(context).colorScheme.onSurface,
                                     fontSize: 20,
                                   ),
                             )
@@ -303,7 +303,7 @@ class _CoachSlotSelectionScreenState extends State<CoachSlotSelectionScreen> {
                         maxLine: 3,
                         label: 'Booking timeout. Please Return to Home and book again.',
                         textStyle:
-                            Theme.of(context).textTheme.titleMedium!.copyWith(fontWeight: FontWeight.w700, color: OQDOThemeData.errorColor, fontSize: 20),
+                            Theme.of(context).textTheme.titleMedium!.copyWith(fontWeight: FontWeight.w700, color: Theme.of(context).colorScheme.error, fontSize: 20),
                       )
                     : isTimingShow
                         ? CountdownTimerWidget(
@@ -383,7 +383,7 @@ class _CoachSlotSelectionScreenState extends State<CoachSlotSelectionScreen> {
         children: [
           CustomTextView(
             label: monthStr,
-            textStyle: Theme.of(context).textTheme.titleLarge!.copyWith(fontSize: 20, fontWeight: FontWeight.w500, color: const Color(0xFF333333)),
+            textStyle: Theme.of(context).textTheme.titleLarge!.copyWith(fontSize: 20, fontWeight: FontWeight.w500, color: Theme.of(context).colorScheme.onSurface),
           ),
           const Spacer(),
           GestureDetector(
@@ -437,13 +437,13 @@ class _CoachSlotSelectionScreenState extends State<CoachSlotSelectionScreen> {
             headerVisible: false,
             daysOfWeekVisible: true,
             daysOfWeekStyle: const DaysOfWeekStyle(
-                weekdayStyle: TextStyle(color: Color(0xFF006590), fontWeight: FontWeight.w500),
-                weekendStyle: TextStyle(color: Color(0xFF006590), fontWeight: FontWeight.w500)),
+                weekdayStyle: TextStyle(color: Theme.of(context).colorScheme.primary, fontWeight: FontWeight.w500),
+                weekendStyle: TextStyle(color: Theme.of(context).colorScheme.primary, fontWeight: FontWeight.w500)),
             calendarStyle: CalendarStyle(
               isTodayHighlighted: false,
               outsideDaysVisible: false,
               selectedDecoration: BoxDecoration(color: Theme.of(context).colorScheme.primary, shape: BoxShape.circle),
-              defaultTextStyle: const TextStyle(fontSize: 15, fontWeight: FontWeight.w400, color: Colors.black),
+              defaultTextStyle: const TextStyle(fontSize: 15, fontWeight: FontWeight.w400, color: Theme.of(context).colorScheme.onSurface),
             ),
             onDaySelected: _onDaySelected,
             selectedDayPredicate: (DateTime date) {
@@ -485,13 +485,13 @@ class _CoachSlotSelectionScreenState extends State<CoachSlotSelectionScreen> {
                           border: Border.all(
                             color: Theme.of(context).colorScheme.primary,
                           ),
-                          color: const Color(0xFFCCCCCC),
+                          color: Theme.of(context).colorScheme.outline,
                         ),
                         child: Center(
                           child: CustomTextView(
                             label: '${_singleFacilityDatesList[0].listOfSlots![index].startTime} - ${_singleFacilityDatesList[0].listOfSlots![index].endTime}',
                             type: styleSubTitle,
-                            textStyle: Theme.of(context).textTheme.titleSmall!.copyWith(color: OQDOThemeData.greyColor),
+                            textStyle: Theme.of(context).textTheme.titleSmall!.copyWith(color: Theme.of(context).colorScheme.onSurface),
                           ),
                         ),
                       ),
@@ -509,7 +509,7 @@ class _CoachSlotSelectionScreenState extends State<CoachSlotSelectionScreen> {
                             CustomTextView(
                               label: _singleFacilityDatesList[0].listOfSlots![index].availableSeat.toString(),
                               textStyle:
-                                  Theme.of(context).textTheme.titleSmall!.copyWith(fontSize: 14, color: OQDOThemeData.blackColor, fontWeight: FontWeight.w300),
+                                  Theme.of(context).textTheme.titleSmall!.copyWith(fontSize: 14, color: Theme.of(context).colorScheme.onSurface, fontWeight: FontWeight.w300),
                             ),
                             const SizedBox(
                               width: 5,
@@ -524,7 +524,7 @@ class _CoachSlotSelectionScreenState extends State<CoachSlotSelectionScreen> {
                         CustomTextView(
                           label: 'Available',
                           textStyle:
-                              Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 10, fontWeight: FontWeight.w500, color: const Color(0xFF333333)),
+                              Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 10, fontWeight: FontWeight.w500, color: Theme.of(context).colorScheme.onSurface),
                         ),
                         const SizedBox(
                           height: 5,
@@ -542,16 +542,16 @@ class _CoachSlotSelectionScreenState extends State<CoachSlotSelectionScreen> {
                           child: Container(
                             decoration: BoxDecoration(
                               border: Border.all(
-                                color: _singleFacilityDatesList[0].listOfSlots![index].isSlotSelected ? Colors.green : Colors.blue,
+                                color: _singleFacilityDatesList[0].listOfSlots![index].isSlotSelected ? Theme.of(context).extension<CustomColors>()!.greenAmount : Theme.of(context).colorScheme.primary,
                               ),
-                              color: _singleFacilityDatesList[0].listOfSlots![index].isSlotSelected ? Colors.green : Colors.blue,
+                              color: _singleFacilityDatesList[0].listOfSlots![index].isSlotSelected ? Theme.of(context).extension<CustomColors>()!.greenAmount : Theme.of(context).colorScheme.primary,
                             ),
                             child: Center(
                               child: CustomTextView(
                                 label:
                                     '${_singleFacilityDatesList[0].listOfSlots![index].startTime} - ${_singleFacilityDatesList[0].listOfSlots![index].endTime}',
                                 type: styleSubTitle,
-                                textStyle: Theme.of(context).textTheme.titleSmall!.copyWith(color: OQDOThemeData.whiteColor),
+                                textStyle: Theme.of(context).textTheme.titleSmall!.copyWith(color: Theme.of(context).extension<CustomColors>()!.white),
                               ),
                             ),
                           ),
@@ -571,7 +571,7 @@ class _CoachSlotSelectionScreenState extends State<CoachSlotSelectionScreen> {
                                   textStyle: Theme.of(context)
                                       .textTheme
                                       .titleSmall!
-                                      .copyWith(fontSize: 14, color: OQDOThemeData.blackColor, fontWeight: FontWeight.w300),
+                                      .copyWith(fontSize: 14, color: Theme.of(context).colorScheme.onSurface, fontWeight: FontWeight.w300),
                                 ),
                                 const SizedBox(
                                   width: 5,
@@ -586,7 +586,7 @@ class _CoachSlotSelectionScreenState extends State<CoachSlotSelectionScreen> {
                             CustomTextView(
                               label: 'Available',
                               textStyle:
-                                  Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 10, fontWeight: FontWeight.w500, color: const Color(0xFF333333)),
+                                  Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 10, fontWeight: FontWeight.w500, color: Theme.of(context).colorScheme.onSurface),
                             ),
                             const SizedBox(
                               height: 5,
@@ -603,9 +603,9 @@ class _CoachSlotSelectionScreenState extends State<CoachSlotSelectionScreen> {
                           child: Container(
                             decoration: BoxDecoration(
                               border: Border.all(
-                                color: _singleFacilityDatesList[0].listOfSlots![index].isSlotSelected ? Colors.green : const Color(0xFFCCCCCC),
+                                color: _singleFacilityDatesList[0].listOfSlots![index].isSlotSelected ? Theme.of(context).extension<CustomColors>()!.greenAmount : Theme.of(context).colorScheme.outline,
                               ),
-                              color: _singleFacilityDatesList[0].listOfSlots![index].isSlotSelected ? Colors.green : const Color(0xFFCCCCCC),
+                              color: _singleFacilityDatesList[0].listOfSlots![index].isSlotSelected ? Theme.of(context).extension<CustomColors>()!.greenAmount : Theme.of(context).colorScheme.outline,
                             ),
                             child: Center(
                               child: CustomTextView(
@@ -632,7 +632,7 @@ class _CoachSlotSelectionScreenState extends State<CoachSlotSelectionScreen> {
                                   textStyle: Theme.of(context)
                                       .textTheme
                                       .titleSmall!
-                                      .copyWith(fontSize: 14, color: OQDOThemeData.blackColor, fontWeight: FontWeight.w300),
+                                      .copyWith(fontSize: 14, color: Theme.of(context).colorScheme.onSurface, fontWeight: FontWeight.w300),
                                 ),
                                 const SizedBox(
                                   width: 5,
@@ -647,7 +647,7 @@ class _CoachSlotSelectionScreenState extends State<CoachSlotSelectionScreen> {
                             CustomTextView(
                               label: 'Available',
                               textStyle:
-                                  Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 10, fontWeight: FontWeight.w500, color: const Color(0xFF333333)),
+                                  Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 10, fontWeight: FontWeight.w500, color: Theme.of(context).colorScheme.onSurface),
                             ),
                             const SizedBox(
                               height: 5,
@@ -956,7 +956,7 @@ class _CoachSlotSelectionScreenState extends State<CoachSlotSelectionScreen> {
                         label:
                             'It appears that you have a scheduled meetup at the chosen time. To prevent any conflicts, you can either unfreeze the slot or request a time change from the meetup creator',
                         maxLine: 5,
-                        textStyle: const TextStyle(fontSize: 15, color: Colors.black),
+                        textStyle: const TextStyle(fontSize: 15, color: Theme.of(context).colorScheme.onSurface),
                         textOverFlow: TextOverflow.ellipsis,
                       ),
                       actions: [
@@ -1115,7 +1115,7 @@ class _CoachSlotSelectionScreenState extends State<CoachSlotSelectionScreen> {
     }
 
     return Container(
-      color: OQDOThemeData.whiteColor,
+      color: Theme.of(context).extension<CustomColors>()!.white,
       width: MediaQuery.of(context).size.width,
       height: MediaQuery.of(context).size.height / 1.2,
       child: SingleChildScrollView(
@@ -1132,14 +1132,14 @@ class _CoachSlotSelectionScreenState extends State<CoachSlotSelectionScreen> {
             ),
             CustomTextView(
               label: '${_currentDay.split("-")[0]} ${_currentDay.split('-')[1]} ${_currentDay.split('-')[2]}',
-              textStyle: Theme.of(context).textTheme.titleLarge!.copyWith(fontSize: 21, color: const Color(0xFF333333), fontWeight: FontWeight.w500),
+              textStyle: Theme.of(context).textTheme.titleLarge!.copyWith(fontSize: 21, color: Theme.of(context).colorScheme.onSurface, fontWeight: FontWeight.w500),
             ),
             const SizedBox(
               height: 3,
             ),
             CustomTextView(
               label: initSelectedDate,
-              textStyle: Theme.of(context).textTheme.titleLarge!.copyWith(fontSize: 21, color: const Color(0xFF333333), fontWeight: FontWeight.w500),
+              textStyle: Theme.of(context).textTheme.titleLarge!.copyWith(fontSize: 21, color: Theme.of(context).colorScheme.onSurface, fontWeight: FontWeight.w500),
             ),
             Padding(
               padding: const EdgeInsets.only(top: 40, left: 25, right: 25),
@@ -1152,13 +1152,13 @@ class _CoachSlotSelectionScreenState extends State<CoachSlotSelectionScreen> {
                 daysOfWeekVisible: true,
                 currentDay: kToday,
                 daysOfWeekStyle: const DaysOfWeekStyle(
-                    weekdayStyle: TextStyle(color: Color(0xFF006590), fontWeight: FontWeight.w500),
-                    weekendStyle: TextStyle(color: Color(0xFF006590), fontWeight: FontWeight.w500)),
+                    weekdayStyle: TextStyle(color: Theme.of(context).colorScheme.primary, fontWeight: FontWeight.w500),
+                    weekendStyle: TextStyle(color: Theme.of(context).colorScheme.primary, fontWeight: FontWeight.w500)),
                 calendarStyle: CalendarStyle(
                   isTodayHighlighted: false,
                   outsideDaysVisible: false,
                   selectedDecoration: BoxDecoration(color: Theme.of(context).colorScheme.primary, shape: BoxShape.circle),
-                  defaultTextStyle: const TextStyle(fontSize: 15, fontWeight: FontWeight.w400, color: Colors.black),
+                  defaultTextStyle: const TextStyle(fontSize: 15, fontWeight: FontWeight.w400, color: Theme.of(context).colorScheme.onSurface),
                 ),
                 onCalendarCreated: (controller) {
                   _pageController = controller;
@@ -1215,14 +1215,14 @@ class _CoachSlotSelectionScreenState extends State<CoachSlotSelectionScreen> {
             children: [
               CustomTextView(
                 label: headerText.split(' ')[0],
-                textStyle: Theme.of(context).textTheme.titleLarge!.copyWith(fontSize: 21, fontWeight: FontWeight.w700, color: const Color(0xFF333333)),
+                textStyle: Theme.of(context).textTheme.titleLarge!.copyWith(fontSize: 21, fontWeight: FontWeight.w700, color: Theme.of(context).colorScheme.onSurface),
               ),
               const SizedBox(
                 height: 5,
               ),
               CustomTextView(
                 label: headerText.split(' ')[1],
-                textStyle: Theme.of(context).textTheme.titleLarge!.copyWith(fontSize: 21, fontWeight: FontWeight.w700, color: const Color(0xFF333333)),
+                textStyle: Theme.of(context).textTheme.titleLarge!.copyWith(fontSize: 21, fontWeight: FontWeight.w700, color: Theme.of(context).colorScheme.onSurface),
               ),
             ],
           ),

--- a/lib/screens/slot_management/facility_cancel_slot_management_screen.dart
+++ b/lib/screens/slot_management/facility_cancel_slot_management_screen.dart
@@ -10,7 +10,7 @@ import 'package:oqdo_mobile_app/model/calendar_view_model.dart';
 import 'package:oqdo_mobile_app/model/cancel_reason_view_model.dart';
 import 'package:oqdo_mobile_app/model/facility_slot_booking_model.dart';
 import 'package:oqdo_mobile_app/model/get_21_days_slot_response_model.dart';
-import 'package:oqdo_mobile_app/theme/oqdo_theme_data.dart';
+import 'package:oqdo_mobile_app/theme/custom_colors.dart';
 import 'package:oqdo_mobile_app/utils/constants.dart';
 import 'package:oqdo_mobile_app/utils/custom_text_view.dart';
 import 'package:oqdo_mobile_app/utils/network_interceptor.dart';
@@ -82,7 +82,7 @@ class _FacilityCancelSlotManagementScreenState extends State<FacilityCancelSlotM
       ),
       body: SafeArea(
         child: Container(
-          color: OQDOThemeData.whiteColor,
+          color: Theme.of(context).extension<CustomColors>()!.white,
           width: MediaQuery.of(context).size.width,
           height: double.infinity,
           child: Column(
@@ -109,7 +109,7 @@ class _FacilityCancelSlotManagementScreenState extends State<FacilityCancelSlotM
                                       textStyle: Theme.of(context)
                                           .textTheme
                                           .titleMedium!
-                                          .copyWith(fontSize: 20, fontWeight: FontWeight.w500, color: const Color(0xFF333333)),
+                                          .copyWith(fontSize: 20, fontWeight: FontWeight.w500, color: Theme.of(context).colorScheme.onSurface),
                                     ),
                                     const Spacer(),
                                     CustomTextView(
@@ -117,7 +117,7 @@ class _FacilityCancelSlotManagementScreenState extends State<FacilityCancelSlotM
                                       textStyle: Theme.of(context)
                                           .textTheme
                                           .titleMedium!
-                                          .copyWith(fontSize: 15, fontWeight: FontWeight.w500, color: const Color(0xFFABABAB)),
+                                          .copyWith(fontSize: 15, fontWeight: FontWeight.w500, color: Theme.of(context).extension<CustomColors>()!.greyText),
                                     ),
                                   ],
                                 ),
@@ -162,7 +162,7 @@ class _FacilityCancelSlotManagementScreenState extends State<FacilityCancelSlotM
                                 textStyle: Theme.of(context)
                                     .textTheme
                                     .titleMedium!
-                                    .copyWith(fontSize: 16, color: OQDOThemeData.greyColor, fontWeight: FontWeight.w500),
+                                    .copyWith(fontSize: 16, color: Theme.of(context).colorScheme.onSurface, fontWeight: FontWeight.w500),
                               ),
                             ],
                           ),
@@ -202,7 +202,7 @@ class _FacilityCancelSlotManagementScreenState extends State<FacilityCancelSlotM
                             maxLine: 3,
                             textOverFlow: TextOverflow.ellipsis,
                             textStyle:
-                                Theme.of(context).textTheme.titleMedium!.copyWith(color: OQDOThemeData.errorColor, fontSize: 16, fontWeight: FontWeight.w400),
+                                Theme.of(context).textTheme.titleMedium!.copyWith(color: Theme.of(context).colorScheme.error, fontSize: 16, fontWeight: FontWeight.w400),
                           ),
                         ),
                       ],
@@ -222,7 +222,7 @@ class _FacilityCancelSlotManagementScreenState extends State<FacilityCancelSlotM
         children: [
           CustomTextView(
             label: monthStr,
-            textStyle: Theme.of(context).textTheme.titleLarge!.copyWith(fontSize: 20, fontWeight: FontWeight.w500, color: const Color(0xFF333333)),
+            textStyle: Theme.of(context).textTheme.titleLarge!.copyWith(fontSize: 20, fontWeight: FontWeight.w500, color: Theme.of(context).colorScheme.onSurface),
           ),
           const Spacer(),
           GestureDetector(
@@ -275,13 +275,13 @@ class _FacilityCancelSlotManagementScreenState extends State<FacilityCancelSlotM
             headerVisible: false,
             daysOfWeekVisible: true,
             daysOfWeekStyle: const DaysOfWeekStyle(
-                weekdayStyle: TextStyle(color: Color(0xFF006590), fontWeight: FontWeight.w500),
-                weekendStyle: TextStyle(color: Color(0xFF006590), fontWeight: FontWeight.w500)),
+                weekdayStyle: TextStyle(color: Theme.of(context).colorScheme.primary, fontWeight: FontWeight.w500),
+                weekendStyle: TextStyle(color: Theme.of(context).colorScheme.primary, fontWeight: FontWeight.w500)),
             calendarStyle: CalendarStyle(
               isTodayHighlighted: false,
               outsideDaysVisible: false,
               selectedDecoration: BoxDecoration(color: Theme.of(context).colorScheme.primary, shape: BoxShape.circle),
-              defaultTextStyle: const TextStyle(fontSize: 15, fontWeight: FontWeight.w400, color: Colors.black),
+              defaultTextStyle: const TextStyle(fontSize: 15, fontWeight: FontWeight.w400, color: Theme.of(context).colorScheme.onSurface),
             ),
             onDaySelected: _onDaySelected,
             selectedDayPredicate: (DateTime date) {
@@ -324,13 +324,13 @@ class _FacilityCancelSlotManagementScreenState extends State<FacilityCancelSlotM
                       border: Border.all(
                         color: Theme.of(context).colorScheme.primary,
                       ),
-                      color: const Color(0xFFCCCCCC),
+                      color: Theme.of(context).colorScheme.outline,
                     ),
                     child: Center(
                       child: CustomTextView(
                         label: '${_singleFacilityDatesList[0].listOfSlots![index].startTime} - ${_singleFacilityDatesList[0].listOfSlots![index].endTime}',
                         type: styleSubTitle,
-                        textStyle: Theme.of(context).textTheme.titleSmall!.copyWith(color: OQDOThemeData.greyColor),
+                        textStyle: Theme.of(context).textTheme.titleSmall!.copyWith(color: Theme.of(context).colorScheme.onSurface),
                       ),
                     ),
                   ),
@@ -348,7 +348,7 @@ class _FacilityCancelSlotManagementScreenState extends State<FacilityCancelSlotM
                         CustomTextView(
                           label: _singleFacilityDatesList[0].listOfSlots![index].bookedSeat.toString(),
                           textStyle:
-                              Theme.of(context).textTheme.titleSmall!.copyWith(fontSize: 14, color: OQDOThemeData.blackColor, fontWeight: FontWeight.w300),
+                              Theme.of(context).textTheme.titleSmall!.copyWith(fontSize: 14, color: Theme.of(context).colorScheme.onSurface, fontWeight: FontWeight.w300),
                         ),
                         const SizedBox(
                           width: 5,
@@ -362,7 +362,7 @@ class _FacilityCancelSlotManagementScreenState extends State<FacilityCancelSlotM
                     ),
                     CustomTextView(
                       label: 'Booked',
-                      textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 10, fontWeight: FontWeight.w500, color: const Color(0xFF333333)),
+                      textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 10, fontWeight: FontWeight.w500, color: Theme.of(context).colorScheme.onSurface),
                     ),
                     const SizedBox(
                       height: 5,
@@ -382,13 +382,13 @@ class _FacilityCancelSlotManagementScreenState extends State<FacilityCancelSlotM
                           border: Border.all(
                             color: Theme.of(context).colorScheme.primary,
                           ),
-                          color: const Color(0xFFCCCCCC),
+                          color: Theme.of(context).colorScheme.outline,
                         ),
                         child: Center(
                           child: CustomTextView(
                             label: '${_singleFacilityDatesList[0].listOfSlots![index].startTime} - ${_singleFacilityDatesList[0].listOfSlots![index].endTime}',
                             type: styleSubTitle,
-                            textStyle: Theme.of(context).textTheme.titleSmall!.copyWith(color: OQDOThemeData.greyColor),
+                            textStyle: Theme.of(context).textTheme.titleSmall!.copyWith(color: Theme.of(context).colorScheme.onSurface),
                           ),
                         ),
                       ),
@@ -406,7 +406,7 @@ class _FacilityCancelSlotManagementScreenState extends State<FacilityCancelSlotM
                             CustomTextView(
                               label: _singleFacilityDatesList[0].listOfSlots![index].bookedSeat.toString(),
                               textStyle:
-                                  Theme.of(context).textTheme.titleSmall!.copyWith(fontSize: 14, color: OQDOThemeData.blackColor, fontWeight: FontWeight.w300),
+                                  Theme.of(context).textTheme.titleSmall!.copyWith(fontSize: 14, color: Theme.of(context).colorScheme.onSurface, fontWeight: FontWeight.w300),
                             ),
                             const SizedBox(
                               width: 5,
@@ -421,7 +421,7 @@ class _FacilityCancelSlotManagementScreenState extends State<FacilityCancelSlotM
                         CustomTextView(
                           label: 'Booked',
                           textStyle:
-                              Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 10, fontWeight: FontWeight.w500, color: const Color(0xFF333333)),
+                              Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 10, fontWeight: FontWeight.w500, color: Theme.of(context).colorScheme.onSurface),
                         ),
                         const SizedBox(
                           height: 5,
@@ -438,15 +438,15 @@ class _FacilityCancelSlotManagementScreenState extends State<FacilityCancelSlotM
                       child: Container(
                         decoration: BoxDecoration(
                           border: Border.all(
-                            color: _singleFacilityDatesList[0].listOfSlots![index].isSlotSelected ? Colors.green : Colors.blue,
+                            color: _singleFacilityDatesList[0].listOfSlots![index].isSlotSelected ? Theme.of(context).extension<CustomColors>()!.greenAmount : Theme.of(context).colorScheme.primary,
                           ),
-                          color: _singleFacilityDatesList[0].listOfSlots![index].isSlotSelected ? Colors.green : Colors.blue,
+                          color: _singleFacilityDatesList[0].listOfSlots![index].isSlotSelected ? Theme.of(context).extension<CustomColors>()!.greenAmount : Theme.of(context).colorScheme.primary,
                         ),
                         child: Center(
                           child: CustomTextView(
                             label: '${_singleFacilityDatesList[0].listOfSlots![index].startTime} - ${_singleFacilityDatesList[0].listOfSlots![index].endTime}',
                             type: styleSubTitle,
-                            textStyle: Theme.of(context).textTheme.titleSmall!.copyWith(color: OQDOThemeData.whiteColor),
+                            textStyle: Theme.of(context).textTheme.titleSmall!.copyWith(color: Theme.of(context).extension<CustomColors>()!.white),
                           ),
                         ),
                       ),
@@ -464,7 +464,7 @@ class _FacilityCancelSlotManagementScreenState extends State<FacilityCancelSlotM
                             CustomTextView(
                               label: _singleFacilityDatesList[0].listOfSlots![index].bookedSeat.toString(),
                               textStyle:
-                                  Theme.of(context).textTheme.titleSmall!.copyWith(fontSize: 14, color: OQDOThemeData.blackColor, fontWeight: FontWeight.w300),
+                                  Theme.of(context).textTheme.titleSmall!.copyWith(fontSize: 14, color: Theme.of(context).colorScheme.onSurface, fontWeight: FontWeight.w300),
                             ),
                             const SizedBox(
                               width: 5,
@@ -479,7 +479,7 @@ class _FacilityCancelSlotManagementScreenState extends State<FacilityCancelSlotM
                         CustomTextView(
                           label: 'Booked',
                           textStyle:
-                              Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 10, fontWeight: FontWeight.w500, color: const Color(0xFF333333)),
+                              Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 10, fontWeight: FontWeight.w500, color: Theme.of(context).colorScheme.onSurface),
                         ),
                         const SizedBox(
                           height: 5,
@@ -735,7 +735,7 @@ class _FacilityCancelSlotManagementScreenState extends State<FacilityCancelSlotM
     }
 
     return Container(
-      color: OQDOThemeData.whiteColor,
+      color: Theme.of(context).extension<CustomColors>()!.white,
       width: MediaQuery.of(context).size.width,
       height: MediaQuery.of(context).size.height / 1.2,
       child: SingleChildScrollView(
@@ -752,14 +752,14 @@ class _FacilityCancelSlotManagementScreenState extends State<FacilityCancelSlotM
             ),
             CustomTextView(
               label: '${_currentDay.split("-")[0]} ${_currentDay.split('-')[1]} ${_currentDay.split('-')[2]}',
-              textStyle: Theme.of(context).textTheme.titleLarge!.copyWith(fontSize: 21, color: const Color(0xFF333333), fontWeight: FontWeight.w500),
+              textStyle: Theme.of(context).textTheme.titleLarge!.copyWith(fontSize: 21, color: Theme.of(context).colorScheme.onSurface, fontWeight: FontWeight.w500),
             ),
             const SizedBox(
               height: 3,
             ),
             CustomTextView(
               label: initSelectedDate,
-              textStyle: Theme.of(context).textTheme.titleLarge!.copyWith(fontSize: 21, color: const Color(0xFF333333), fontWeight: FontWeight.w500),
+              textStyle: Theme.of(context).textTheme.titleLarge!.copyWith(fontSize: 21, color: Theme.of(context).colorScheme.onSurface, fontWeight: FontWeight.w500),
             ),
             Padding(
               padding: const EdgeInsets.only(top: 40, left: 25, right: 25),
@@ -772,13 +772,13 @@ class _FacilityCancelSlotManagementScreenState extends State<FacilityCancelSlotM
                 daysOfWeekVisible: true,
                 currentDay: kToday,
                 daysOfWeekStyle: const DaysOfWeekStyle(
-                    weekdayStyle: TextStyle(color: Color(0xFF006590), fontWeight: FontWeight.w500),
-                    weekendStyle: TextStyle(color: Color(0xFF006590), fontWeight: FontWeight.w500)),
+                    weekdayStyle: TextStyle(color: Theme.of(context).colorScheme.primary, fontWeight: FontWeight.w500),
+                    weekendStyle: TextStyle(color: Theme.of(context).colorScheme.primary, fontWeight: FontWeight.w500)),
                 calendarStyle: CalendarStyle(
                   isTodayHighlighted: true,
                   outsideDaysVisible: false,
                   selectedDecoration: BoxDecoration(color: Theme.of(context).colorScheme.primary, shape: BoxShape.circle),
-                  defaultTextStyle: const TextStyle(fontSize: 15, fontWeight: FontWeight.w400, color: Colors.black),
+                  defaultTextStyle: const TextStyle(fontSize: 15, fontWeight: FontWeight.w400, color: Theme.of(context).colorScheme.onSurface),
                 ),
                 onCalendarCreated: (controller) {
                   _pageController = controller;
@@ -835,14 +835,14 @@ class _FacilityCancelSlotManagementScreenState extends State<FacilityCancelSlotM
             children: [
               CustomTextView(
                 label: headerText.split(' ')[0],
-                textStyle: Theme.of(context).textTheme.titleLarge!.copyWith(fontSize: 21, fontWeight: FontWeight.w700, color: const Color(0xFF333333)),
+                textStyle: Theme.of(context).textTheme.titleLarge!.copyWith(fontSize: 21, fontWeight: FontWeight.w700, color: Theme.of(context).colorScheme.onSurface),
               ),
               const SizedBox(
                 height: 5,
               ),
               CustomTextView(
                 label: headerText.split(' ')[1],
-                textStyle: Theme.of(context).textTheme.titleLarge!.copyWith(fontSize: 21, fontWeight: FontWeight.w700, color: const Color(0xFF333333)),
+                textStyle: Theme.of(context).textTheme.titleLarge!.copyWith(fontSize: 21, fontWeight: FontWeight.w700, color: Theme.of(context).colorScheme.onSurface),
               ),
             ],
           ),

--- a/lib/screens/slot_management/review_coach_booking_screen.dart
+++ b/lib/screens/slot_management/review_coach_booking_screen.dart
@@ -18,7 +18,6 @@ import 'package:oqdo_mobile_app/oqdo_application.dart';
 import 'package:oqdo_mobile_app/screens/appointment/intent/selected_coupon_intent.dart';
 import 'package:oqdo_mobile_app/screens/appointment/views/appointment_btn_view.dart';
 import 'package:oqdo_mobile_app/screens/appointment/views/selected_discount_view.dart';
-import 'package:oqdo_mobile_app/theme/oqdo_theme_data.dart';
 import 'package:oqdo_mobile_app/utils/constants.dart';
 import 'package:oqdo_mobile_app/utils/custom_text_view.dart';
 import 'package:oqdo_mobile_app/utils/extentions.dart';
@@ -114,7 +113,7 @@ class _ReviewCoachBookingScreenState extends State<ReviewCoachBookingScreen> {
           child: Container(
             width: MediaQuery.of(context).size.width,
             height: MediaQuery.of(context).size.height,
-            color: Theme.of(context).colorScheme.onBackground,
+            color: Theme.of(context).extension<CustomColors>()!.white,
             child: _coachBookingListModelResponse != null
                 ? Column(
                     crossAxisAlignment: CrossAxisAlignment.start,
@@ -138,7 +137,7 @@ class _ReviewCoachBookingScreenState extends State<ReviewCoachBookingScreen> {
                                     textStyle: Theme.of(context)
                                         .textTheme
                                         .titleLarge!
-                                        .copyWith(fontSize: 20, color: OQDOThemeData.greyColor, fontWeight: FontWeight.w500),
+                                        .copyWith(fontSize: 20, color: Theme.of(context).colorScheme.onSurface, fontWeight: FontWeight.w500),
                                   ),
                                 ),
                                 const SizedBox(
@@ -154,7 +153,7 @@ class _ReviewCoachBookingScreenState extends State<ReviewCoachBookingScreen> {
                                           label: 'Slots',
                                           textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(
                                                 fontSize: 16,
-                                                color: OQDOThemeData.otherTextColor.withOpacity(0.6),
+                                                color: Theme.of(context).extension<CustomColors>()!.greyText.withOpacity(0.6),
                                                 fontWeight: FontWeight.w500,
                                                 decoration: TextDecoration.underline,
                                               ),
@@ -168,7 +167,7 @@ class _ReviewCoachBookingScreenState extends State<ReviewCoachBookingScreen> {
                                         isStrikeThrough: true,
                                         textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(
                                               fontSize: 16,
-                                              color: OQDOThemeData.otherTextColor.withOpacity(0.6),
+                                              color: Theme.of(context).extension<CustomColors>()!.greyText.withOpacity(0.6),
                                               fontWeight: FontWeight.w500,
                                               decoration: TextDecoration.underline,
                                             ),
@@ -202,9 +201,9 @@ class _ReviewCoachBookingScreenState extends State<ReviewCoachBookingScreen> {
                                         },
                                         child: Container(
                                           decoration: BoxDecoration(
-                                            color: const Color(0xFF0099FA).withOpacity(0.1),
+                                            color: const Theme.of(context).colorScheme.primary.withOpacity(0.1),
                                             borderRadius: BorderRadius.circular(8),
-                                            border: Border.all(color: const Color(0xFF0099FA).withOpacity(0.5), width: 2),
+                                            border: Border.all(color: const Theme.of(context).colorScheme.primary.withOpacity(0.5), width: 2),
                                           ),
                                           padding: const EdgeInsets.all(15.0),
                                           margin: const EdgeInsets.all(10.0),
@@ -220,7 +219,7 @@ class _ReviewCoachBookingScreenState extends State<ReviewCoachBookingScreen> {
                                                 'View All Coupons',
                                                 style: TextStyle(
                                                   fontSize: 16.0,
-                                                  color: Color(0xFF0099FA),
+                                                  color: Theme.of(context).colorScheme.primary,
                                                   fontWeight: FontWeight.w600,
                                                 ),
                                               ),
@@ -262,7 +261,7 @@ class _ReviewCoachBookingScreenState extends State<ReviewCoachBookingScreen> {
                                     textStyle: Theme.of(context)
                                         .textTheme
                                         .titleSmall!
-                                        .copyWith(fontSize: 16.0, fontWeight: FontWeight.w400, color: OQDOThemeData.greyColor),
+                                        .copyWith(fontSize: 16.0, fontWeight: FontWeight.w400, color: Theme.of(context).colorScheme.onSurface),
                                   ),
                                 ),
                                 const SizedBox(height: 100.0),
@@ -273,10 +272,10 @@ class _ReviewCoachBookingScreenState extends State<ReviewCoachBookingScreen> {
                       ),
                       Container(
                         decoration: BoxDecoration(
-                          color: Colors.white,
+                          color: Theme.of(context).extension<CustomColors>()!.white,
                           boxShadow: [
                             BoxShadow(
-                              color: Colors.black.withOpacity(0.1),
+                              color: Theme.of(context).colorScheme.onSurface.withOpacity(0.1),
                               spreadRadius: 1,
                               blurRadius: 5,
                               offset: const Offset(0, -3),
@@ -294,7 +293,7 @@ class _ReviewCoachBookingScreenState extends State<ReviewCoachBookingScreen> {
                                     textStyle: Theme.of(context)
                                         .textTheme
                                         .titleMedium!
-                                        .copyWith(color: OQDOThemeData.greyColor, fontSize: 16, fontWeight: FontWeight.w400),
+                                        .copyWith(color: Theme.of(context).colorScheme.onSurface, fontSize: 16, fontWeight: FontWeight.w400),
                                   )
                                 : CustomTextView(
                                     maxLine: 2,
@@ -302,7 +301,7 @@ class _ReviewCoachBookingScreenState extends State<ReviewCoachBookingScreen> {
                                     textStyle: Theme.of(context)
                                         .textTheme
                                         .titleMedium!
-                                        .copyWith(fontWeight: FontWeight.w700, color: OQDOThemeData.errorColor, fontSize: 20),
+                                        .copyWith(fontWeight: FontWeight.w700, color: Theme.of(context).colorScheme.error, fontSize: 20),
                                   ),
                             const SizedBox(height: 20.0),
                             !isHomeVisible
@@ -398,7 +397,7 @@ class _ReviewCoachBookingScreenState extends State<ReviewCoachBookingScreen> {
                         textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(
                               fontSize: 18.0,
                               fontWeight: FontWeight.w500,
-                              color: OQDOThemeData.greyColor,
+                              color: Theme.of(context).colorScheme.onSurface,
                             ),
                       ),
                       const SizedBox(
@@ -408,7 +407,7 @@ class _ReviewCoachBookingScreenState extends State<ReviewCoachBookingScreen> {
                         label:
                             '${_coachBookingListModelResponse!.coachBookingFreezeSlots![index].startTime} - ${_coachBookingListModelResponse!.coachBookingFreezeSlots![index].endTime}',
                         textStyle:
-                            Theme.of(context).textTheme.titleSmall!.copyWith(fontSize: 12.0, fontWeight: FontWeight.w400, color: OQDOThemeData.greyColor),
+                            Theme.of(context).textTheme.titleSmall!.copyWith(fontSize: 12.0, fontWeight: FontWeight.w400, color: Theme.of(context).colorScheme.onSurface),
                       ),
                       const SizedBox(
                         width: 20,
@@ -416,7 +415,7 @@ class _ReviewCoachBookingScreenState extends State<ReviewCoachBookingScreen> {
                       CustomTextView(
                         label: 'S\$ ${_coachBookingListModelResponse?.coachBookingFreezeSlots?[index].ratePerHour?.toStringAsFixed(2) ?? 0.00}/hour',
                         textStyle:
-                            Theme.of(context).textTheme.titleSmall!.copyWith(fontSize: 12.0, fontWeight: FontWeight.w400, color: OQDOThemeData.greyColor),
+                            Theme.of(context).textTheme.titleSmall!.copyWith(fontSize: 12.0, fontWeight: FontWeight.w400, color: Theme.of(context).colorScheme.onSurface),
                       ),
                     ],
                   ),
@@ -429,7 +428,7 @@ class _ReviewCoachBookingScreenState extends State<ReviewCoachBookingScreen> {
             child: Center(
               child: CustomTextView(
                 label: 'S\$ ${_coachBookingListModelResponse?.coachBookingFreezeSlots?[index].amount?.toStringAsFixed(2) ?? 0.00}',
-                textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 16.0, fontWeight: FontWeight.w500, color: OQDOThemeData.greyColor),
+                textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 16.0, fontWeight: FontWeight.w500, color: Theme.of(context).colorScheme.onSurface),
               ),
             ),
           ),
@@ -704,10 +703,10 @@ class _ReviewCoachBookingScreenState extends State<ReviewCoachBookingScreen> {
                   googlePay: gpay,
                   applePay: const PaymentSheetApplePay(merchantCountryCode: 'SG', buttonType: PlatformButtonType.buy),
                   appearance: const PaymentSheetAppearance(
-                      colors: PaymentSheetAppearanceColors(primary: OQDOThemeData.dividerColor),
+                      colors: PaymentSheetAppearanceColors(primary: Theme.of(context).colorScheme.primary),
                       primaryButton: PaymentSheetPrimaryButtonAppearance(
                           colors: PaymentSheetPrimaryButtonTheme(
-                              light: PaymentSheetPrimaryButtonThemeColors(background: OQDOThemeData.dividerColor, text: Colors.white)))),
+                              light: PaymentSheetPrimaryButtonThemeColors(background: Theme.of(context).colorScheme.primary, text: Theme.of(context).extension<CustomColors>()!.white)))),
                   merchantDisplayName: 'OQDO'))
           .then((value) {});
 
@@ -816,7 +815,7 @@ class _ReviewCoachBookingScreenState extends State<ReviewCoachBookingScreen> {
                       children: [
                         const Icon(
                           Icons.check_circle,
-                          color: Colors.green,
+                          color: Theme.of(context).extension<CustomColors>()!.greenAmount,
                           size: 100.0,
                         ),
                         const SizedBox(height: 10.0),
@@ -902,7 +901,7 @@ class _ReviewCoachBookingScreenState extends State<ReviewCoachBookingScreen> {
                       children: [
                         const Icon(
                           Icons.cancel,
-                          color: Colors.red,
+                          color: Theme.of(context).colorScheme.error,
                           size: 100.0,
                         ),
                         const SizedBox(height: 10.0),
@@ -966,8 +965,8 @@ class _ReviewCoachBookingScreenState extends State<ReviewCoachBookingScreen> {
             padding: const EdgeInsets.symmetric(horizontal: 10.0),
             child: Container(
               decoration: BoxDecoration(
-                color: OQDOThemeData.whiteColor,
-                border: Border.all(color: OQDOThemeData.otherTextColor),
+                color: Theme.of(context).extension<CustomColors>()!.white,
+                border: Border.all(color: Theme.of(context).extension<CustomColors>()!.greyText),
               ),
               padding: const EdgeInsets.all(10.0),
               child: Column(
@@ -978,7 +977,7 @@ class _ReviewCoachBookingScreenState extends State<ReviewCoachBookingScreen> {
                     textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(
                           fontSize: 16.0,
                           fontWeight: FontWeight.w600,
-                          color: OQDOThemeData.buttonColor,
+                          color: Theme.of(context).colorScheme.primary,
                         ),
                   ),
                   const SizedBox(
@@ -999,14 +998,14 @@ class _ReviewCoachBookingScreenState extends State<ReviewCoachBookingScreen> {
                       CustomTextView(
                         label: "Total Amount : ",
                         textStyle:
-                            Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 16.0, fontWeight: FontWeight.w600, color: OQDOThemeData.blackColor),
+                            Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 16.0, fontWeight: FontWeight.w600, color: Theme.of(context).colorScheme.onSurface),
                       ),
                       Column(
                         children: [
                           CustomTextView(
                             label: 'S\$ ${totalAmount.toStringAsFixed(2)}',
                             textStyle:
-                                Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 14.0, fontWeight: FontWeight.w600, color: OQDOThemeData.blackColor),
+                                Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 14.0, fontWeight: FontWeight.w600, color: Theme.of(context).colorScheme.onSurface),
                           ),
                         ],
                       ),
@@ -1016,7 +1015,7 @@ class _ReviewCoachBookingScreenState extends State<ReviewCoachBookingScreen> {
                     height: 10,
                   ),
                   const Divider(
-                    color: OQDOThemeData.greyColor,
+                    color: Theme.of(context).colorScheme.onSurface,
                   ),
                   const SizedBox(
                     height: 10,
@@ -1036,7 +1035,7 @@ class _ReviewCoachBookingScreenState extends State<ReviewCoachBookingScreen> {
                                   textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(
                                       fontSize: 14.0,
                                       fontWeight: FontWeight.w600,
-                                      color: !isCouponSelected ? OQDOThemeData.blackColor : Theme.of(context).colorScheme.secondaryContainer),
+                                      color: !isCouponSelected ? Theme.of(context).colorScheme.onSurface : Theme.of(context).colorScheme.secondaryContainer),
                                 ),
                                 const SizedBox(
                                   height: 3,
@@ -1047,7 +1046,7 @@ class _ReviewCoachBookingScreenState extends State<ReviewCoachBookingScreen> {
                                   textStyle: Theme.of(context)
                                       .textTheme
                                       .titleMedium!
-                                      .copyWith(fontSize: 12.0, fontWeight: FontWeight.w500, color: OQDOThemeData.greyColor),
+                                      .copyWith(fontSize: 12.0, fontWeight: FontWeight.w500, color: Theme.of(context).colorScheme.onSurface),
                                 ).visible(isCouponSelected),
                               ],
                             ),
@@ -1065,7 +1064,7 @@ class _ReviewCoachBookingScreenState extends State<ReviewCoachBookingScreen> {
                                   textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(
                                       fontSize: 13.0,
                                       fontWeight: FontWeight.w600,
-                                      color: !isCouponSelected ? OQDOThemeData.blackColor : Theme.of(context).colorScheme.secondaryContainer),
+                                      color: !isCouponSelected ? Theme.of(context).colorScheme.onSurface : Theme.of(context).colorScheme.secondaryContainer),
                                 ),
                               ],
                             ),
@@ -1097,7 +1096,7 @@ class _ReviewCoachBookingScreenState extends State<ReviewCoachBookingScreen> {
                 children: [
                   CustomTextView(
                     label: title,
-                    textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 14.0, fontWeight: FontWeight.w600, color: OQDOThemeData.blackColor),
+                    textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 14.0, fontWeight: FontWeight.w600, color: Theme.of(context).colorScheme.onSurface),
                   ),
                   const SizedBox(
                     height: 3,
@@ -1105,7 +1104,7 @@ class _ReviewCoachBookingScreenState extends State<ReviewCoachBookingScreen> {
                   CustomTextView(
                     label: details,
                     maxLine: 2,
-                    textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 12.0, fontWeight: FontWeight.w500, color: OQDOThemeData.greyColor),
+                    textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 12.0, fontWeight: FontWeight.w500, color: Theme.of(context).colorScheme.onSurface),
                   ),
                 ],
               ),
@@ -1120,7 +1119,7 @@ class _ReviewCoachBookingScreenState extends State<ReviewCoachBookingScreen> {
                     label: 'S\$ $rate',
                     maxLine: 2,
                     textOverFlow: TextOverflow.ellipsis,
-                    textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 13.0, fontWeight: FontWeight.w600, color: OQDOThemeData.blackColor),
+                    textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 13.0, fontWeight: FontWeight.w600, color: Theme.of(context).colorScheme.onSurface),
                   ),
                 ],
               ),
@@ -1131,7 +1130,7 @@ class _ReviewCoachBookingScreenState extends State<ReviewCoachBookingScreen> {
           height: 3,
         ),
         const Divider(
-          color: OQDOThemeData.greyColor,
+          color: Theme.of(context).colorScheme.onSurface,
         ),
       ],
     );

--- a/lib/screens/slot_management/slot_management_calendar_screen.dart
+++ b/lib/screens/slot_management/slot_management_calendar_screen.dart
@@ -5,7 +5,7 @@ import 'package:intl/intl.dart';
 import 'package:oqdo_mobile_app/components/custom_app_bar.dart';
 import 'package:oqdo_mobile_app/components/my_button.dart';
 import 'package:oqdo_mobile_app/model/calendar_view_model.dart';
-import 'package:oqdo_mobile_app/theme/oqdo_theme_data.dart';
+import 'package:oqdo_mobile_app/theme/custom_colors.dart';
 import 'package:oqdo_mobile_app/utils/constants.dart';
 import 'package:oqdo_mobile_app/utils/custom_text_view.dart';
 import 'package:oqdo_mobile_app/utils/utilities.dart';
@@ -50,7 +50,7 @@ class _SlotManagementCalendarScreenState extends State<SlotManagementCalendarScr
       ),
       body: SafeArea(
         child: Container(
-          color: OQDOThemeData.whiteColor,
+          color: Theme.of(context).extension<CustomColors>()!.white,
           width: MediaQuery.of(context).size.width,
           height: MediaQuery.of(context).size.height,
           child: Column(
@@ -66,14 +66,14 @@ class _SlotManagementCalendarScreenState extends State<SlotManagementCalendarScr
               ),
               CustomTextView(
                 label: '${_currentDay.split("-")[0]} ${_currentDay.split('-')[1]} ${_currentDay.split('-')[2]}',
-                textStyle: Theme.of(context).textTheme.titleLarge!.copyWith(fontSize: 21, color: const Color(0xFF333333), fontWeight: FontWeight.w500),
+                textStyle: Theme.of(context).textTheme.titleLarge!.copyWith(fontSize: 21, color: Theme.of(context).colorScheme.onSurface, fontWeight: FontWeight.w500),
               ),
               const SizedBox(
                 height: 3,
               ),
               CustomTextView(
                 label: initSelectedDate,
-                textStyle: Theme.of(context).textTheme.titleLarge!.copyWith(fontSize: 21, color: const Color(0xFF333333), fontWeight: FontWeight.w500),
+                textStyle: Theme.of(context).textTheme.titleLarge!.copyWith(fontSize: 21, color: Theme.of(context).colorScheme.onSurface, fontWeight: FontWeight.w500),
               ),
               Expanded(
                 child: Padding(
@@ -87,13 +87,13 @@ class _SlotManagementCalendarScreenState extends State<SlotManagementCalendarScr
                     daysOfWeekVisible: true,
                     currentDay: kToday,
                     daysOfWeekStyle: const DaysOfWeekStyle(
-                        weekdayStyle: TextStyle(color: Color(0xFF006590), fontWeight: FontWeight.w500),
-                        weekendStyle: TextStyle(color: Color(0xFF006590), fontWeight: FontWeight.w500)),
+                        weekdayStyle: TextStyle(color: Theme.of(context).colorScheme.primary, fontWeight: FontWeight.w500),
+                        weekendStyle: TextStyle(color: Theme.of(context).colorScheme.primary, fontWeight: FontWeight.w500)),
                     calendarStyle: CalendarStyle(
                       isTodayHighlighted: true,
                       outsideDaysVisible: false,
                       selectedDecoration: BoxDecoration(color: Theme.of(context).colorScheme.primary, shape: BoxShape.circle),
-                      defaultTextStyle: const TextStyle(fontSize: 15, fontWeight: FontWeight.w400, color: Colors.black),
+                      defaultTextStyle: const TextStyle(fontSize: 15, fontWeight: FontWeight.w400, color: Theme.of(context).colorScheme.onSurface),
                     ),
                     onCalendarCreated: (controller) {
                       _pageController = controller;
@@ -163,14 +163,14 @@ class _SlotManagementCalendarScreenState extends State<SlotManagementCalendarScr
             children: [
               CustomTextView(
                 label: headerText.split(' ')[0],
-                textStyle: Theme.of(context).textTheme.titleLarge!.copyWith(fontSize: 21, fontWeight: FontWeight.w700, color: const Color(0xFF333333)),
+                textStyle: Theme.of(context).textTheme.titleLarge!.copyWith(fontSize: 21, fontWeight: FontWeight.w700, color: Theme.of(context).colorScheme.onSurface),
               ),
               const SizedBox(
                 height: 5,
               ),
               CustomTextView(
                 label: headerText.split(' ')[1],
-                textStyle: Theme.of(context).textTheme.titleLarge!.copyWith(fontSize: 21, fontWeight: FontWeight.w700, color: const Color(0xFF333333)),
+                textStyle: Theme.of(context).textTheme.titleLarge!.copyWith(fontSize: 21, fontWeight: FontWeight.w700, color: Theme.of(context).colorScheme.onSurface),
               ),
             ],
           ),

--- a/lib/screens/slot_management/slot_selection_screen.dart
+++ b/lib/screens/slot_management/slot_selection_screen.dart
@@ -15,7 +15,7 @@ import 'package:oqdo_mobile_app/model/facility_slot_booking_model.dart';
 import 'package:oqdo_mobile_app/model/freeze_facility_response_model.dart';
 import 'package:oqdo_mobile_app/model/get_21_days_slot_response_model.dart';
 import 'package:oqdo_mobile_app/oqdo_application.dart';
-import 'package:oqdo_mobile_app/theme/oqdo_theme_data.dart';
+import 'package:oqdo_mobile_app/theme/custom_colors.dart';
 import 'package:oqdo_mobile_app/utils/constants.dart';
 import 'package:oqdo_mobile_app/utils/coutdown_timer.dart';
 import 'package:oqdo_mobile_app/utils/custom_text_view.dart';
@@ -153,7 +153,7 @@ class _SlotSelectionScreenState extends State<SlotSelectionScreen> {
         ),
         body: SafeArea(
           child: Container(
-            color: OQDOThemeData.whiteColor,
+            color: Theme.of(context).extension<CustomColors>()!.white,
             width: MediaQuery.of(context).size.width,
             height: double.infinity,
             child: Column(
@@ -181,7 +181,7 @@ class _SlotSelectionScreenState extends State<SlotSelectionScreen> {
                                         textStyle: Theme.of(context)
                                             .textTheme
                                             .titleMedium!
-                                            .copyWith(fontSize: 20, fontWeight: FontWeight.w500, color: const Color(0xFF333333)),
+                                            .copyWith(fontSize: 20, fontWeight: FontWeight.w500, color: Theme.of(context).colorScheme.onSurface),
                                       ),
                                     ],
                                   ),
@@ -226,7 +226,7 @@ class _SlotSelectionScreenState extends State<SlotSelectionScreen> {
                                   textStyle: Theme.of(context)
                                       .textTheme
                                       .titleMedium!
-                                      .copyWith(fontSize: 16, color: OQDOThemeData.greyColor, fontWeight: FontWeight.w500),
+                                      .copyWith(fontSize: 16, color: Theme.of(context).colorScheme.onSurface, fontWeight: FontWeight.w500),
                                 ),
                               ],
                             ),
@@ -243,14 +243,14 @@ class _SlotSelectionScreenState extends State<SlotSelectionScreen> {
                             CustomTextView(
                               label: 'Total Amount',
                               textStyle:
-                                  Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 18, color: OQDOThemeData.greyColor, fontWeight: FontWeight.w500),
+                                  Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 18, color: Theme.of(context).colorScheme.onSurface, fontWeight: FontWeight.w500),
                             ),
                             const Spacer(),
                             CustomTextView(
                               label: 'S\$ ${totalAmount.toStringAsFixed(2)}',
                               textStyle: Theme.of(context).textTheme.titleLarge!.copyWith(
                                     fontWeight: FontWeight.w400,
-                                    color: OQDOThemeData.greyColor,
+                                    color: Theme.of(context).colorScheme.onSurface,
                                     fontSize: 20,
                                   ),
                             )
@@ -268,7 +268,7 @@ class _SlotSelectionScreenState extends State<SlotSelectionScreen> {
                           maxLine: 3,
                           label: 'Booking timeout. Please Return to Home and book again.',
                           textStyle:
-                              Theme.of(context).textTheme.titleMedium!.copyWith(fontWeight: FontWeight.w700, color: OQDOThemeData.errorColor, fontSize: 18),
+                              Theme.of(context).textTheme.titleMedium!.copyWith(fontWeight: FontWeight.w700, color: Theme.of(context).colorScheme.error, fontSize: 18),
                         ),
                       )
                     : isTimingShow
@@ -352,7 +352,7 @@ class _SlotSelectionScreenState extends State<SlotSelectionScreen> {
         children: [
           CustomTextView(
             label: monthStr,
-            textStyle: Theme.of(context).textTheme.titleLarge!.copyWith(fontSize: 20, fontWeight: FontWeight.w500, color: const Color(0xFF333333)),
+            textStyle: Theme.of(context).textTheme.titleLarge!.copyWith(fontSize: 20, fontWeight: FontWeight.w500, color: Theme.of(context).colorScheme.onSurface),
           ),
           const Spacer(),
           GestureDetector(
@@ -406,13 +406,13 @@ class _SlotSelectionScreenState extends State<SlotSelectionScreen> {
             headerVisible: false,
             daysOfWeekVisible: true,
             daysOfWeekStyle: const DaysOfWeekStyle(
-                weekdayStyle: TextStyle(color: Color(0xFF006590), fontWeight: FontWeight.w500),
-                weekendStyle: TextStyle(color: Color(0xFF006590), fontWeight: FontWeight.w500)),
+                weekdayStyle: TextStyle(color: Theme.of(context).colorScheme.primary, fontWeight: FontWeight.w500),
+                weekendStyle: TextStyle(color: Theme.of(context).colorScheme.primary, fontWeight: FontWeight.w500)),
             calendarStyle: CalendarStyle(
               isTodayHighlighted: false,
               outsideDaysVisible: false,
               selectedDecoration: BoxDecoration(color: Theme.of(context).colorScheme.primary, shape: BoxShape.circle),
-              defaultTextStyle: const TextStyle(fontSize: 15, fontWeight: FontWeight.w400, color: Colors.black),
+              defaultTextStyle: const TextStyle(fontSize: 15, fontWeight: FontWeight.w400, color: Theme.of(context).colorScheme.onSurface),
             ),
             onDaySelected: _onDaySelected,
             selectedDayPredicate: (DateTime date) {
@@ -454,13 +454,13 @@ class _SlotSelectionScreenState extends State<SlotSelectionScreen> {
                           border: Border.all(
                             color: Theme.of(context).colorScheme.primary,
                           ),
-                          color: const Color(0xFFCCCCCC),
+                          color: Theme.of(context).colorScheme.outline,
                         ),
                         child: Center(
                           child: CustomTextView(
                             label: '${_singleFacilityDatesList[0].listOfSlots![index].startTime} - ${_singleFacilityDatesList[0].listOfSlots![index].endTime}',
                             type: styleSubTitle,
-                            textStyle: Theme.of(context).textTheme.titleSmall!.copyWith(color: OQDOThemeData.greyColor),
+                            textStyle: Theme.of(context).textTheme.titleSmall!.copyWith(color: Theme.of(context).colorScheme.onSurface),
                           ),
                         ),
                       ),
@@ -478,7 +478,7 @@ class _SlotSelectionScreenState extends State<SlotSelectionScreen> {
                             CustomTextView(
                               label: _singleFacilityDatesList[0].listOfSlots![index].availableSeat.toString(),
                               textStyle:
-                                  Theme.of(context).textTheme.titleSmall!.copyWith(fontSize: 14, color: OQDOThemeData.blackColor, fontWeight: FontWeight.w300),
+                                  Theme.of(context).textTheme.titleSmall!.copyWith(fontSize: 14, color: Theme.of(context).colorScheme.onSurface, fontWeight: FontWeight.w300),
                             ),
                             const SizedBox(
                               width: 5,
@@ -493,7 +493,7 @@ class _SlotSelectionScreenState extends State<SlotSelectionScreen> {
                         CustomTextView(
                           label: 'Available',
                           textStyle:
-                              Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 10, fontWeight: FontWeight.w500, color: const Color(0xFF333333)),
+                              Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 10, fontWeight: FontWeight.w500, color: Theme.of(context).colorScheme.onSurface),
                         ),
                         const SizedBox(
                           height: 5,
@@ -510,14 +510,14 @@ class _SlotSelectionScreenState extends State<SlotSelectionScreen> {
                           fit: FlexFit.tight,
                           child: Container(
                             decoration: BoxDecoration(
-                                border: Border.all(color: _singleFacilityDatesList[0].listOfSlots![index].isSlotSelected ? Colors.green : Colors.blue),
-                                color: _singleFacilityDatesList[0].listOfSlots![index].isSlotSelected ? Colors.green : Colors.blue),
+                                border: Border.all(color: _singleFacilityDatesList[0].listOfSlots![index].isSlotSelected ? Theme.of(context).extension<CustomColors>()!.greenAmount : Theme.of(context).colorScheme.primary),
+                                color: _singleFacilityDatesList[0].listOfSlots![index].isSlotSelected ? Theme.of(context).extension<CustomColors>()!.greenAmount : Theme.of(context).colorScheme.primary),
                             child: Center(
                               child: CustomTextView(
                                 label:
                                     '${_singleFacilityDatesList[0].listOfSlots![index].startTime} - ${_singleFacilityDatesList[0].listOfSlots![index].endTime}',
                                 type: styleSubTitle,
-                                textStyle: Theme.of(context).textTheme.titleSmall!.copyWith(color: OQDOThemeData.whiteColor),
+                                textStyle: Theme.of(context).textTheme.titleSmall!.copyWith(color: Theme.of(context).extension<CustomColors>()!.white),
                               ),
                             ),
                           ),
@@ -537,7 +537,7 @@ class _SlotSelectionScreenState extends State<SlotSelectionScreen> {
                                   textStyle: Theme.of(context)
                                       .textTheme
                                       .titleSmall!
-                                      .copyWith(fontSize: 14, color: OQDOThemeData.blackColor, fontWeight: FontWeight.w300),
+                                      .copyWith(fontSize: 14, color: Theme.of(context).colorScheme.onSurface, fontWeight: FontWeight.w300),
                                 ),
                                 const SizedBox(
                                   width: 5,
@@ -552,7 +552,7 @@ class _SlotSelectionScreenState extends State<SlotSelectionScreen> {
                             CustomTextView(
                               label: 'Available',
                               textStyle:
-                                  Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 10, fontWeight: FontWeight.w500, color: const Color(0xFF333333)),
+                                  Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 10, fontWeight: FontWeight.w500, color: Theme.of(context).colorScheme.onSurface),
                             ),
                             const SizedBox(
                               height: 5,
@@ -569,9 +569,9 @@ class _SlotSelectionScreenState extends State<SlotSelectionScreen> {
                           child: Container(
                             decoration: BoxDecoration(
                               border: Border.all(
-                                color: _singleFacilityDatesList[0].listOfSlots![index].isSlotSelected ? Colors.green : const Color(0xFFCCCCCC),
+                                color: _singleFacilityDatesList[0].listOfSlots![index].isSlotSelected ? Theme.of(context).extension<CustomColors>()!.greenAmount : Theme.of(context).colorScheme.outline,
                               ),
-                              color: _singleFacilityDatesList[0].listOfSlots![index].isSlotSelected ? Colors.green : const Color(0xFFCCCCCC),
+                              color: _singleFacilityDatesList[0].listOfSlots![index].isSlotSelected ? Theme.of(context).extension<CustomColors>()!.greenAmount : Theme.of(context).colorScheme.outline,
                             ),
                             child: Center(
                               child: CustomTextView(
@@ -598,7 +598,7 @@ class _SlotSelectionScreenState extends State<SlotSelectionScreen> {
                                   textStyle: Theme.of(context)
                                       .textTheme
                                       .titleSmall!
-                                      .copyWith(fontSize: 14, color: OQDOThemeData.blackColor, fontWeight: FontWeight.w300),
+                                      .copyWith(fontSize: 14, color: Theme.of(context).colorScheme.onSurface, fontWeight: FontWeight.w300),
                                 ),
                                 const SizedBox(
                                   width: 5,
@@ -613,7 +613,7 @@ class _SlotSelectionScreenState extends State<SlotSelectionScreen> {
                             CustomTextView(
                               label: 'Available',
                               textStyle:
-                                  Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 10, fontWeight: FontWeight.w500, color: const Color(0xFF333333)),
+                                  Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 10, fontWeight: FontWeight.w500, color: Theme.of(context).colorScheme.onSurface),
                             ),
                             const SizedBox(
                               height: 5,
@@ -916,7 +916,7 @@ class _SlotSelectionScreenState extends State<SlotSelectionScreen> {
                         label:
                             'It appears that you have a scheduled meetup at the chosen time. To prevent any conflicts, you can either unfreeze the slot or request a time change from the meetup creator',
                         maxLine: 5,
-                        textStyle: const TextStyle(fontSize: 15, color: Colors.black),
+                        textStyle: const TextStyle(fontSize: 15, color: Theme.of(context).colorScheme.onSurface),
                         textOverFlow: TextOverflow.ellipsis,
                       ),
                       actions: [
@@ -1078,7 +1078,7 @@ class _SlotSelectionScreenState extends State<SlotSelectionScreen> {
     }
 
     return Container(
-      color: OQDOThemeData.whiteColor,
+      color: Theme.of(context).extension<CustomColors>()!.white,
       width: MediaQuery.of(context).size.width,
       height: MediaQuery.of(context).size.height / 1.2,
       child: SingleChildScrollView(
@@ -1095,14 +1095,14 @@ class _SlotSelectionScreenState extends State<SlotSelectionScreen> {
             ),
             CustomTextView(
               label: '${_currentDay.split("-")[0]} ${_currentDay.split('-')[1]} ${_currentDay.split('-')[2]}',
-              textStyle: Theme.of(context).textTheme.titleLarge!.copyWith(fontSize: 21, color: const Color(0xFF333333), fontWeight: FontWeight.w500),
+              textStyle: Theme.of(context).textTheme.titleLarge!.copyWith(fontSize: 21, color: Theme.of(context).colorScheme.onSurface, fontWeight: FontWeight.w500),
             ),
             const SizedBox(
               height: 3,
             ),
             CustomTextView(
               label: initSelectedDate,
-              textStyle: Theme.of(context).textTheme.titleLarge!.copyWith(fontSize: 21, color: const Color(0xFF333333), fontWeight: FontWeight.w500),
+              textStyle: Theme.of(context).textTheme.titleLarge!.copyWith(fontSize: 21, color: Theme.of(context).colorScheme.onSurface, fontWeight: FontWeight.w500),
             ),
             Padding(
               padding: const EdgeInsets.only(top: 40, left: 25, right: 25),
@@ -1115,13 +1115,13 @@ class _SlotSelectionScreenState extends State<SlotSelectionScreen> {
                 daysOfWeekVisible: true,
                 currentDay: kToday,
                 daysOfWeekStyle: const DaysOfWeekStyle(
-                    weekdayStyle: TextStyle(color: Color(0xFF006590), fontWeight: FontWeight.w500),
-                    weekendStyle: TextStyle(color: Color(0xFF006590), fontWeight: FontWeight.w500)),
+                    weekdayStyle: TextStyle(color: Theme.of(context).colorScheme.primary, fontWeight: FontWeight.w500),
+                    weekendStyle: TextStyle(color: Theme.of(context).colorScheme.primary, fontWeight: FontWeight.w500)),
                 calendarStyle: CalendarStyle(
                   isTodayHighlighted: false,
                   outsideDaysVisible: false,
                   selectedDecoration: BoxDecoration(color: Theme.of(context).colorScheme.primary, shape: BoxShape.circle),
-                  defaultTextStyle: const TextStyle(fontSize: 15, fontWeight: FontWeight.w400, color: Colors.black),
+                  defaultTextStyle: const TextStyle(fontSize: 15, fontWeight: FontWeight.w400, color: Theme.of(context).colorScheme.onSurface),
                 ),
                 onCalendarCreated: (controller) {
                   _pageController = controller;
@@ -1178,14 +1178,14 @@ class _SlotSelectionScreenState extends State<SlotSelectionScreen> {
             children: [
               CustomTextView(
                 label: headerText.split(' ')[0],
-                textStyle: Theme.of(context).textTheme.titleLarge!.copyWith(fontSize: 21, fontWeight: FontWeight.w700, color: const Color(0xFF333333)),
+                textStyle: Theme.of(context).textTheme.titleLarge!.copyWith(fontSize: 21, fontWeight: FontWeight.w700, color: Theme.of(context).colorScheme.onSurface),
               ),
               const SizedBox(
                 height: 5,
               ),
               CustomTextView(
                 label: headerText.split(' ')[1],
-                textStyle: Theme.of(context).textTheme.titleLarge!.copyWith(fontSize: 21, fontWeight: FontWeight.w700, color: const Color(0xFF333333)),
+                textStyle: Theme.of(context).textTheme.titleLarge!.copyWith(fontSize: 21, fontWeight: FontWeight.w700, color: Theme.of(context).colorScheme.onSurface),
               ),
             ],
           ),


### PR DESCRIPTION
## Summary
- update slot management screens to use dynamic theme colors
- support custom light and dark color schemes via CustomColors extension

## Testing
- `flutter analyze lib/screens/slot_management` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bff39eed20833292c8d8cb6fd30747