### PR TITLE
Add dark/light theme support to appointment and listing screens

### DIFF
--- a/lib/screens/appointment/EndUserFacilityAppointmentDetails.dart
+++ b/lib/screens/appointment/EndUserFacilityAppointmentDetails.dart
@@ -50,13 +50,14 @@ class _EndUserFacilityAppointmentDetailsState extends State<EndUserFacilityAppoi
 
   @override
   Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
     return Scaffold(
       appBar: appbarView(),
       body: SafeArea(
         child: Container(
           width: MediaQuery.of(context).size.width,
           height: MediaQuery.of(context).size.height,
-          color: Theme.of(context).extension<CustomColors>()!.white,
+          color: colorScheme.surface,
           child: _facilityAppointmentDetailModel != null
               ? SingleChildScrollView(
                   child: Column(
@@ -538,7 +539,7 @@ class _EndUserFacilityAppointmentDetailsState extends State<EndUserFacilityAppoi
   Widget _paymentSummaryView() {
     return Container(
       decoration: BoxDecoration(
-        color: Theme.of(context).extension<CustomColors>()!.white,
+        color: Theme.of(context).colorScheme.surface,
         border: Border.all(color: Theme.of(context).extension<CustomColors>()!.greyText),
       ),
       padding: const EdgeInsets.all(8.0),

--- a/lib/screens/appointment/appointment_view_order_screen.dart
+++ b/lib/screens/appointment/appointment_view_order_screen.dart
@@ -54,13 +54,14 @@ class _EndUserCoachAppointmentDetailsScreenState extends State<EndUserCoachAppoi
 
   @override
   Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
     return Scaffold(
       appBar: appbarView(),
       body: SafeArea(
         child: Container(
           width: MediaQuery.of(context).size.width,
           height: MediaQuery.of(context).size.height,
-          color: Theme.of(context).extension<CustomColors>()!.white,
+          color: colorScheme.surface,
           child: coachAppointmentDetailResponseModel != null
               ? SingleChildScrollView(
                   child: Column(
@@ -567,7 +568,7 @@ class _EndUserCoachAppointmentDetailsScreenState extends State<EndUserCoachAppoi
   Widget _paymentSummaryView() {
     return Container(
       decoration: BoxDecoration(
-        color: Theme.of(context).extension<CustomColors>()!.white,
+        color: Theme.of(context).colorScheme.surface,
         border: Border.all(color: Theme.of(context).extension<CustomColors>()!.greyText),
       ),
       padding: const EdgeInsets.all(8.0),

--- a/lib/screens/appointment/coach_appointment_screen.dart
+++ b/lib/screens/appointment/coach_appointment_screen.dart
@@ -82,6 +82,7 @@ class _CoachAppointmentsScreenState extends State<CoachAppointmentsScreen> {
 
   @override
   Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
     return Scaffold(
       appBar: CustomAppBar(
           title: 'Appointments Management',
@@ -90,7 +91,7 @@ class _CoachAppointmentsScreenState extends State<CoachAppointmentsScreen> {
           }),
       body: SafeArea(
         child: Container(
-          color: Theme.of(context).extension<CustomColors>()!.white,
+          color: colorScheme.surface,
           width: MediaQuery.of(context).size.width,
           height: double.infinity,
           child: _endUserAppointmentResponseList.isNotEmpty
@@ -130,7 +131,7 @@ class _CoachAppointmentsScreenState extends State<CoachAppointmentsScreen> {
                                     textStyle: Theme.of(context)
                                         .textTheme
                                         .bodyMedium!
-                                        .copyWith(color: Theme.of(context).extension<CustomColors>()!.white, fontSize: 18, fontWeight: FontWeight.w500),
+                                        .copyWith(color: colorScheme.onPrimary, fontSize: 18, fontWeight: FontWeight.w500),
                                   ),
                                 ),
                               ),
@@ -568,7 +569,7 @@ class _CoachAppointmentsScreenState extends State<CoachAppointmentsScreen> {
     }
 
     return Container(
-      color: Theme.of(context).extension<CustomColors>()!.white,
+      color: Theme.of(context).colorScheme.surface,
       width: MediaQuery.of(context).size.width,
       height: MediaQuery.of(context).size.height / 1.2,
       child: SingleChildScrollView(

--- a/lib/screens/appointment/coach_details_appointment_screen.dart
+++ b/lib/screens/appointment/coach_details_appointment_screen.dart
@@ -263,7 +263,7 @@ class _CoachDetailAppointmentScreenState extends State<CoachDetailAppointmentScr
   Widget _paymentSummaryView() {
     return Container(
       decoration: BoxDecoration(
-        color: Theme.of(context).extension<CustomColors>()!.white,
+        color: Theme.of(context).colorScheme.surface,
         border: Border.all(color: Theme.of(context).extension<CustomColors>()!.greyText),
       ),
       padding: const EdgeInsets.all(8.0),

--- a/lib/screens/appointment/coach_enduser_verification_screen.dart
+++ b/lib/screens/appointment/coach_enduser_verification_screen.dart
@@ -262,7 +262,7 @@ class _CoachEndUserVerificationScreenState extends State<CoachEndUserVerificatio
                                         textStyle: Theme.of(context)
                                             .textTheme
                                             .bodyMedium!
-                                            .copyWith(fontSize: 16, color: Theme.of(context).extension<CustomColors>()!.white, fontWeight: FontWeight.w400),
+                                            .copyWith(fontSize: 16, color: Theme.of(context).colorScheme.onError, fontWeight: FontWeight.w400),
                                       ),
                                     ),
                                   ),
@@ -278,14 +278,14 @@ class _CoachEndUserVerificationScreenState extends State<CoachEndUserVerificatio
                                         facilityCancelRequest(context);
                                       },
                                       style: ButtonStyle(
-                                        backgroundColor: MaterialStateProperty.all(Theme.of(context).extension<CustomColors>()!.greenAmount),
+                                        backgroundColor: MaterialStateProperty.all(Theme.of(context).colorScheme.primary),
                                       ),
                                       child: CustomTextView(
                                         label: 'Confirm',
                                         textStyle: Theme.of(context)
                                             .textTheme
                                             .bodyMedium!
-                                            .copyWith(fontSize: 16, color: Theme.of(context).extension<CustomColors>()!.white, fontWeight: FontWeight.w400),
+                                            .copyWith(fontSize: 16, color: Theme.of(context).colorScheme.onPrimary, fontWeight: FontWeight.w400),
                                       ),
                                     ),
                                   ),

--- a/lib/screens/appointment/enduser_appointment_screen.dart
+++ b/lib/screens/appointment/enduser_appointment_screen.dart
@@ -83,6 +83,7 @@ class _EndUserAppointmentsScreenState extends State<EndUserAppointmentsScreen> {
 
   @override
   Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
     return Scaffold(
       appBar: CustomAppBar(
           title: 'Appointments Management',
@@ -91,7 +92,7 @@ class _EndUserAppointmentsScreenState extends State<EndUserAppointmentsScreen> {
           }),
       body: SafeArea(
         child: Container(
-          color: Theme.of(context).extension<CustomColors>()!.white,
+          color: colorScheme.surface,
           width: MediaQuery.of(context).size.width,
           height: double.infinity,
           child: _endUserAppointmentList.isNotEmpty
@@ -131,7 +132,7 @@ class _EndUserAppointmentsScreenState extends State<EndUserAppointmentsScreen> {
                                     textStyle: Theme.of(context)
                                         .textTheme
                                         .bodyMedium!
-                                        .copyWith(color: Theme.of(context).extension<CustomColors>()!.white, fontSize: 18, fontWeight: FontWeight.w500),
+                                        .copyWith(color: colorScheme.onPrimary, fontSize: 18, fontWeight: FontWeight.w500),
                                   ),
                                 ),
                               ),
@@ -659,7 +660,7 @@ class _EndUserAppointmentsScreenState extends State<EndUserAppointmentsScreen> {
     }
 
     return Container(
-      color: Theme.of(context).extension<CustomColors>()!.white,
+      color: Theme.of(context).colorScheme.surface,
       width: MediaQuery.of(context).size.width,
       height: MediaQuery.of(context).size.height / 1.2,
       child: SingleChildScrollView(

--- a/lib/screens/appointment/facility_appointment_details_screen.dart
+++ b/lib/screens/appointment/facility_appointment_details_screen.dart
@@ -354,7 +354,7 @@ class _FacilityAppointmentDetailsScreenState extends State<FacilityAppointmentDe
   Widget _paymentSummaryView() {
     return Container(
       decoration: BoxDecoration(
-        color: Theme.of(context).extension<CustomColors>()!.white,
+        color: Theme.of(context).colorScheme.surface,
         border: Border.all(color: Theme.of(context).extension<CustomColors>()!.greyText),
       ),
       padding: const EdgeInsets.all(8.0),

--- a/lib/screens/appointment/facility_appointment_screen.dart
+++ b/lib/screens/appointment/facility_appointment_screen.dart
@@ -82,6 +82,7 @@ class _FacilityAppointmentsScreenState extends State<FacilityAppointmentsScreen>
 
   @override
   Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
     return Scaffold(
       appBar: CustomAppBar(
           title: 'Appointments Management',
@@ -90,7 +91,7 @@ class _FacilityAppointmentsScreenState extends State<FacilityAppointmentsScreen>
           }),
       body: SafeArea(
         child: Container(
-          color: Theme.of(context).extension<CustomColors>()!.white,
+          color: colorScheme.surface,
           width: MediaQuery.of(context).size.width,
           height: double.infinity,
           child: _endUserAppointmentResponseList.isNotEmpty
@@ -130,7 +131,7 @@ class _FacilityAppointmentsScreenState extends State<FacilityAppointmentsScreen>
                                     textStyle: Theme.of(context)
                                         .textTheme
                                         .bodyMedium!
-                                        .copyWith(color: Theme.of(context).extension<CustomColors>()!.white, fontSize: 18, fontWeight: FontWeight.w500),
+                                        .copyWith(color: colorScheme.onPrimary, fontSize: 18, fontWeight: FontWeight.w500),
                                   ),
                                 ),
                               ),
@@ -569,7 +570,7 @@ class _FacilityAppointmentsScreenState extends State<FacilityAppointmentsScreen>
     }
 
     return Container(
-      color: Theme.of(context).extension<CustomColors>()!.white,
+      color: Theme.of(context).colorScheme.surface,
       width: MediaQuery.of(context).size.width,
       height: MediaQuery.of(context).size.height / 1.2,
       child: SingleChildScrollView(

--- a/lib/screens/appointment/facility_enduser_verification_screen.dart
+++ b/lib/screens/appointment/facility_enduser_verification_screen.dart
@@ -252,7 +252,7 @@ class _FacilityEndUserCancelAppointmentVerificationScreenState extends State<Fac
                                         textStyle: Theme.of(context)
                                             .textTheme
                                             .bodyMedium!
-                                            .copyWith(fontSize: 16, color: Theme.of(context).extension<CustomColors>()!.white, fontWeight: FontWeight.w400),
+                                            .copyWith(fontSize: 16, color: Theme.of(context).colorScheme.onError, fontWeight: FontWeight.w400),
                                       ),
                                     ),
                                   ),
@@ -268,14 +268,14 @@ class _FacilityEndUserCancelAppointmentVerificationScreenState extends State<Fac
                                         facilityCancelRequest(context);
                                       },
                                       style: ButtonStyle(
-                                        backgroundColor: MaterialStateProperty.all(Theme.of(context).extension<CustomColors>()!.greenAmount),
+                                        backgroundColor: MaterialStateProperty.all(Theme.of(context).colorScheme.primary),
                                       ),
                                       child: CustomTextView(
                                         label: 'Confirm',
                                         textStyle: Theme.of(context)
                                             .textTheme
                                             .bodyMedium!
-                                            .copyWith(fontSize: 16, color: Theme.of(context).extension<CustomColors>()!.white, fontWeight: FontWeight.w400),
+                                            .copyWith(fontSize: 16, color: Theme.of(context).colorScheme.onPrimary, fontWeight: FontWeight.w400),
                                       ),
                                     ),
                                   ),

--- a/lib/screens/appointment/review_appointment_screen.dart
+++ b/lib/screens/appointment/review_appointment_screen.dart
@@ -1203,7 +1203,7 @@ class _ReviewAppointmentScreenState extends State<ReviewAppointmentScreen> {
             padding: const EdgeInsets.symmetric(horizontal: 10.0),
             child: Container(
               decoration: BoxDecoration(
-                color: Theme.of(context).extension<CustomColors>()!.white,
+                color: Theme.of(context).colorScheme.surface,
                 border: Border.all(
                     color:
                         Theme.of(context).extension<CustomColors>()!.greyText),

--- a/lib/screens/coach/coach_details_booking_screen.dart
+++ b/lib/screens/coach/coach_details_booking_screen.dart
@@ -4,6 +4,7 @@ import 'package:oqdo_mobile_app/components/custom_app_bar.dart';
 
 import '../../components/my_button.dart';
 import '../../theme/oqdo_theme_data.dart';
+import '../../theme/custom_colors.dart';
 import '../../utils/custom_text_view.dart';
 
 class CoachDetailsBookingScreen extends StatefulWidget {
@@ -137,9 +138,9 @@ class _CoachDetailsBookingScreenState extends State<CoachDetailsBookingScreen> {
                     itemCount: 5,
                     itemSize: 15,
                     itemPadding: const EdgeInsets.symmetric(horizontal: 2.0),
-                    itemBuilder: (context, _) => const Icon(
+                    itemBuilder: (context, _) => Icon(
                       Icons.star,
-                      color: Colors.amber,
+                      color: Theme.of(context).extension<CustomColors>()!.yellowStatus,
                       size: 15,
                     ),
                     onRatingUpdate: (rating) {

--- a/lib/screens/coach/coach_details_screen.dart
+++ b/lib/screens/coach/coach_details_screen.dart
@@ -638,9 +638,9 @@ class _CoachDetailsScreenState extends State<CoachDetailsScreen> {
                     itemSize: 15,
                     tapOnlyMode: true,
                     itemPadding: const EdgeInsets.symmetric(horizontal: 2.0),
-                    itemBuilder: (context, _) => const Icon(
+                    itemBuilder: (context, _) => Icon(
                       Icons.star,
-                      color: Colors.amber,
+                      color: Theme.of(context).extension<CustomColors>()!.yellowStatus,
                       size: 15,
                     ),
                     onRatingUpdate: (rating) {

--- a/lib/screens/coach/coach_list_page.dart
+++ b/lib/screens/coach/coach_list_page.dart
@@ -89,6 +89,7 @@ class _CoachListPageState extends State<CoachListPage> {
 
   @override
   Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
     return Scaffold(
       appBar: CustomAppBar(
         title: 'Book',
@@ -1152,9 +1153,9 @@ class _CoachListPageState extends State<CoachListPage> {
                     child: Container(
                       height: 100.0,
                       decoration: BoxDecoration(
-                        color: Theme.of(context).colorScheme.onPrimary,
+                        color: colorScheme.surface,
                         border: Border.all(
-                          color: Colors.black,
+                          color: colorScheme.outline,
                           width: 1,
                         ),
                         borderRadius: BorderRadius.circular(2),
@@ -1211,9 +1212,9 @@ class _CoachListPageState extends State<CoachListPage> {
                     child: Container(
                       height: 100.0,
                       decoration: BoxDecoration(
-                        color: Theme.of(context).colorScheme.onPrimary,
+                        color: colorScheme.surface,
                         border: Border.all(
-                          color: Colors.black,
+                          color: colorScheme.outline,
                           width: 1,
                         ),
                         borderRadius: BorderRadius.circular(2),

--- a/lib/screens/common_widget/facility_coach_reviews_screen.dart
+++ b/lib/screens/common_widget/facility_coach_reviews_screen.dart
@@ -3,6 +3,7 @@ import 'package:flutter_rating_bar/flutter_rating_bar.dart';
 import 'package:oqdo_mobile_app/components/custom_app_bar.dart';
 import 'package:oqdo_mobile_app/model/CoachDetailsResponseModel.dart';
 import 'package:oqdo_mobile_app/theme/oqdo_theme_data.dart';
+import 'package:oqdo_mobile_app/theme/custom_colors.dart';
 import 'package:oqdo_mobile_app/utils/custom_text_view.dart';
 
 class FacilityCoachReviewScreen extends StatefulWidget {
@@ -126,9 +127,9 @@ class _FacilityCoachReviewScreenState extends State<FacilityCoachReviewScreen> {
                 itemCount: 5,
                 itemSize: 15,
                 itemPadding: const EdgeInsets.symmetric(horizontal: 2.0),
-                itemBuilder: (context, _) => const Icon(
+                itemBuilder: (context, _) => Icon(
                   Icons.star,
-                  color: Colors.amber,
+                  color: Theme.of(context).extension<CustomColors>()!.yellowStatus,
                   size: 15,
                 ),
                 onRatingUpdate: (rating) {

--- a/lib/screens/common_widget/facility_review_screen.dart
+++ b/lib/screens/common_widget/facility_review_screen.dart
@@ -3,6 +3,7 @@ import 'package:flutter_rating_bar/flutter_rating_bar.dart';
 import 'package:oqdo_mobile_app/components/custom_app_bar.dart';
 import 'package:oqdo_mobile_app/model/GetFacilityByIdModel.dart';
 import 'package:oqdo_mobile_app/theme/oqdo_theme_data.dart';
+import 'package:oqdo_mobile_app/theme/custom_colors.dart';
 import 'package:oqdo_mobile_app/utils/custom_text_view.dart';
 
 class FacilityReviewScreen extends StatefulWidget {
@@ -126,9 +127,9 @@ class _FacilityReviewScreenState extends State<FacilityReviewScreen> {
                 itemCount: 5,
                 itemSize: 15,
                 itemPadding: const EdgeInsets.symmetric(horizontal: 2.0),
-                itemBuilder: (context, _) => const Icon(
+                itemBuilder: (context, _) => Icon(
                   Icons.star,
-                  color: Colors.amber,
+                  color: Theme.of(context).extension<CustomColors>()!.yellowStatus,
                   size: 15,
                 ),
                 onRatingUpdate: (rating) {

--- a/lib/screens/facilities/facilities_list_page.dart
+++ b/lib/screens/facilities/facilities_list_page.dart
@@ -122,6 +122,7 @@ class FacilitiesListPageState extends State<FacilitiesListPage> {
 
   @override
   Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
     return Scaffold(
       appBar: CustomAppBar(
         title: 'Book',
@@ -943,13 +944,13 @@ class FacilitiesListPageState extends State<FacilitiesListPage> {
             height: 70.0,
             child: ElevatedButton(
                 style: ButtonStyle(
-                  foregroundColor: MaterialStateProperty.all<Color>(const Color(0xFFCECECE)),
-                  backgroundColor: MaterialStateProperty.all<Color>(const Color(0xFFCECECE)),
+                  foregroundColor: MaterialStateProperty.all<Color>(colorScheme.onSurface),
+                  backgroundColor: MaterialStateProperty.all<Color>(colorScheme.surfaceVariant),
                   shape: MaterialStateProperty.all<RoundedRectangleBorder>(
-                    const RoundedRectangleBorder(
+                    RoundedRectangleBorder(
                       borderRadius: BorderRadius.zero,
                       side: BorderSide(
-                        color: Color(0xFFCECECE),
+                        color: colorScheme.surfaceVariant,
                       ),
                     ),
                   ),
@@ -988,13 +989,13 @@ class FacilitiesListPageState extends State<FacilitiesListPage> {
             height: 70.0,
             child: ElevatedButton(
                 style: ButtonStyle(
-                  foregroundColor: MaterialStateProperty.all<Color>(const Color(0xFF006590)),
-                  backgroundColor: MaterialStateProperty.all<Color>(const Color(0xFF006590)),
+                  foregroundColor: MaterialStateProperty.all<Color>(colorScheme.onPrimary),
+                  backgroundColor: MaterialStateProperty.all<Color>(colorScheme.primary),
                   shape: MaterialStateProperty.all<RoundedRectangleBorder>(
-                    const RoundedRectangleBorder(
+                    RoundedRectangleBorder(
                       borderRadius: BorderRadius.zero,
                       side: BorderSide(
-                        color: Color(0xFF006590),
+                        color: colorScheme.primary,
                       ),
                     ),
                   ),

--- a/lib/screens/facilities/facility_details_screen.dart
+++ b/lib/screens/facilities/facility_details_screen.dart
@@ -254,9 +254,9 @@ class _FacilityDetailsScreenState extends State<FacilityDetailsScreen> {
                     itemCount: 5,
                     itemSize: 15,
                     itemPadding: const EdgeInsets.symmetric(horizontal: 2.0),
-                    itemBuilder: (context, _) => const Icon(
+                    itemBuilder: (context, _) => Icon(
                       Icons.star,
-                      color: Colors.amber,
+                      color: Theme.of(context).extension<CustomColors>()!.yellowStatus,
                       size: 15,
                     ),
                     onRatingUpdate: (rating) {


### PR DESCRIPTION
## Summary
- replace hardcoded whites in appointment flow with theme colors
- update coach & facility listings and details to use color scheme
- adopt theme-based star rating colors

## Testing
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bff77f9dd48332873972ebe4aa5918