### PR TITLE
Enable dark/light theming for bazaar screens

### DIFF
--- a/lib/screens/bazaar/ads_screen/add_ads_screen.dart
+++ b/lib/screens/bazaar/ads_screen/add_ads_screen.dart
@@ -7,7 +7,6 @@ import 'package:flutter/services.dart';
 import 'package:http/http.dart';
 import 'package:oqdo_mobile_app/components/custom_app_bar.dart';
 import 'package:oqdo_mobile_app/screens/bazaar/ads_screen/viewmodel/ads_view_model.dart';
-import 'package:oqdo_mobile_app/theme/oqdo_theme_data.dart';
 import 'package:oqdo_mobile_app/utils/constants.dart';
 import 'package:oqdo_mobile_app/utils/network_interceptor.dart';
 import 'package:oqdo_mobile_app/utils/string_manager.dart';
@@ -77,9 +76,9 @@ class _AddAdsScreenState extends State<AddAdsScreen> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      backgroundColor: Colors.white,
+      backgroundColor: Theme.of(context).colorScheme.background,
       appBar: CustomAppBar(
-        backgroundColor: Color(0xFF006590),
+        backgroundColor: Theme.of(context).colorScheme.primary,
         title: 'Advertisements',
         isIconColorBlack: false,
         onBack: () {
@@ -87,7 +86,7 @@ class _AddAdsScreenState extends State<AddAdsScreen> {
         },
       ),
       body: Padding(
-        padding: const EdgeInsets.all(16.0),
+        padding: EdgeInsets.all(16.0),
         child: Column(
           children: [
             Expanded(
@@ -100,7 +99,7 @@ class _AddAdsScreenState extends State<AddAdsScreen> {
                     children: [
                       Text(
                         'Request to Post Ad',
-                        style: TextStyle(fontWeight: FontWeight.w400, color: Colors.black, fontSize: 16, fontFamily: 'SFPro'),
+                        style: TextStyle(fontWeight: FontWeight.w400, color: Theme.of(context).colorScheme.onBackground, fontSize: 16, fontFamily: 'SFPro'),
                       ),
                       CustomTextFormField(
                         read: false,
@@ -110,7 +109,7 @@ class _AddAdsScreenState extends State<AddAdsScreen> {
                         inputformat: [
                           FilteringTextInputFormatter.allow(RegExp(r'^[a-zA-Z ]+')),
                         ],
-                        fillColor: OQDOThemeData.backgroundColor,
+                        fillColor: Theme.of(context).colorScheme.background,
                         labelText: 'Full Name',
                         hintText: 'Enter Full Name',
                         keyboardType: TextInputType.text,
@@ -125,7 +124,7 @@ class _AddAdsScreenState extends State<AddAdsScreen> {
                         inputformat: [
                           FilteringTextInputFormatter.allow(RegExp(r'^[a-zA-Z ]+')),
                         ],
-                        fillColor: OQDOThemeData.backgroundColor,
+                        fillColor: Theme.of(context).colorScheme.background,
                         labelText: 'Name of Organization',
                         hintText: 'Enter Organization Name',
                         keyboardType: TextInputType.text,
@@ -137,7 +136,7 @@ class _AddAdsScreenState extends State<AddAdsScreen> {
                         obscureText: false,
                         maxlines: 1,
                         maxlength: 50,
-                        fillColor: OQDOThemeData.backgroundColor,
+                        fillColor: Theme.of(context).colorScheme.background,
                         labelText: 'Email Address',
                         hintText: 'Enter Email Address',
                         keyboardType: TextInputType.text,
@@ -153,7 +152,7 @@ class _AddAdsScreenState extends State<AddAdsScreen> {
                           FilteringTextInputFormatter.allow(RegExp(r'[0-9]')),
                           FilteringTextInputFormatter.digitsOnly,
                         ],
-                        fillColor: OQDOThemeData.backgroundColor,
+                        fillColor: Theme.of(context).colorScheme.background,
                         labelText: 'Mobile Number',
                         hintText: 'Enter Mobile Number',
                         keyboardType: TextInputType.number,
@@ -165,7 +164,7 @@ class _AddAdsScreenState extends State<AddAdsScreen> {
                         obscureText: false,
                         maxlines: 5,
                         maxlength: 500,
-                        fillColor: OQDOThemeData.backgroundColor,
+                        fillColor: Theme.of(context).colorScheme.background,
                         labelText: 'Description',
                         keyboardType: TextInputType.text,
                         validator: (value) => validateRequired(value, 'Description'),
@@ -204,7 +203,7 @@ class _AddAdsScreenState extends State<AddAdsScreen> {
                                     fontWeight: FontWeight.w600,
                                     fontSize: 17.0,
                                     fontFamily: 'Montserrat',
-                                    color: const Color(0xFF006590),
+                                    color: Theme.of(context).colorScheme.primary,
                                     decoration: TextDecoration.underline,
                                     decorationThickness: 2),
                               ),
@@ -238,7 +237,7 @@ class _AddAdsScreenState extends State<AddAdsScreen> {
                   }
                 },
                 style: ElevatedButton.styleFrom(
-                  backgroundColor: Color(0xFF006590),
+                  backgroundColor: Theme.of(context).colorScheme.primary,
                   padding: EdgeInsets.symmetric(vertical: 16),
                   shape: RoundedRectangleBorder(
                     borderRadius: BorderRadius.circular(8),
@@ -247,7 +246,7 @@ class _AddAdsScreenState extends State<AddAdsScreen> {
                 child: Text(
                   'Send Request',
                   style: TextStyle(
-                    color: Colors.white,
+                    color: Theme.of(context).colorScheme.background,
                     fontSize: 18,
                     fontFamily: 'SFPro',
                     fontWeight: FontWeight.w700,

--- a/lib/screens/bazaar/ads_screen/ads_screen.dart
+++ b/lib/screens/bazaar/ads_screen/ads_screen.dart
@@ -42,12 +42,12 @@ class _AdsScreenState extends State<AdsScreen> with SingleTickerProviderStateMix
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      backgroundColor: Colors.white,
+      backgroundColor: Theme.of(context).colorScheme.background,
       body: categories.isNotEmpty
           ? Column(
               children: [
                 Padding(
-                  padding: const EdgeInsets.fromLTRB(10.0, 20, 10, 0),
+                  padding: EdgeInsets.fromLTRB(10.0, 20, 10, 0),
                   child: SegmentedView(
                     segments: segments,
                     backgroundColor: Color(0xFFD4EEF9),
@@ -60,7 +60,7 @@ class _AdsScreenState extends State<AdsScreen> with SingleTickerProviderStateMix
                 ),
                 Expanded(
                   child: Padding(
-                    padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 15),
+                    padding: EdgeInsets.symmetric(horizontal: 20, vertical: 15),
                     child: Column(
                       children: [
                         Expanded(
@@ -87,7 +87,7 @@ class _AdsScreenState extends State<AdsScreen> with SingleTickerProviderStateMix
                                           image: category.filePath,
                                           title: category.name,
                                         ),
-                                        if (index != categories.length - 1) const SizedBox(height: 16),
+                                        if (index != categories.length - 1) SizedBox(height: 16),
                                       ],
                                     );
                                   },
@@ -104,16 +104,16 @@ class _AdsScreenState extends State<AdsScreen> with SingleTickerProviderStateMix
                               Navigator.pushNamed(context, Constants.addAdsScreen);
                             },
                             style: ElevatedButton.styleFrom(
-                              backgroundColor: Color(0xFF006590),
-                              foregroundColor: Color(0xFF006590),
+                              backgroundColor: Theme.of(context).colorScheme.primary,
+                              foregroundColor: Theme.of(context).colorScheme.primary,
                               shape: RoundedRectangleBorder(
                                 borderRadius: BorderRadius.circular(15.0),
                               ),
-                              padding: const EdgeInsets.symmetric(horizontal: 32, vertical: 16),
+                              padding: EdgeInsets.symmetric(horizontal: 32, vertical: 16),
                             ),
                             child: Text(
                               'Add Your Advertisement',
-                              style: TextStyle(fontSize: 20, color: Colors.white, fontWeight: FontWeight.w700, fontFamily: 'SFPro'),
+                              style: TextStyle(fontSize: 20, color: Theme.of(context).colorScheme.background, fontWeight: FontWeight.w700, fontFamily: 'SFPro'),
                             ),
                           ),
                         )

--- a/lib/screens/bazaar/ads_screen/ads_view.dart
+++ b/lib/screens/bazaar/ads_screen/ads_view.dart
@@ -135,9 +135,9 @@ class _SportsAdvertisementCarouselState extends State<SportsAdvertisementCarouse
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      backgroundColor: Colors.white,
+      backgroundColor: Theme.of(context).colorScheme.background,
       appBar: CustomAppBar(
-        backgroundColor: const Color(0xFF006590),
+        backgroundColor: Theme.of(context).colorScheme.primary,
         title: widget.intent!.selectedAdsType == 1 ? 'Advertisement' : 'Events',
         isIconColorBlack: false,
         onBack: () => Navigator.pop(context),
@@ -234,7 +234,7 @@ class _SportsAdvertisementCarouselState extends State<SportsAdvertisementCarouse
                               child: Container(
                                 width: MediaQuery.of(context).size.width,
                                 decoration: BoxDecoration(
-                                  color: Colors.grey[900],
+                                  color: Theme.of(context).colorScheme.onSurface.withOpacity(0.9),
                                 ),
                                 child: Image.network(
                                   advertisementList[index].filePath,
@@ -243,7 +243,7 @@ class _SportsAdvertisementCarouselState extends State<SportsAdvertisementCarouse
                                     return const Center(
                                       child: Icon(
                                         Icons.error_outline,
-                                        color: Colors.white,
+                                        color: Theme.of(context).colorScheme.background,
                                         size: 48.0,
                                       ),
                                     );
@@ -264,13 +264,13 @@ class _SportsAdvertisementCarouselState extends State<SportsAdvertisementCarouse
                                       child: Container(
                                         width: 16.0,
                                         height: 16.0,
-                                        margin: const EdgeInsets.symmetric(horizontal: 4.0),
+                                        margin: EdgeInsets.symmetric(horizontal: 4.0),
                                         decoration: BoxDecoration(
                                           shape: BoxShape.circle,
-                                          color: _currentIndex == entry.key ? const Color(0xFF006590) : Colors.white,
+                                          color: _currentIndex == entry.key ? Theme.of(context).colorScheme.primary : Theme.of(context).colorScheme.background,
                                           border: _currentIndex == entry.key
-                                              ? Border.all(color: Colors.white, width: 2.0)
-                                              : Border.all(color: Colors.grey[300]!, width: 1.0),
+                                              ? Border.all(color: Theme.of(context).colorScheme.background, width: 2.0)
+                                              : Border.all(color: Theme.of(context).colorScheme.outline, width: 1.0),
                                         ),
                                       ),
                                     );

--- a/lib/screens/bazaar/ads_screen/category_screen.dart
+++ b/lib/screens/bazaar/ads_screen/category_screen.dart
@@ -7,7 +7,6 @@ import 'package:oqdo_mobile_app/model/common_passing_args.dart';
 import 'package:oqdo_mobile_app/screens/bazaar/ads_screen/intent/ads_intent.dart';
 import 'package:oqdo_mobile_app/screens/bazaar/ads_screen/model/subactivyt_and_activity_response_model.dart';
 import 'package:oqdo_mobile_app/screens/bazaar/ads_screen/viewmodel/ads_view_model.dart';
-import 'package:oqdo_mobile_app/theme/oqdo_theme_data.dart';
 import 'package:oqdo_mobile_app/utils/constants.dart';
 import 'package:oqdo_mobile_app/utils/custom_text_view.dart';
 import 'package:oqdo_mobile_app/utils/network_interceptor.dart';
@@ -169,12 +168,12 @@ class _CategoryScreenState extends State<CategoryScreen> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      backgroundColor: Colors.white,
+      backgroundColor: Theme.of(context).colorScheme.background,
       appBar: CustomAppBar(
         title: 'Filter',
         onBack: () => Navigator.pop(context),
         isIconColorBlack: false,
-        backgroundColor: const Color(0xFF006989),
+        backgroundColor: Theme.of(context).colorScheme.primary,
       ),
       body: WillPopScope(
         onWillPop: () async {
@@ -186,7 +185,7 @@ class _CategoryScreenState extends State<CategoryScreen> {
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             Padding(
-              padding: const EdgeInsets.all(16),
+              padding: EdgeInsets.all(16),
               child: _buildHeader(),
             ),
             Expanded(
@@ -208,14 +207,14 @@ class _CategoryScreenState extends State<CategoryScreen> {
           textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(
                 fontWeight: FontWeight.w400,
                 fontSize: 18.0,
-                color: OQDOThemeData.otherTextColor,
+                color: Theme.of(context).colorScheme.onSurface.withOpacity(0.6),
               ),
         ),
-        const SizedBox(height: 15.0),
+        SizedBox(height: 15.0),
         CustomTextView(
           label: '(Select categories)',
           textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(
-                color: OQDOThemeData.blackColor,
+                color: Theme.of(context).colorScheme.onBackground,
                 fontWeight: FontWeight.w400,
                 fontSize: 16.0,
               ),
@@ -234,7 +233,7 @@ class _CategoryScreenState extends State<CategoryScreen> {
           child: _buildActivityList(),
         ),
         Container(
-          color: const Color.fromRGBO(227, 227, 227, 1.0),
+          color: Theme.of(context).colorScheme.outline,
           width: 1,
           height: double.infinity,
         ),
@@ -263,13 +262,13 @@ class _CategoryScreenState extends State<CategoryScreen> {
               child: Container(
                 height: 80.0,
                 width: double.infinity,
-                color: selectedActivityName == activity.name ? OQDOThemeData.filterDividerColor : OQDOThemeData.whiteColor,
+                color: selectedActivityName == activity.name ? Theme.of(context).colorScheme.outline : Theme.of(context).colorScheme.background,
                 child: Center(
                   child: CustomTextView(
                     label: activity.name,
                     textStyle: Theme.of(context).textTheme.titleLarge!.copyWith(
                           fontSize: 16.0,
-                          color: OQDOThemeData.greyColor,
+                          color: Theme.of(context).colorScheme.onSurface,
                           fontWeight: FontWeight.w700,
                         ),
                   ),
@@ -278,7 +277,7 @@ class _CategoryScreenState extends State<CategoryScreen> {
             ),
             Container(
               height: 1.0,
-              color: OQDOThemeData.filterDividerColor,
+              color: Theme.of(context).colorScheme.outline,
             ),
           ],
         );
@@ -296,7 +295,7 @@ class _CategoryScreenState extends State<CategoryScreen> {
         final subActivity = selectedValuesFromKey[index];
 
         return Container(
-          padding: const EdgeInsets.only(left: 10.0, right: 20.0, top: 20.0),
+          padding: EdgeInsets.only(left: 10.0, right: 20.0, top: 20.0),
           child: Row(
             mainAxisSize: MainAxisSize.min,
             children: [
@@ -317,7 +316,7 @@ class _CategoryScreenState extends State<CategoryScreen> {
                   },
                 ),
               ),
-              const SizedBox(width: 15.0),
+              SizedBox(width: 15.0),
               Expanded(
                 child: CustomTextView(
                   label: subActivity.name,
@@ -325,7 +324,7 @@ class _CategoryScreenState extends State<CategoryScreen> {
                   textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(
                         fontSize: 18.0,
                         fontWeight: FontWeight.w500,
-                        color: OQDOThemeData.greyColor,
+                        color: Theme.of(context).colorScheme.onSurface,
                       ),
                 ),
               ),
@@ -344,12 +343,12 @@ class _CategoryScreenState extends State<CategoryScreen> {
             height: 70.0,
             child: ElevatedButton(
               style: ButtonStyle(
-                foregroundColor: MaterialStateProperty.all(const Color(0xFFCECECE)),
-                backgroundColor: MaterialStateProperty.all(const Color(0xFFCECECE)),
+                foregroundColor: MaterialStateProperty.all(Theme.of(context).colorScheme.outline),
+                backgroundColor: MaterialStateProperty.all(Theme.of(context).colorScheme.outline),
                 shape: MaterialStateProperty.all(
                   const RoundedRectangleBorder(
                     borderRadius: BorderRadius.zero,
-                    side: BorderSide(color: Color(0xFFCECECE)),
+                    side: BorderSide(color: Theme.of(context).colorScheme.outline),
                   ),
                 ),
               ),
@@ -363,7 +362,7 @@ class _CategoryScreenState extends State<CategoryScreen> {
                       fontWeight: FontWeight.w400,
                       fontSize: 16.0,
                       decoration: TextDecoration.underline,
-                      color: OQDOThemeData.blackColor,
+                      color: Theme.of(context).colorScheme.onBackground,
                     ),
               ),
             ),
@@ -374,13 +373,13 @@ class _CategoryScreenState extends State<CategoryScreen> {
             height: 70.0,
             child: ElevatedButton(
               style: ButtonStyle(
-                foregroundColor: MaterialStateProperty.all(const Color(0xFF006590)),
-                backgroundColor: MaterialStateProperty.all(const Color(0xFF006590)),
+                foregroundColor: MaterialStateProperty.all(Theme.of(context).colorScheme.primary),
+                backgroundColor: MaterialStateProperty.all(Theme.of(context).colorScheme.primary),
                 shape: MaterialStateProperty.all(
                   RoundedRectangleBorder(
                     borderRadius: BorderRadius.zero,
                     side: BorderSide(
-                      color: hasSelections() ? const Color(0xFF006590) : const Color(0xFFCECECE),
+                      color: hasSelections() ? Theme.of(context).colorScheme.primary : Theme.of(context).colorScheme.outline,
                     ),
                   ),
                 ),
@@ -413,7 +412,7 @@ class _CategoryScreenState extends State<CategoryScreen> {
                 textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(
                       fontWeight: FontWeight.w600,
                       fontSize: 16.0,
-                      color: OQDOThemeData.whiteColor,
+                      color: Theme.of(context).colorScheme.background,
                     ),
               ),
             ),

--- a/lib/screens/bazaar/ads_screen/widgets/category_view.dart
+++ b/lib/screens/bazaar/ads_screen/widgets/category_view.dart
@@ -29,14 +29,14 @@ class CategoryView extends StatelessWidget {
               Positioned.fill(
                 child: Container(
                   decoration: BoxDecoration(
-                    color: Colors.black.withAlpha(75), // 0.2 * 255 ≈ 51
+                    color: Theme.of(context).colorScheme.onBackground.withAlpha(75), // 0.2 * 255 ≈ 51
                   ),
                   child: Center(
                     child: Text(
                       title ?? '',
-                      style: const TextStyle(
+                      style: TextStyle(
                         fontFamily: 'Montserrat',
-                        color: Colors.white,
+                        color: Theme.of(context).colorScheme.background,
                         fontSize: 30,
                         fontWeight: FontWeight.bold,
                       ),

--- a/lib/screens/bazaar/ads_screen/widgets/segmented_view.dart
+++ b/lib/screens/bazaar/ads_screen/widgets/segmented_view.dart
@@ -15,7 +15,7 @@ class SegmentedView extends StatefulWidget {
     required this.segments,
     this.onSegmentSelected,
     this.onPressed,
-    this.selectedColor = const Color(0xFF006590),
+    this.selectedColor = Theme.of(context).colorScheme.primary,
     this.unselectedColor = const Color(0xFFD4EEF9),
     this.backgroundColor = const Color(0xFFE0E0E0),
     this.initialIndex = 0,
@@ -60,7 +60,7 @@ class _SegmentedViewState extends State<SegmentedView> {
   @override
   Widget build(BuildContext context) {
     return Container(
-      padding: const EdgeInsets.all(8.0),
+      padding: EdgeInsets.all(8.0),
       child: Row(
         children: [
           Expanded(
@@ -114,7 +114,7 @@ class _SegmentedViewState extends State<SegmentedView> {
           segment.onPressed?.call();
         },
         child: Container(
-          padding: const EdgeInsets.symmetric(vertical: 12.0),
+          padding: EdgeInsets.symmetric(vertical: 12.0),
           decoration: BoxDecoration(
             color: isSelected ? widget.selectedColor : widget.unselectedColor,
             borderRadius: BorderRadius.circular(20.0),
@@ -127,7 +127,7 @@ class _SegmentedViewState extends State<SegmentedView> {
                 segment.name,
                 textAlign: TextAlign.center,
                 style: TextStyle(
-                  color: isSelected ? Colors.white : Colors.black87,
+                  color: isSelected ? Theme.of(context).colorScheme.background : Theme.of(context).colorScheme.onBackground.withOpacity(0.87),
                   fontWeight: FontWeight.w700,
                   fontSize: 17.0,
                   fontFamily: 'Montserrat',

--- a/lib/screens/bazaar/bazaar_home/bazaar_home_screen.dart
+++ b/lib/screens/bazaar/bazaar_home/bazaar_home_screen.dart
@@ -60,7 +60,7 @@ class _BazaarHomeScreenState extends State<BazaarHomeScreen> {
           centerTitle: false,
           elevation: 0.0,
           leadingWidth: 0.0,
-          leading: const SizedBox(),
+          leading: SizedBox(),
           title: Text(
             index == 0
                 ? "Home"
@@ -71,9 +71,9 @@ class _BazaarHomeScreenState extends State<BazaarHomeScreen> {
                         : index == 3
                             ? "Chats"
                             : "OQDO - Advertisements",
-            style: TextStyle(color: Colors.white, fontFamily: 'SFPro', fontWeight: FontWeight.w700, fontSize: 17),
+            style: TextStyle(color: Theme.of(context).colorScheme.background, fontFamily: 'SFPro', fontWeight: FontWeight.w700, fontSize: 17),
           ),
-          backgroundColor: const Color(0xFF006590),
+          backgroundColor: Theme.of(context).colorScheme.primary,
         ),
         body: isPageSet ? page : ChangeNotifierProvider(create: (context) => SellViewmodel(), child: const BuyScreen()),
         bottomNavigationBar: BottomNavigationBar(
@@ -174,19 +174,19 @@ class _BazaarHomeScreenState extends State<BazaarHomeScreen> {
     showDialog(
       context: context,
       builder: (context) => AlertDialog(
-        title: const Text('Are you sure?'),
-        content: const Text('Do you want to exit a Bazaar?'),
+        title:  Text('Are you sure?'),
+        content:  Text('Do you want to exit a Bazaar?'),
         actions: <Widget>[
           TextButton(
             onPressed: () => Navigator.of(context).pop(false),
-            child: const Text('No'),
+            child:  Text('No'),
           ),
           TextButton(
             onPressed: () {
               Navigator.of(context).pop();
               Navigator.of(context).pop();
             },
-            child: const Text('Yes'),
+            child:  Text('Yes'),
           ),
         ],
       ),
@@ -197,19 +197,19 @@ class _BazaarHomeScreenState extends State<BazaarHomeScreen> {
   //   return await showDialog(
   //         context: context,
   //         builder: (context) => AlertDialog(
-  //           title: const Text('Are you sure?'),
-  //           content: const Text('Do you want to exit a Bazaar?'),
+  //           title:  Text('Are you sure?'),
+  //           content:  Text('Do you want to exit a Bazaar?'),
   //           actions: <Widget>[
   //             TextButton(
   //               onPressed: () => Navigator.of(context).pop(false),
-  //               child: const Text('No'),
+  //               child:  Text('No'),
   //             ),
   //             TextButton(
   //               onPressed: () {
   //                 Navigator.of(context).pop();
   //                 Navigator.of(context).pop();
   //               },
-  //               child: const Text('Yes'),
+  //               child:  Text('Yes'),
   //             ),
   //           ],
   //         ),

--- a/lib/screens/bazaar/buy/buy_fav_screen.dart
+++ b/lib/screens/bazaar/buy/buy_fav_screen.dart
@@ -7,7 +7,6 @@ import 'package:oqdo_mobile_app/screens/bazaar/buy/buy_product_details_screen.da
 import 'package:oqdo_mobile_app/screens/bazaar/buy/model/buy_fav_response_model.dart';
 import 'package:oqdo_mobile_app/screens/bazaar/buy/views/buy_favorite_equipment_card.dart';
 import 'package:oqdo_mobile_app/screens/bazaar/sell/viewmodel/sell_viewmodel.dart';
-import 'package:oqdo_mobile_app/theme/oqdo_theme_data.dart';
 import 'package:oqdo_mobile_app/utils/constants.dart';
 import 'package:oqdo_mobile_app/utils/custom_text_view.dart';
 import 'package:oqdo_mobile_app/utils/network_interceptor.dart';
@@ -69,7 +68,7 @@ class _BuyFavScreenState extends State<BuyFavScreen> {
       },
       child: Scaffold(
         appBar: CustomAppBar(
-            backgroundColor: Color(0xFF006590),
+            backgroundColor: Theme.of(context).colorScheme.primary,
             title: 'My Favorites',
             isIconColorBlack: false,
             onBack: () {
@@ -87,7 +86,7 @@ class _BuyFavScreenState extends State<BuyFavScreen> {
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
-                  const SizedBox(height: 20),
+                  SizedBox(height: 20),
                   equipments.isNotEmpty
                       ? Expanded(
                           child: Stack(
@@ -122,7 +121,7 @@ class _BuyFavScreenState extends State<BuyFavScreen> {
                                     textStyle: Theme.of(context)
                                         .textTheme
                                         .titleLarge!
-                                        .copyWith(fontWeight: FontWeight.w600, color: OQDOThemeData.blackColor, fontSize: 16.0),
+                                        .copyWith(fontWeight: FontWeight.w600, color: Theme.of(context).colorScheme.onBackground, fontSize: 16.0),
                                   ),
                           ),
                         ),
@@ -135,7 +134,7 @@ class _BuyFavScreenState extends State<BuyFavScreen> {
 
   Widget _buildEquipmentGrid(List<BuyFavoriteEquipment> equipments) {
     return GridView.builder(
-      padding: const EdgeInsets.all(2.0),
+      padding: EdgeInsets.all(2.0),
       gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
         crossAxisCount: 2,
         childAspectRatio: 0.79,

--- a/lib/screens/bazaar/buy/buy_product_details_screen.dart
+++ b/lib/screens/bazaar/buy/buy_product_details_screen.dart
@@ -44,27 +44,27 @@ class _BuyProductDetailsScreenState extends State<BuyProductDetailsScreen> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      backgroundColor: Colors.white,
+      backgroundColor: Theme.of(context).colorScheme.background,
       appBar: AppBar(
-        backgroundColor: Color(0xFF006989),
+        backgroundColor: Theme.of(context).colorScheme.primary,
         leading: IconButton(
           icon: Icon(
             Icons.arrow_back,
-            color: Colors.white,
+            color: Theme.of(context).colorScheme.background,
           ),
           onPressed: () => Navigator.pop(context),
         ),
         title: Text(
           'Product List',
           style: Theme.of(context).textTheme.titleMedium!.copyWith(
-                color: Colors.white,
+                color: Theme.of(context).colorScheme.background,
                 fontWeight: FontWeight.w600,
                 fontSize: 20.0,
               ),
         ),
       ),
       floatingActionButton: FloatingActionButton(
-        backgroundColor: Color(0xFF006590),
+        backgroundColor: Theme.of(context).colorScheme.primary,
         onPressed: () async {
           final value = await Navigator.pushNamed(context, Constants.buyingChatScreen, arguments: equipmentDetails);
           if (value != null && value is bool && value) {
@@ -74,7 +74,7 @@ class _BuyProductDetailsScreenState extends State<BuyProductDetailsScreen> {
         },
         child: Image.asset(
           'assets/images/ic_bazaar_msg.png',
-          color: Colors.white,
+          color: Theme.of(context).colorScheme.background,
           height: 25,
           width: 25,
         ),
@@ -86,7 +86,7 @@ class _BuyProductDetailsScreenState extends State<BuyProductDetailsScreen> {
             Expanded(
               child: SingleChildScrollView(
                 child: Padding(
-                  padding: const EdgeInsets.all(16.0),
+                  padding: EdgeInsets.all(16.0),
                   child: equipmentDetails == null
                       ? Container()
                       : Column(
@@ -112,7 +112,7 @@ class _BuyProductDetailsScreenState extends State<BuyProductDetailsScreen> {
                                   controller: PageController(viewportFraction: 0.93),
                                   itemBuilder: (context, index) {
                                     return Container(
-                                      margin: const EdgeInsets.symmetric(horizontal: 4),
+                                      margin: EdgeInsets.symmetric(horizontal: 4),
                                       child: ClipRRect(
                                         borderRadius: BorderRadius.circular(8),
                                         child: Image.network(
@@ -120,8 +120,8 @@ class _BuyProductDetailsScreenState extends State<BuyProductDetailsScreen> {
                                           fit: BoxFit.cover,
                                           errorBuilder: (context, error, stackTrace) {
                                             return Container(
-                                              color: Colors.grey[300],
-                                              child: const Icon(Icons.error),
+                                              color: Theme.of(context).colorScheme.outline,
+                                              child:  Icon(Icons.error),
                                             );
                                           },
                                         ),
@@ -149,7 +149,7 @@ class _BuyProductDetailsScreenState extends State<BuyProductDetailsScreen> {
                               style: TextStyle(
                                 fontSize: 20,
                                 fontWeight: FontWeight.w700,
-                                color: Color(0xFF006590),
+                                color: Theme.of(context).colorScheme.primary,
                               ),
                             ),
                             SizedBox(height: 16),
@@ -177,14 +177,14 @@ class _BuyProductDetailsScreenState extends State<BuyProductDetailsScreen> {
                                   children: equipmentDetails?.equipmentSubActivities.map((activity) {
                                         return Container(
                                           decoration: BoxDecoration(
-                                            color: const Color(0xFFF1F5F9), // Light blue-grey background
+                                            color: Theme.of(context).colorScheme.surfaceVariant, // Light blue-grey background
                                             borderRadius: BorderRadius.circular(20),
                                           ),
                                           child: Padding(
-                                            padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+                                            padding: EdgeInsets.symmetric(horizontal: 12, vertical: 6),
                                             child: Text(
                                               activity.name,
-                                              style: const TextStyle(
+                                              style: TextStyle(
                                                 color: Color(0xFF475569), // Dark blue-grey text
                                                 fontSize: 14,
                                                 fontWeight: FontWeight.w500,
@@ -208,7 +208,7 @@ class _BuyProductDetailsScreenState extends State<BuyProductDetailsScreen> {
                             if (equipmentDetails?.expiryDate != null)
                               Text(
                                 'Post expiry date: ${DateFormat('dd/MM/yyyy').format(equipmentDetails?.expiryDate ?? DateTime.now())}',
-                                style: const TextStyle(
+                                style: TextStyle(
                                   fontSize: 16,
                                   fontWeight: FontWeight.w400,
                                   fontFamily: 'Montserrat',

--- a/lib/screens/bazaar/buy/buy_screen.dart
+++ b/lib/screens/bazaar/buy/buy_screen.dart
@@ -79,7 +79,7 @@ class _BuyScreenState extends State<BuyScreen> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      backgroundColor: Colors.white,
+      backgroundColor: Theme.of(context).colorScheme.background,
       body: Column(
         children: [_buildSearchBar(), Expanded(child: _buildEquipmentGrid(equipments))],
       ),
@@ -88,8 +88,8 @@ class _BuyScreenState extends State<BuyScreen> {
 
   Widget _buildSearchBar() {
     return Container(
-      color: Color(0xFF006590),
-      padding: const EdgeInsets.only(left: 16.0, right: 16.0, bottom: 16.0),
+      color: Theme.of(context).colorScheme.primary,
+      padding: EdgeInsets.only(left: 16.0, right: 16.0, bottom: 16.0),
       child: Row(
         children: [
           Expanded(
@@ -97,16 +97,16 @@ class _BuyScreenState extends State<BuyScreen> {
               onChanged: _onSearchChanged,
               decoration: InputDecoration(
                 hintText: "Search Equipment's",
-                prefixIcon: const Icon(
+                prefixIcon:  Icon(
                   Icons.search,
-                  color: Color(0xFF006590),
+                  color: Theme.of(context).colorScheme.primary,
                 ),
                 border: OutlineInputBorder(
                   borderRadius: BorderRadius.circular(8.0),
                   borderSide: BorderSide.none,
                 ),
                 filled: true,
-                fillColor: Colors.white,
+                fillColor: Theme.of(context).colorScheme.background,
               ),
             ),
           ),
@@ -131,7 +131,7 @@ class _BuyScreenState extends State<BuyScreen> {
                 }
               },
               child: Image.asset('assets/images/ic_bazaar_filter.png', width: 30.0, height: 30.0)),
-          const SizedBox(width: 15.0), // Space between filter icon and fav icon
+          SizedBox(width: 15.0), // Space between filter icon and fav icon
           GestureDetector(
             onTap: () async {
               var result = await Navigator.pushNamed(context, BuyFavScreen.routeName);
@@ -168,7 +168,7 @@ class _BuyScreenState extends State<BuyScreen> {
         Expanded(
           child: GridView.builder(
             controller: _scrollController,
-            padding: const EdgeInsets.all(2.0),
+            padding: EdgeInsets.all(2.0),
             gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
               crossAxisCount: 2,
               childAspectRatio: 0.79,
@@ -198,7 +198,7 @@ class _BuyScreenState extends State<BuyScreen> {
         ),
         if (isLoading && hasMoreData && equipments.isNotEmpty)
           Container(
-            padding: const EdgeInsets.symmetric(vertical: 16.0),
+            padding: EdgeInsets.symmetric(vertical: 16.0),
             child: const Center(
               child: CircularProgressIndicator(),
             ),

--- a/lib/screens/bazaar/buy/category_screen.dart
+++ b/lib/screens/bazaar/buy/category_screen.dart
@@ -7,7 +7,6 @@ import 'package:oqdo_mobile_app/model/common_passing_args.dart';
 import 'package:oqdo_mobile_app/screens/bazaar/ads_screen/model/subactivyt_and_activity_response_model.dart';
 import 'package:oqdo_mobile_app/screens/bazaar/sell/models/equipment_category_response_model.dart';
 import 'package:oqdo_mobile_app/screens/bazaar/sell/viewmodel/sell_viewmodel.dart';
-import 'package:oqdo_mobile_app/theme/oqdo_theme_data.dart';
 import 'package:oqdo_mobile_app/utils/constants.dart';
 import 'package:oqdo_mobile_app/utils/custom_text_view.dart';
 import 'package:oqdo_mobile_app/utils/network_interceptor.dart';
@@ -283,12 +282,12 @@ class _BuyCategoryScreenState extends State<BuyCategoryScreen> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      backgroundColor: Colors.white,
+      backgroundColor: Theme.of(context).colorScheme.background,
       appBar: CustomAppBar(
         title: 'Filter',
         onBack: () => Navigator.pop(context),
         isIconColorBlack: false,
-        backgroundColor: const Color(0xFF006989),
+        backgroundColor: Theme.of(context).colorScheme.primary,
       ),
       body: WillPopScope(
         onWillPop: () async {
@@ -300,7 +299,7 @@ class _BuyCategoryScreenState extends State<BuyCategoryScreen> {
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             Padding(
-              padding: const EdgeInsets.all(16),
+              padding: EdgeInsets.all(16),
               child: _buildHeader(),
             ),
             Expanded(
@@ -322,14 +321,14 @@ class _BuyCategoryScreenState extends State<BuyCategoryScreen> {
           textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(
                 fontWeight: FontWeight.w400,
                 fontSize: 18.0,
-                color: OQDOThemeData.otherTextColor,
+                color: Theme.of(context).colorScheme.onSurface.withOpacity(0.6),
               ),
         ),
-        const SizedBox(height: 15.0),
+        SizedBox(height: 15.0),
         CustomTextView(
           label: '(Select categories)',
           textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(
-                color: OQDOThemeData.blackColor,
+                color: Theme.of(context).colorScheme.onBackground,
                 fontWeight: FontWeight.w400,
                 fontSize: 16.0,
               ),
@@ -348,7 +347,7 @@ class _BuyCategoryScreenState extends State<BuyCategoryScreen> {
           child: _buildActivityList(),
         ),
         Container(
-          color: const Color.fromRGBO(227, 227, 227, 1.0),
+          color: Theme.of(context).colorScheme.outline,
           width: 1,
           height: double.infinity,
         ),
@@ -377,13 +376,13 @@ class _BuyCategoryScreenState extends State<BuyCategoryScreen> {
             child: Container(
               height: 80.0,
               width: double.infinity,
-              color: selectedActivityName == activity.name ? OQDOThemeData.filterDividerColor : OQDOThemeData.whiteColor,
+              color: selectedActivityName == activity.name ? Theme.of(context).colorScheme.outline : Theme.of(context).colorScheme.background,
               child: Center(
                 child: CustomTextView(
                   label: activity.name,
                   textStyle: Theme.of(context).textTheme.titleLarge!.copyWith(
                         fontSize: 16.0,
-                        color: OQDOThemeData.greyColor,
+                        color: Theme.of(context).colorScheme.onSurface,
                         fontWeight: FontWeight.w700,
                       ),
                 ),
@@ -392,7 +391,7 @@ class _BuyCategoryScreenState extends State<BuyCategoryScreen> {
           ),
           Container(
             height: 1.0,
-            color: OQDOThemeData.filterDividerColor,
+            color: Theme.of(context).colorScheme.outline,
           ),
         ],
       ));
@@ -409,13 +408,13 @@ class _BuyCategoryScreenState extends State<BuyCategoryScreen> {
           child: Container(
             height: 80.0,
             width: double.infinity,
-            color: selectedActivityName == PRODUCT_CATEGORY_KEY ? OQDOThemeData.filterDividerColor : OQDOThemeData.whiteColor,
+            color: selectedActivityName == PRODUCT_CATEGORY_KEY ? Theme.of(context).colorScheme.outline : Theme.of(context).colorScheme.background,
             child: Center(
               child: CustomTextView(
                 label: PRODUCT_CATEGORY_KEY,
                 textStyle: Theme.of(context).textTheme.titleLarge!.copyWith(
                       fontSize: 16.0,
-                      color: OQDOThemeData.greyColor,
+                      color: Theme.of(context).colorScheme.onSurface,
                       fontWeight: FontWeight.w700,
                     ),
               ),
@@ -424,7 +423,7 @@ class _BuyCategoryScreenState extends State<BuyCategoryScreen> {
         ),
         Container(
           height: 1.0,
-          color: OQDOThemeData.filterDividerColor,
+          color: Theme.of(context).colorScheme.outline,
         ),
       ],
     ));
@@ -453,7 +452,7 @@ class _BuyCategoryScreenState extends State<BuyCategoryScreen> {
         final subActivity = selectedValuesFromKey[index] as SubActivity;
 
         return Container(
-          padding: const EdgeInsets.only(left: 10.0, right: 20.0, top: 20.0),
+          padding: EdgeInsets.only(left: 10.0, right: 20.0, top: 20.0),
           child: Row(
             mainAxisSize: MainAxisSize.min,
             children: [
@@ -474,7 +473,7 @@ class _BuyCategoryScreenState extends State<BuyCategoryScreen> {
                   },
                 ),
               ),
-              const SizedBox(width: 15.0),
+              SizedBox(width: 15.0),
               Expanded(
                 child: CustomTextView(
                   label: subActivity.name,
@@ -482,7 +481,7 @@ class _BuyCategoryScreenState extends State<BuyCategoryScreen> {
                   textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(
                         fontSize: 18.0,
                         fontWeight: FontWeight.w500,
-                        color: OQDOThemeData.greyColor,
+                        color: Theme.of(context).colorScheme.onSurface,
                       ),
                 ),
               ),
@@ -501,7 +500,7 @@ class _BuyCategoryScreenState extends State<BuyCategoryScreen> {
         final category = equipmentCategories[index];
 
         return Container(
-          padding: const EdgeInsets.only(left: 10.0, right: 20.0, top: 20.0),
+          padding: EdgeInsets.only(left: 10.0, right: 20.0, top: 20.0),
           child: Row(
             mainAxisSize: MainAxisSize.min,
             children: [
@@ -522,7 +521,7 @@ class _BuyCategoryScreenState extends State<BuyCategoryScreen> {
                   },
                 ),
               ),
-              const SizedBox(width: 15.0),
+              SizedBox(width: 15.0),
               Expanded(
                 child: CustomTextView(
                   label: category.name,
@@ -530,7 +529,7 @@ class _BuyCategoryScreenState extends State<BuyCategoryScreen> {
                   textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(
                         fontSize: 18.0,
                         fontWeight: FontWeight.w500,
-                        color: OQDOThemeData.greyColor,
+                        color: Theme.of(context).colorScheme.onSurface,
                       ),
                 ),
               ),
@@ -549,12 +548,12 @@ class _BuyCategoryScreenState extends State<BuyCategoryScreen> {
             height: 70.0,
             child: ElevatedButton(
               style: ButtonStyle(
-                foregroundColor: MaterialStateProperty.all(const Color(0xFFCECECE)),
-                backgroundColor: MaterialStateProperty.all(const Color(0xFFCECECE)),
+                foregroundColor: MaterialStateProperty.all(Theme.of(context).colorScheme.outline),
+                backgroundColor: MaterialStateProperty.all(Theme.of(context).colorScheme.outline),
                 shape: MaterialStateProperty.all(
                   const RoundedRectangleBorder(
                     borderRadius: BorderRadius.zero,
-                    side: BorderSide(color: Color(0xFFCECECE)),
+                    side: BorderSide(color: Theme.of(context).colorScheme.outline),
                   ),
                 ),
               ),
@@ -568,7 +567,7 @@ class _BuyCategoryScreenState extends State<BuyCategoryScreen> {
                       fontWeight: FontWeight.w400,
                       fontSize: 16.0,
                       decoration: TextDecoration.underline,
-                      color: OQDOThemeData.blackColor,
+                      color: Theme.of(context).colorScheme.onBackground,
                     ),
               ),
             ),
@@ -579,13 +578,13 @@ class _BuyCategoryScreenState extends State<BuyCategoryScreen> {
             height: 70.0,
             child: ElevatedButton(
               style: ButtonStyle(
-                foregroundColor: MaterialStateProperty.all(const Color(0xFF006590)),
-                backgroundColor: MaterialStateProperty.all(const Color(0xFF006590)),
+                foregroundColor: MaterialStateProperty.all(Theme.of(context).colorScheme.primary),
+                backgroundColor: MaterialStateProperty.all(Theme.of(context).colorScheme.primary),
                 shape: MaterialStateProperty.all(
                   RoundedRectangleBorder(
                     borderRadius: BorderRadius.zero,
                     side: BorderSide(
-                      color: hasSelections() ? const Color(0xFF006590) : const Color(0xFFCECECE),
+                      color: hasSelections() ? Theme.of(context).colorScheme.primary : Theme.of(context).colorScheme.outline,
                     ),
                   ),
                 ),
@@ -651,7 +650,7 @@ class _BuyCategoryScreenState extends State<BuyCategoryScreen> {
                 textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(
                       fontWeight: FontWeight.w600,
                       fontSize: 16.0,
-                      color: OQDOThemeData.whiteColor,
+                      color: Theme.of(context).colorScheme.background,
                     ),
               ),
             ),

--- a/lib/screens/bazaar/buy/views/buy_equipment_card.dart
+++ b/lib/screens/bazaar/buy/views/buy_equipment_card.dart
@@ -47,14 +47,14 @@ class BuyEquipmentCard extends StatelessWidget {
             ),
             // Content Section
             Padding(
-              padding: const EdgeInsets.all(8.0),
+              padding: EdgeInsets.all(8.0),
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
                   // Title
                   Text(
                     equipment.title,
-                    style: const TextStyle(
+                    style: TextStyle(
                       fontSize: 15,
                       fontWeight: FontWeight.bold,
                       height: 1.2,
@@ -62,7 +62,7 @@ class BuyEquipmentCard extends StatelessWidget {
                     maxLines: 1,
                     overflow: TextOverflow.ellipsis,
                   ),
-                  const SizedBox(height: 4),
+                  SizedBox(height: 4),
                   // Source
                   Text(
                     'by ${equipment.equipmentCategory?.name ?? ''}',
@@ -72,10 +72,10 @@ class BuyEquipmentCard extends StatelessWidget {
                       fontSize: 12,
                       fontFamily: 'Montserrat',
                       overflow: TextOverflow.ellipsis,
-                      color: Colors.grey[600],
+                      color: Theme.of(context).colorScheme.onSurface.withOpacity(0.6),
                     ),
                   ),
-                  const SizedBox(height: 10),
+                  SizedBox(height: 10),
                   // Price and Favorite Row
                   Row(
                     mainAxisAlignment: MainAxisAlignment.spaceBetween,
@@ -83,10 +83,10 @@ class BuyEquipmentCard extends StatelessWidget {
                     children: [
                       Text(
                         'S\$ - ${equipment.price.toStringAsFixed(2)}',
-                        style: const TextStyle(
+                        style: TextStyle(
                           fontSize: 18,
                           fontWeight: FontWeight.bold,
-                          color: Color(0xFF006590),
+                          color: Theme.of(context).colorScheme.primary,
                         ),
                       ),
                       GestureDetector(

--- a/lib/screens/bazaar/buy/views/buy_favorite_equipment_card.dart
+++ b/lib/screens/bazaar/buy/views/buy_favorite_equipment_card.dart
@@ -47,14 +47,14 @@ class BuyFavoriteEquipmentCard extends StatelessWidget {
             ),
             // Content Section
             Padding(
-              padding: const EdgeInsets.all(8.0),
+              padding: EdgeInsets.all(8.0),
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
                   // Title
                   Text(
                     equipment.title,
-                    style: const TextStyle(
+                    style: TextStyle(
                       fontSize: 14,
                       fontWeight: FontWeight.bold,
                       height: 1.2,
@@ -62,7 +62,7 @@ class BuyFavoriteEquipmentCard extends StatelessWidget {
                     maxLines: 1,
                     overflow: TextOverflow.ellipsis,
                   ),
-                  const SizedBox(height: 4),
+                  SizedBox(height: 4),
                   // Source
                   Text(
                     'by ${equipment.equipmentCategory.name ?? ''}',
@@ -71,10 +71,10 @@ class BuyFavoriteEquipmentCard extends StatelessWidget {
                       fontSize: 12,
                       fontFamily: 'Montserrat',
                       overflow: TextOverflow.ellipsis,
-                      color: Colors.grey[600],
+                      color: Theme.of(context).colorScheme.onSurface.withOpacity(0.6),
                     ),
                   ),
-                  const SizedBox(height: 10),
+                  SizedBox(height: 10),
                   // Price and Favorite Row
                   Row(
                     mainAxisAlignment: MainAxisAlignment.spaceBetween,
@@ -82,10 +82,10 @@ class BuyFavoriteEquipmentCard extends StatelessWidget {
                     children: [
                       Text(
                         'S\$ - ${equipment.price.toStringAsFixed(2)}',
-                        style: const TextStyle(
+                        style: TextStyle(
                           fontSize: 18,
                           fontWeight: FontWeight.bold,
-                          color: Color(0xFF006590),
+                          color: Theme.of(context).colorScheme.primary,
                         ),
                       ),
                       GestureDetector(

--- a/lib/screens/bazaar/chats/buying/buying_chat_list_screen.dart
+++ b/lib/screens/bazaar/chats/buying/buying_chat_list_screen.dart
@@ -187,7 +187,7 @@ class BuyingChatListScreenState extends State<BuyingChatListScreen> with Automat
     _notificationService = Provider.of<ChatNotificationService>(context);
 
     return Material(
-      color: Colors.white,
+      color: Theme.of(context).colorScheme.background,
       child: RefreshIndicator(
         key: _refreshIndicatorKey,
         onRefresh: _refreshData,
@@ -205,7 +205,7 @@ class BuyingChatListScreenState extends State<BuyingChatListScreen> with Automat
             : ListView.builder(
                 controller: _scrollController,
                 itemCount: _chatList.length + (_isLoading && _hasMoreData ? 1 : 0),
-                padding: const EdgeInsets.all(16),
+                padding: EdgeInsets.all(16),
                 physics: const AlwaysScrollableScrollPhysics(),
                 scrollDirection: Axis.vertical,
                 itemBuilder: (context, index) {
@@ -237,7 +237,7 @@ class BuyingChatListScreenState extends State<BuyingChatListScreen> with Automat
     debugPrint('Chat item at index $index: isNewMsg=${chatItem.isNewMsg}');
 
     return Padding(
-      padding: const EdgeInsets.only(top: 8, bottom: 8),
+      padding: EdgeInsets.only(top: 8, bottom: 8),
       child: GestureDetector(
         onTap: () async {
           // Mark as read when opening the chat
@@ -297,7 +297,7 @@ class BuyingChatListScreenState extends State<BuyingChatListScreen> with Automat
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             Card(
-              color: Colors.white,
+              color: Theme.of(context).colorScheme.background,
               elevation: 0,
               shape: RoundedRectangleBorder(
                 borderRadius: BorderRadius.circular(10.0),
@@ -341,10 +341,10 @@ class BuyingChatListScreenState extends State<BuyingChatListScreen> with Automat
                 ),
               ),
             ),
-            const SizedBox(width: 8),
+            SizedBox(width: 8),
             Flexible(
               child: Padding(
-                padding: const EdgeInsets.fromLTRB(0, 8.0, 0, 0),
+                padding: EdgeInsets.fromLTRB(0, 8.0, 0, 0),
                 child: Column(
                   mainAxisAlignment: MainAxisAlignment.start,
                   crossAxisAlignment: CrossAxisAlignment.stretch,
@@ -368,7 +368,7 @@ class BuyingChatListScreenState extends State<BuyingChatListScreen> with Automat
                         ),
                       ],
                     ),
-                    const SizedBox(height: 8),
+                    SizedBox(height: 8),
                     CustomTextView(
                       label: chatItem.title,
                       maxLine: 2,
@@ -381,7 +381,7 @@ class BuyingChatListScreenState extends State<BuyingChatListScreen> with Automat
                             overflow: TextOverflow.ellipsis,
                           ),
                     ),
-                    const SizedBox(height: 4),
+                    SizedBox(height: 4),
                   ],
                 ),
               ),
@@ -391,7 +391,7 @@ class BuyingChatListScreenState extends State<BuyingChatListScreen> with Automat
               key: Key('notification_dot_${chatItem.equipmentChatId}_${chatItem.isNewMsg}'),
               visible: chatItem.isNewMsg ?? false,
               child: Padding(
-                padding: const EdgeInsets.fromLTRB(0, 22.0, 15.0, 0.0),
+                padding: EdgeInsets.fromLTRB(0, 22.0, 15.0, 0.0),
                 child: Container(
                   height: 10,
                   width: 10,

--- a/lib/screens/bazaar/chats/buying/buying_chat_screen.dart
+++ b/lib/screens/bazaar/chats/buying/buying_chat_screen.dart
@@ -11,7 +11,6 @@ import 'package:oqdo_mobile_app/screens/bazaar/chats/viewmodel/chat_view_model.d
 import 'package:oqdo_mobile_app/screens/bazaar/chats/views/close_deal_view.dart';
 import 'package:oqdo_mobile_app/screens/bazaar/chats/views/offer_price_bottom_sheet_view.dart';
 import 'package:oqdo_mobile_app/screens/bazaar/sell/models/sell_equipment_response_model.dart';
-import 'package:oqdo_mobile_app/theme/oqdo_theme_data.dart';
 import 'package:oqdo_mobile_app/utils/constants.dart';
 import 'package:oqdo_mobile_app/utils/network_interceptor.dart';
 import 'package:oqdo_mobile_app/utils/string_manager.dart';
@@ -162,9 +161,9 @@ class _BuyingChatScreenState extends State<BuyingChatScreen> {
           centerTitle: false,
           elevation: 0.0,
           leadingWidth: 0.0,
-          leading: const SizedBox(),
+          leading: SizedBox(),
           title: Container(
-            padding: const EdgeInsets.symmetric(vertical: 12, horizontal: 4),
+            padding: EdgeInsets.symmetric(vertical: 12, horizontal: 4),
             // Added padding
             child: Column(
               mainAxisAlignment: MainAxisAlignment.start,
@@ -180,11 +179,11 @@ class _BuyingChatScreenState extends State<BuyingChatScreen> {
                       },
                       child: Icon(
                         Icons.arrow_back,
-                        color: Colors.white,
+                        color: Theme.of(context).colorScheme.background,
                         size: 30,
                       ),
                     ),
-                    const SizedBox(width: 18),
+                    SizedBox(width: 18),
                     ClipPath(
                       clipper: ShapeBorderClipper(
                         shape: RoundedRectangleBorder(
@@ -203,13 +202,13 @@ class _BuyingChatScreenState extends State<BuyingChatScreen> {
                             fit: BoxFit.fill,
                           )),
                     ),
-                    const SizedBox(width: 12),
+                    SizedBox(width: 12),
                     Text(
                       widget.equipmentDetails.fullName,
                       maxLines: 1,
                       overflow: TextOverflow.ellipsis,
                       style: TextStyle(
-                        color: Colors.white,
+                        color: Theme.of(context).colorScheme.background,
                         fontSize: 18,
                         fontWeight: FontWeight.bold,
                         fontFamily: 'Montserrat',
@@ -217,7 +216,7 @@ class _BuyingChatScreenState extends State<BuyingChatScreen> {
                     ),
                   ],
                 ),
-                const SizedBox(height: 5),
+                SizedBox(height: 5),
                 Row(
                   mainAxisAlignment: MainAxisAlignment.spaceBetween,
                   children: [
@@ -227,18 +226,18 @@ class _BuyingChatScreenState extends State<BuyingChatScreen> {
                         overflow: TextOverflow.ellipsis,
                         widget.equipmentDetails.title,
                         style: TextStyle(
-                          color: Colors.white,
+                          color: Theme.of(context).colorScheme.background,
                           fontSize: 14,
                           fontWeight: FontWeight.w500,
                           fontFamily: 'Montserrat',
                         ),
                       ),
                     ),
-                    const SizedBox(width: 10),
+                    SizedBox(width: 10),
                     Text(
                       'S\$ ${widget.equipmentDetails.price.toStringAsFixed(2)}',
                       style: TextStyle(
-                        color: Colors.white,
+                        color: Theme.of(context).colorScheme.background,
                         fontSize: 18,
                         fontWeight: FontWeight.bold,
                         fontFamily: 'Montserrat',
@@ -249,7 +248,7 @@ class _BuyingChatScreenState extends State<BuyingChatScreen> {
               ],
             ),
           ),
-          backgroundColor: const Color(0xFF006590),
+          backgroundColor: Theme.of(context).colorScheme.primary,
         ),
         body: SafeArea(
           child: isLoading
@@ -276,13 +275,13 @@ class _BuyingChatScreenState extends State<BuyingChatScreen> {
             Icon(
               Icons.chat_bubble_outline,
               size: 48,
-              color: const Color(0xFF006590),
+              color: Theme.of(context).colorScheme.primary,
             ),
-            const SizedBox(height: 16),
+            SizedBox(height: 16),
             Text(
               "Please send a message to start the chat",
               style: TextStyle(
-                color: Colors.black54,
+                color: Theme.of(context).colorScheme.onBackground.withOpacity(0.54),
                 fontSize: 16,
                 fontWeight: FontWeight.w500,
                 fontFamily: 'Montserrat',
@@ -295,7 +294,7 @@ class _BuyingChatScreenState extends State<BuyingChatScreen> {
       return ListView.builder(
         physics: BouncingScrollPhysics(),
         controller: _scrollController,
-        padding: const EdgeInsets.all(16),
+        padding: EdgeInsets.all(16),
         reverse: false,
         itemCount: chatMessageResponseModelList.isNotEmpty ? chatMessageResponseModelList.length : 0,
         itemBuilder: (context, index) {
@@ -334,20 +333,20 @@ class _BuyingChatScreenState extends State<BuyingChatScreen> {
         children: [
           Container(
             constraints: BoxConstraints(maxWidth: (MediaQuery.sizeOf(context).width / 1.4)),
-            margin: const EdgeInsets.only(bottom: 5),
+            margin: EdgeInsets.only(bottom: 5),
             padding: EdgeInsets.fromLTRB(16, 15, isOfferAcceptanceMessage! ? 16 : 32, 15),
             decoration: BoxDecoration(
               color: (isOfferMessage!)
-                  ? const Color(0xFF006590)
+                  ? Theme.of(context).colorScheme.primary
                   : (((!isSentByMe) && isOfferAcceptanceMessage))
-                      ? Colors.white
+                      ? Theme.of(context).colorScheme.background
                       : isSentByMe
                           ? const Color(0xFFC7DDE7)
-                          : Colors.white,
+                          : Theme.of(context).colorScheme.background,
               borderRadius: BorderRadius.circular(10),
               boxShadow: [
                 BoxShadow(
-                  color: Colors.black.withValues(alpha: 0.1),
+                  color: Theme.of(context).colorScheme.onBackground.withValues(alpha: 0.1),
                   blurRadius: 4,
                   offset: const Offset(0, 2),
                 ),
@@ -371,7 +370,7 @@ class _BuyingChatScreenState extends State<BuyingChatScreen> {
                                           maxLines: 2,
                                           "Offer: S\$ ${price.toStringAsFixed(2)}",
                                           style: TextStyle(
-                                            color: Colors.black,
+                                            color: Theme.of(context).colorScheme.onBackground,
                                             fontSize: 14,
                                             fontWeight: FontWeight.w400,
                                             fontFamily: 'Montserrat',
@@ -391,7 +390,7 @@ class _BuyingChatScreenState extends State<BuyingChatScreen> {
                                   ),
                                 )
                               : Container(
-                                  color: Colors.white,
+                                  color: Theme.of(context).colorScheme.background,
                                   padding: EdgeInsets.all(10),
                                   child: Row(
                                     mainAxisAlignment: MainAxisAlignment.spaceBetween,
@@ -401,7 +400,7 @@ class _BuyingChatScreenState extends State<BuyingChatScreen> {
                                           maxLines: 2,
                                           "Offer: S\$ ${price.toStringAsFixed(2)}",
                                           style: TextStyle(
-                                            color: Colors.black,
+                                            color: Theme.of(context).colorScheme.onBackground,
                                             fontSize: 14,
                                             fontWeight: FontWeight.w400,
                                             fontFamily: 'Montserrat',
@@ -420,11 +419,11 @@ class _BuyingChatScreenState extends State<BuyingChatScreen> {
                                     ],
                                   ),
                                 ),
-                          const SizedBox(height: 15),
+                          SizedBox(height: 15),
                           Text(
                             message,
                             style: TextStyle(
-                              color: Colors.black,
+                              color: Theme.of(context).colorScheme.onBackground,
                               fontSize: 18,
                               fontWeight: FontWeight.w400,
                               fontFamily: 'Montserrat',
@@ -439,17 +438,17 @@ class _BuyingChatScreenState extends State<BuyingChatScreen> {
                               Text(
                                 "${isSentByMe ? "YOUR" : "SELLER'S"} OFFER",
                                 style: TextStyle(
-                                  color: Colors.white,
+                                  color: Theme.of(context).colorScheme.background,
                                   fontSize: 14,
                                   fontWeight: FontWeight.w600,
                                   fontFamily: 'Montserrat',
                                 ),
                               ),
-                              const SizedBox(height: 10),
+                              SizedBox(height: 10),
                               Text(
                                 'S\$ $message',
                                 style: TextStyle(
-                                  color: Colors.white,
+                                  color: Theme.of(context).colorScheme.background,
                                   fontSize: 18,
                                   fontWeight: FontWeight.w800,
                                   fontFamily: 'Montserrat',
@@ -460,7 +459,7 @@ class _BuyingChatScreenState extends State<BuyingChatScreen> {
                         : Text(
                             message,
                             style: TextStyle(
-                              color: Colors.black,
+                              color: Theme.of(context).colorScheme.onBackground,
                               fontSize: 16,
                               fontWeight: FontWeight.w400,
                               fontFamily: 'Montserrat',
@@ -472,11 +471,11 @@ class _BuyingChatScreenState extends State<BuyingChatScreen> {
           Text(
             time,
             style: TextStyle(
-              color: Colors.black,
+              color: Theme.of(context).colorScheme.onBackground,
               fontSize: 12,
             ),
           ),
-          const SizedBox(height: 5),
+          SizedBox(height: 5),
         ],
       ),
     );
@@ -484,7 +483,7 @@ class _BuyingChatScreenState extends State<BuyingChatScreen> {
 
   Widget _buildBottomSection(bool isKeyboardVisible) {
     return Padding(
-      padding: const EdgeInsets.symmetric(vertical: 10),
+      padding: EdgeInsets.symmetric(vertical: 10),
       child: Column(
         children: [
           showCloseDealView
@@ -497,28 +496,28 @@ class _BuyingChatScreenState extends State<BuyingChatScreen> {
                   mainAxisAlignment: MainAxisAlignment.center,
                   children: [
                     isKeyboardVisible
-                        ? const SizedBox(
+                        ? SizedBox(
                             width: 18,
                           )
                         : Padding(
-                            padding: const EdgeInsets.symmetric(horizontal: 18),
+                            padding: EdgeInsets.symmetric(horizontal: 18),
                             child: Container(
                               decoration: BoxDecoration(
-                                color: Color(0xFF006590),
+                                color: Theme.of(context).colorScheme.primary,
                                 shape: BoxShape.circle,
                               ),
                               child: Theme(
                                 data: Theme.of(context).copyWith(
-                                  cardColor: Color(0xFF006590),
+                                  cardColor: Theme.of(context).colorScheme.primary,
                                   dividerTheme: DividerThemeData(
-                                    color: Colors.white,
+                                    color: Theme.of(context).colorScheme.background,
                                   ),
                                 ),
                                 child: PopupMenuButton<String>(
                                   offset: const Offset(0, -115),
                                   popUpAnimationStyle: AnimationStyle.noAnimation,
                                   menuPadding: EdgeInsets.zero,
-                                  icon: const Icon(Icons.more_vert, color: Colors.white),
+                                  icon:  Icon(Icons.more_vert, color: Theme.of(context).colorScheme.background),
                                   shape: RoundedRectangleBorder(
                                     borderRadius: BorderRadius.all(
                                       Radius.circular(5.0),
@@ -535,7 +534,7 @@ class _BuyingChatScreenState extends State<BuyingChatScreen> {
                                         'Offer Price',
                                         textAlign: TextAlign.start,
                                         style: TextStyle(
-                                          color: Colors.white,
+                                          color: Theme.of(context).colorScheme.background,
                                           fontSize: 16,
                                           fontWeight: FontWeight.w600,
                                           fontFamily: 'Montserrat',
@@ -562,7 +561,7 @@ class _BuyingChatScreenState extends State<BuyingChatScreen> {
                                                 text: TextSpan(
                                                     text: 'Ok, Done |',
                                                     style: TextStyle(
-                                                      color: Colors.white,
+                                                      color: Theme.of(context).colorScheme.background,
                                                       fontSize: 16,
                                                       fontWeight: FontWeight.w400,
                                                       fontFamily: 'Montserrat',
@@ -571,7 +570,7 @@ class _BuyingChatScreenState extends State<BuyingChatScreen> {
                                                       TextSpan(
                                                         text: ' S\$ ${price.toStringAsFixed(2)}',
                                                         style: TextStyle(
-                                                          color: Colors.white,
+                                                          color: Theme.of(context).colorScheme.background,
                                                           fontSize: 16,
                                                           fontWeight: FontWeight.w800,
                                                           fontFamily: 'Montserrat',
@@ -583,7 +582,7 @@ class _BuyingChatScreenState extends State<BuyingChatScreen> {
                                           : Text(
                                               'Ok, Done',
                                               style: TextStyle(
-                                                color: Colors.white,
+                                                color: Theme.of(context).colorScheme.background,
                                                 fontSize: 16,
                                                 fontWeight: FontWeight.w600,
                                                 fontFamily: 'Montserrat',
@@ -630,7 +629,7 @@ class _BuyingChatScreenState extends State<BuyingChatScreen> {
                                 }
                               },
                               child: Padding(
-                                padding: const EdgeInsets.symmetric(horizontal: 15),
+                                padding: EdgeInsets.symmetric(horizontal: 15),
                                 child: Image.asset(
                                   "assets/images/ic_send.png",
                                   height: 30,
@@ -642,7 +641,7 @@ class _BuyingChatScreenState extends State<BuyingChatScreen> {
                         ),
                       ),
                     ),
-                    const SizedBox(width: 18),
+                    SizedBox(width: 18),
                   ],
                 ),
         ],
@@ -657,7 +656,7 @@ class _BuyingChatScreenState extends State<BuyingChatScreen> {
       enableDrag: true,
       isScrollControlled: true,
       showDragHandle: true,
-      backgroundColor: OQDOThemeData.whiteColor,
+      backgroundColor: Theme.of(context).colorScheme.background,
       builder: (context) => OfferPriceBottomSheetView(
         title: 'Make an Offer',
         offerPriceController: offerPriceController,
@@ -1107,7 +1106,7 @@ class _BuyingChatScreenState extends State<BuyingChatScreen> {
           content: Text('Chat timed out. Relaunch from list.'),
           actions: <Widget>[
             TextButton(
-              child: const Text('Okay'),
+              child:  Text('Okay'),
               onPressed: () {
                 Navigator.pop(context, true);
                 Navigator.pop(context, true);

--- a/lib/screens/bazaar/chats/chats_screen.dart
+++ b/lib/screens/bazaar/chats/chats_screen.dart
@@ -103,14 +103,14 @@ class _ChatsScreenState extends State<ChatsScreen> with SingleTickerProviderStat
         ],
         child: Scaffold(
           key: scaffoldKey,
-          backgroundColor: Colors.white,
+          backgroundColor: Theme.of(context).colorScheme.background,
           body: SafeArea(
             child: Column(
               children: [
                 Padding(
-                  padding: const EdgeInsets.fromLTRB(20.0, 20, 20, 0),
+                  padding: EdgeInsets.fromLTRB(20.0, 20, 20, 0),
                   child: Container(
-                    color: Colors.white,
+                    color: Theme.of(context).colorScheme.background,
                     child: Container(
                       decoration: BoxDecoration(
                         color: Color(0xFFD4EEF9),
@@ -124,9 +124,9 @@ class _ChatsScreenState extends State<ChatsScreen> with SingleTickerProviderStat
                               child: GestureDetector(
                                 onTap: () => _onTabTapped(0),
                                 child: Container(
-                                  padding: const EdgeInsets.symmetric(vertical: 14.0),
+                                  padding: EdgeInsets.symmetric(vertical: 14.0),
                                   decoration: BoxDecoration(
-                                    color: _selectedIndex == 0 ? const Color(0xFF006590) : Colors.transparent,
+                                    color: _selectedIndex == 0 ? Theme.of(context).colorScheme.primary : Colors.transparent,
                                     borderRadius: BorderRadius.circular(25.0),
                                   ),
                                   child: Text(
@@ -134,7 +134,7 @@ class _ChatsScreenState extends State<ChatsScreen> with SingleTickerProviderStat
                                     textAlign: TextAlign.center,
                                     style: TextStyle(
                                       fontFamily: 'Montserrat',
-                                      color: _selectedIndex == 0 ? Colors.white : Colors.black,
+                                      color: _selectedIndex == 0 ? Theme.of(context).colorScheme.background : Theme.of(context).colorScheme.onBackground,
                                       fontSize: 15,
                                       fontWeight: FontWeight.w500,
                                     ),
@@ -146,9 +146,9 @@ class _ChatsScreenState extends State<ChatsScreen> with SingleTickerProviderStat
                               child: GestureDetector(
                                 onTap: () => _onTabTapped(1),
                                 child: Container(
-                                  padding: const EdgeInsets.symmetric(vertical: 12.0),
+                                  padding: EdgeInsets.symmetric(vertical: 12.0),
                                   decoration: BoxDecoration(
-                                    color: _selectedIndex == 1 ? const Color(0xFF006590) : Colors.transparent,
+                                    color: _selectedIndex == 1 ? Theme.of(context).colorScheme.primary : Colors.transparent,
                                     borderRadius: BorderRadius.circular(25.0),
                                   ),
                                   child: Text(
@@ -156,7 +156,7 @@ class _ChatsScreenState extends State<ChatsScreen> with SingleTickerProviderStat
                                     textAlign: TextAlign.center,
                                     style: TextStyle(
                                       fontFamily: 'Montserrat',
-                                      color: _selectedIndex == 1 ? Colors.white : Colors.black,
+                                      color: _selectedIndex == 1 ? Theme.of(context).colorScheme.background : Theme.of(context).colorScheme.onBackground,
                                       fontSize: 15,
                                       fontWeight: FontWeight.w500,
                                     ),

--- a/lib/screens/bazaar/chats/selling/selling_chat_list_screen.dart
+++ b/lib/screens/bazaar/chats/selling/selling_chat_list_screen.dart
@@ -192,7 +192,7 @@ class SellingChatListScreenState extends State<SellingChatListScreen> with Autom
     _notificationService = Provider.of<ChatNotificationService>(context);
 
     return Material(
-      color: Colors.white,
+      color: Theme.of(context).colorScheme.background,
       child: RefreshIndicator(
         key: _refreshIndicatorKey,
         onRefresh: _refreshData,
@@ -210,7 +210,7 @@ class SellingChatListScreenState extends State<SellingChatListScreen> with Autom
             : ListView.builder(
                 controller: _scrollController,
                 itemCount: _chatList.length + (_isLoading && _hasMoreData ? 1 : 0),
-                padding: const EdgeInsets.all(16),
+                padding: EdgeInsets.all(16),
                 physics: const AlwaysScrollableScrollPhysics(),
                 scrollDirection: Axis.vertical,
                 itemBuilder: (context, index) {
@@ -242,7 +242,7 @@ class SellingChatListScreenState extends State<SellingChatListScreen> with Autom
     debugPrint('Chat item at index $index: isNewMsg=${chatItem.isNewMsg}');
 
     return Padding(
-      padding: const EdgeInsets.only(top: 8, bottom: 8),
+      padding: EdgeInsets.only(top: 8, bottom: 8),
       child: GestureDetector(
         onTap: () async {
           // Mark as read when opening the chat
@@ -302,7 +302,7 @@ class SellingChatListScreenState extends State<SellingChatListScreen> with Autom
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             Card(
-              color: Colors.white,
+              color: Theme.of(context).colorScheme.background,
               elevation: 0,
               shape: RoundedRectangleBorder(
                 borderRadius: BorderRadius.circular(10.0),
@@ -346,10 +346,10 @@ class SellingChatListScreenState extends State<SellingChatListScreen> with Autom
                 ),
               ),
             ),
-            const SizedBox(width: 8),
+            SizedBox(width: 8),
             Flexible(
               child: Padding(
-                padding: const EdgeInsets.fromLTRB(0, 8.0, 0, 0),
+                padding: EdgeInsets.fromLTRB(0, 8.0, 0, 0),
                 child: Column(
                   mainAxisAlignment: MainAxisAlignment.start,
                   crossAxisAlignment: CrossAxisAlignment.stretch,
@@ -373,7 +373,7 @@ class SellingChatListScreenState extends State<SellingChatListScreen> with Autom
                         ),
                       ],
                     ),
-                    const SizedBox(height: 8),
+                    SizedBox(height: 8),
                     CustomTextView(
                       label: chatItem.title,
                       maxLine: 2,
@@ -386,7 +386,7 @@ class SellingChatListScreenState extends State<SellingChatListScreen> with Autom
                             overflow: TextOverflow.ellipsis,
                           ),
                     ),
-                    const SizedBox(height: 4),
+                    SizedBox(height: 4),
                   ],
                 ),
               ),
@@ -396,7 +396,7 @@ class SellingChatListScreenState extends State<SellingChatListScreen> with Autom
               key: Key('notification_dot_${chatItem.equipmentChatId}_${chatItem.isNewMsg}'),
               visible: chatItem.isNewMsg ?? false,
               child: Padding(
-                padding: const EdgeInsets.fromLTRB(0, 22.0, 15.0, 0.0),
+                padding: EdgeInsets.fromLTRB(0, 22.0, 15.0, 0.0),
                 child: Container(
                   height: 10,
                   width: 10,

--- a/lib/screens/bazaar/chats/selling/selling_chat_screen.dart
+++ b/lib/screens/bazaar/chats/selling/selling_chat_screen.dart
@@ -14,7 +14,6 @@ import 'package:oqdo_mobile_app/screens/bazaar/chats/viewmodel/chat_view_model.d
 import 'package:oqdo_mobile_app/screens/bazaar/chats/views/close_deal_view.dart';
 import 'package:oqdo_mobile_app/screens/bazaar/chats/views/offer_price_bottom_sheet_view.dart';
 import 'package:oqdo_mobile_app/screens/bazaar/sell/models/sell_equipment_response_model.dart';
-import 'package:oqdo_mobile_app/theme/oqdo_theme_data.dart';
 import 'package:oqdo_mobile_app/utils/constants.dart';
 import 'package:oqdo_mobile_app/utils/network_interceptor.dart';
 import 'package:oqdo_mobile_app/utils/string_manager.dart';
@@ -150,9 +149,9 @@ class _SellingChatScreenState extends State<SellingChatScreen> {
           centerTitle: false,
           elevation: 0.0,
           leadingWidth: 0.0,
-          leading: const SizedBox(),
+          leading: SizedBox(),
           title: Container(
-            padding: const EdgeInsets.symmetric(vertical: 12, horizontal: 4), // Added padding
+            padding: EdgeInsets.symmetric(vertical: 12, horizontal: 4), // Added padding
             child: Column(
               mainAxisAlignment: MainAxisAlignment.start,
               crossAxisAlignment: CrossAxisAlignment.start,
@@ -167,11 +166,11 @@ class _SellingChatScreenState extends State<SellingChatScreen> {
                       },
                       child: Icon(
                         Icons.arrow_back,
-                        color: Colors.white,
+                        color: Theme.of(context).colorScheme.background,
                         size: 30,
                       ),
                     ),
-                    const SizedBox(width: 18),
+                    SizedBox(width: 18),
                     ClipPath(
                       clipper: ShapeBorderClipper(
                         shape: RoundedRectangleBorder(
@@ -190,13 +189,13 @@ class _SellingChatScreenState extends State<SellingChatScreen> {
                             fit: BoxFit.fill,
                           )),
                     ),
-                    const SizedBox(width: 12),
+                    SizedBox(width: 12),
                     Text(
                       widget.equipmentDetails.fullName,
                       maxLines: 1,
                       overflow: TextOverflow.ellipsis,
                       style: TextStyle(
-                        color: Colors.white,
+                        color: Theme.of(context).colorScheme.background,
                         fontSize: 18,
                         fontWeight: FontWeight.bold,
                         fontFamily: 'Montserrat',
@@ -204,7 +203,7 @@ class _SellingChatScreenState extends State<SellingChatScreen> {
                     ),
                   ],
                 ),
-                const SizedBox(height: 5),
+                SizedBox(height: 5),
                 Row(
                   mainAxisAlignment: MainAxisAlignment.spaceBetween,
                   children: [
@@ -214,18 +213,18 @@ class _SellingChatScreenState extends State<SellingChatScreen> {
                         overflow: TextOverflow.ellipsis,
                         widget.equipmentDetails.title,
                         style: TextStyle(
-                          color: Colors.white,
+                          color: Theme.of(context).colorScheme.background,
                           fontSize: 14,
                           fontWeight: FontWeight.w500,
                           fontFamily: 'Montserrat',
                         ),
                       ),
                     ),
-                    const SizedBox(width: 10),
+                    SizedBox(width: 10),
                     Text(
                       'S\$ ${widget.equipmentDetails.price.toStringAsFixed(2)}',
                       style: TextStyle(
-                        color: Colors.white,
+                        color: Theme.of(context).colorScheme.background,
                         fontSize: 18,
                         fontWeight: FontWeight.bold,
                         fontFamily: 'Montserrat',
@@ -236,7 +235,7 @@ class _SellingChatScreenState extends State<SellingChatScreen> {
               ],
             ),
           ),
-          backgroundColor: const Color(0xFF006590),
+          backgroundColor: Theme.of(context).colorScheme.primary,
         ),
         body: SafeArea(
           child: Column(
@@ -265,13 +264,13 @@ class _SellingChatScreenState extends State<SellingChatScreen> {
             Icon(
               Icons.chat_bubble_outline,
               size: 48,
-              color: const Color(0xFF006590),
+              color: Theme.of(context).colorScheme.primary,
             ),
-            const SizedBox(height: 16),
+            SizedBox(height: 16),
             Text(
               "Please send a message to start the chat",
               style: TextStyle(
-                color: Colors.black54,
+                color: Theme.of(context).colorScheme.onBackground.withOpacity(0.54),
                 fontSize: 16,
                 fontWeight: FontWeight.w500,
                 fontFamily: 'Montserrat',
@@ -284,7 +283,7 @@ class _SellingChatScreenState extends State<SellingChatScreen> {
       return ListView.builder(
         physics: BouncingScrollPhysics(),
         controller: _scrollController,
-        padding: const EdgeInsets.all(16),
+        padding: EdgeInsets.all(16),
         reverse: false,
         itemCount: chatMessageResponseModelList.isNotEmpty ? chatMessageResponseModelList.length : 0,
         itemBuilder: (context, index) {
@@ -323,20 +322,20 @@ class _SellingChatScreenState extends State<SellingChatScreen> {
         children: [
           Container(
             constraints: BoxConstraints(maxWidth: (MediaQuery.sizeOf(context).width / 1.4)),
-            margin: const EdgeInsets.only(bottom: 5),
+            margin: EdgeInsets.only(bottom: 5),
             padding: EdgeInsets.fromLTRB(16, 15, isOfferAcceptanceMessage! ? 16 : 32, 15),
             decoration: BoxDecoration(
               color: isOfferMessage!
-                  ? const Color(0xFF006590)
+                  ? Theme.of(context).colorScheme.primary
                   : (((!isSentByMe) && isOfferAcceptanceMessage))
-                      ? Colors.white
+                      ? Theme.of(context).colorScheme.background
                       : isSentByMe
                           ? const Color(0xFFC7DDE7)
-                          : Colors.white,
+                          : Theme.of(context).colorScheme.background,
               borderRadius: BorderRadius.circular(10),
               boxShadow: [
                 BoxShadow(
-                  color: Colors.black.withValues(alpha: 0.1),
+                  color: Theme.of(context).colorScheme.onBackground.withValues(alpha: 0.1),
                   blurRadius: 4,
                   offset: const Offset(0, 2),
                 ),
@@ -350,7 +349,7 @@ class _SellingChatScreenState extends State<SellingChatScreen> {
                         children: [
                           isSentByMe
                               ? Container(
-                                  color: Colors.white,
+                                  color: Theme.of(context).colorScheme.background,
                                   padding: EdgeInsets.all(10),
                                   child: Row(
                                     mainAxisAlignment: MainAxisAlignment.spaceBetween,
@@ -360,7 +359,7 @@ class _SellingChatScreenState extends State<SellingChatScreen> {
                                           maxLines: 2,
                                           "Offer: S\$ ${price.toStringAsFixed(2)}",
                                           style: TextStyle(
-                                            color: Colors.black,
+                                            color: Theme.of(context).colorScheme.onBackground,
                                             fontSize: 14,
                                             fontWeight: FontWeight.w400,
                                             fontFamily: 'Montserrat',
@@ -390,7 +389,7 @@ class _SellingChatScreenState extends State<SellingChatScreen> {
                                           maxLines: 2,
                                           "Offer: S\$ ${price.toStringAsFixed(2)}",
                                           style: TextStyle(
-                                            color: Colors.black,
+                                            color: Theme.of(context).colorScheme.onBackground,
                                             fontSize: 14,
                                             fontWeight: FontWeight.w400,
                                             fontFamily: 'Montserrat',
@@ -409,11 +408,11 @@ class _SellingChatScreenState extends State<SellingChatScreen> {
                                     ],
                                   ),
                                 ),
-                          const SizedBox(height: 15),
+                          SizedBox(height: 15),
                           Text(
                             message,
                             style: TextStyle(
-                              color: Colors.black,
+                              color: Theme.of(context).colorScheme.onBackground,
                               fontSize: 18,
                               fontWeight: FontWeight.w400,
                               fontFamily: 'Montserrat',
@@ -428,17 +427,17 @@ class _SellingChatScreenState extends State<SellingChatScreen> {
                               Text(
                                 "${isSentByMe ? "YOUR" : "BUYER'S"} OFFER",
                                 style: TextStyle(
-                                  color: Colors.white,
+                                  color: Theme.of(context).colorScheme.background,
                                   fontSize: 14,
                                   fontWeight: FontWeight.w600,
                                   fontFamily: 'Montserrat',
                                 ),
                               ),
-                              const SizedBox(height: 10),
+                              SizedBox(height: 10),
                               Text(
                                 'S\$ $message',
                                 style: TextStyle(
-                                  color: Colors.white,
+                                  color: Theme.of(context).colorScheme.background,
                                   fontSize: 18,
                                   fontWeight: FontWeight.w800,
                                   fontFamily: 'Montserrat',
@@ -449,7 +448,7 @@ class _SellingChatScreenState extends State<SellingChatScreen> {
                         : Text(
                             message,
                             style: TextStyle(
-                              color: Colors.black,
+                              color: Theme.of(context).colorScheme.onBackground,
                               fontSize: 16,
                               fontWeight: FontWeight.w400,
                               fontFamily: 'Montserrat',
@@ -461,11 +460,11 @@ class _SellingChatScreenState extends State<SellingChatScreen> {
           Text(
             time,
             style: TextStyle(
-              color: Colors.black,
+              color: Theme.of(context).colorScheme.onBackground,
               fontSize: 12,
             ),
           ),
-          const SizedBox(height: 5),
+          SizedBox(height: 5),
         ],
       ),
     );
@@ -473,7 +472,7 @@ class _SellingChatScreenState extends State<SellingChatScreen> {
 
   Widget _buildBottomSection(bool isKeyboardVisible) {
     return Padding(
-      padding: const EdgeInsets.symmetric(vertical: 10),
+      padding: EdgeInsets.symmetric(vertical: 10),
       child: Column(
         children: [
           showCloseDealView
@@ -486,21 +485,21 @@ class _SellingChatScreenState extends State<SellingChatScreen> {
                   mainAxisAlignment: MainAxisAlignment.center,
                   children: [
                     isKeyboardVisible
-                        ? const SizedBox(
+                        ? SizedBox(
                             width: 18,
                           )
                         : Padding(
-                            padding: const EdgeInsets.symmetric(horizontal: 18),
+                            padding: EdgeInsets.symmetric(horizontal: 18),
                             child: Container(
                               decoration: BoxDecoration(
-                                color: Color(0xFF006590),
+                                color: Theme.of(context).colorScheme.primary,
                                 shape: BoxShape.circle,
                               ),
                               child: Theme(
                                 data: Theme.of(context).copyWith(
-                                  cardColor: Color(0xFF006590),
+                                  cardColor: Theme.of(context).colorScheme.primary,
                                   dividerTheme: DividerThemeData(
-                                    color: Colors.white,
+                                    color: Theme.of(context).colorScheme.background,
                                   ),
                                 ),
                                 child: PopupMenuButton<String>(
@@ -509,7 +508,7 @@ class _SellingChatScreenState extends State<SellingChatScreen> {
                                   // popUpAnimationStyle: AnimationStyle.noAnimation,
                                   popUpAnimationStyle: AnimationStyle.noAnimation,
                                   menuPadding: EdgeInsets.zero,
-                                  icon: const Icon(Icons.more_vert, color: Colors.white),
+                                  icon:  Icon(Icons.more_vert, color: Theme.of(context).colorScheme.background),
                                   shape: RoundedRectangleBorder(
                                     borderRadius: BorderRadius.all(
                                       Radius.circular(5.0),
@@ -526,7 +525,7 @@ class _SellingChatScreenState extends State<SellingChatScreen> {
                                         'Offer Price',
                                         textAlign: TextAlign.start,
                                         style: TextStyle(
-                                          color: Colors.white,
+                                          color: Theme.of(context).colorScheme.background,
                                           fontSize: 16,
                                           fontWeight: FontWeight.w600,
                                           fontFamily: 'Montserrat',
@@ -553,7 +552,7 @@ class _SellingChatScreenState extends State<SellingChatScreen> {
                                                 text: TextSpan(
                                                     text: 'Ok, Done |',
                                                     style: TextStyle(
-                                                      color: Colors.white,
+                                                      color: Theme.of(context).colorScheme.background,
                                                       fontSize: 16,
                                                       fontWeight: FontWeight.w400,
                                                       fontFamily: 'Montserrat',
@@ -562,7 +561,7 @@ class _SellingChatScreenState extends State<SellingChatScreen> {
                                                       TextSpan(
                                                         text: ' S\$ ${price.toStringAsFixed(2)}',
                                                         style: TextStyle(
-                                                          color: Colors.white,
+                                                          color: Theme.of(context).colorScheme.background,
                                                           fontSize: 16,
                                                           fontWeight: FontWeight.w800,
                                                           fontFamily: 'Montserrat',
@@ -574,7 +573,7 @@ class _SellingChatScreenState extends State<SellingChatScreen> {
                                           : Text(
                                               'Ok, Done',
                                               style: TextStyle(
-                                                color: Colors.white,
+                                                color: Theme.of(context).colorScheme.background,
                                                 fontSize: 16,
                                                 fontWeight: FontWeight.w600,
                                                 fontFamily: 'Montserrat',
@@ -591,7 +590,7 @@ class _SellingChatScreenState extends State<SellingChatScreen> {
                                         'Close the Deal',
                                         textAlign: TextAlign.start,
                                         style: TextStyle(
-                                          color: Colors.white,
+                                          color: Theme.of(context).colorScheme.background,
                                           fontSize: 16,
                                           fontWeight: FontWeight.w600,
                                           fontFamily: 'Montserrat',
@@ -640,7 +639,7 @@ class _SellingChatScreenState extends State<SellingChatScreen> {
                                 }
                               },
                               child: Padding(
-                                padding: const EdgeInsets.symmetric(horizontal: 15),
+                                padding: EdgeInsets.symmetric(horizontal: 15),
                                 child: Image.asset(
                                   "assets/images/ic_send.png",
                                   height: 22,
@@ -652,7 +651,7 @@ class _SellingChatScreenState extends State<SellingChatScreen> {
                         ),
                       ),
                     ),
-                    const SizedBox(width: 18),
+                    SizedBox(width: 18),
                   ],
                 ),
         ],
@@ -667,7 +666,7 @@ class _SellingChatScreenState extends State<SellingChatScreen> {
         enableDrag: true,
         isScrollControlled: true,
         showDragHandle: true,
-        backgroundColor: OQDOThemeData.whiteColor,
+        backgroundColor: Theme.of(context).colorScheme.background,
         builder: (context) => OfferPriceBottomSheetView(
               title: 'Offer Price',
               offerPriceController: offerPriceController,
@@ -1192,10 +1191,10 @@ class _SellingChatScreenState extends State<SellingChatScreen> {
                   ],
                 ),
               ),
-              const SizedBox(height: 8),
+              SizedBox(height: 8),
               const Divider(
                 height: 4,
-                color: Colors.black,
+                color: Theme.of(context).colorScheme.onBackground,
               ),
               IntrinsicHeight(
                 child: Row(
@@ -1203,8 +1202,8 @@ class _SellingChatScreenState extends State<SellingChatScreen> {
                     Expanded(
                       child: TextButton(
                         style: TextButton.styleFrom(
-                          foregroundColor: Colors.white,
-                          backgroundColor: Color(0xFF006590),
+                          foregroundColor: Theme.of(context).colorScheme.background,
+                          backgroundColor: Theme.of(context).colorScheme.primary,
                           padding: EdgeInsets.symmetric(vertical: 16),
                           shape: RoundedRectangleBorder(
                             borderRadius: BorderRadius.only(
@@ -1216,14 +1215,14 @@ class _SellingChatScreenState extends State<SellingChatScreen> {
                           Navigator.of(context).pop();
                           closeDeal();
                         },
-                        child: const Text('Yes'),
+                        child:  Text('Yes'),
                       ),
                     ),
                     const VerticalDivider(width: 1),
                     Expanded(
                       child: TextButton(
                         style: TextButton.styleFrom(
-                          foregroundColor: Colors.black87,
+                          foregroundColor: Theme.of(context).colorScheme.onBackground.withOpacity(0.87),
                           padding: EdgeInsets.symmetric(vertical: 16),
                           shape: RoundedRectangleBorder(
                             borderRadius: BorderRadius.only(
@@ -1232,7 +1231,7 @@ class _SellingChatScreenState extends State<SellingChatScreen> {
                           ),
                         ),
                         onPressed: () => Navigator.of(context).pop(false),
-                        child: const Text('No'),
+                        child:  Text('No'),
                       ),
                     ),
                   ],
@@ -1286,7 +1285,7 @@ class _SellingChatScreenState extends State<SellingChatScreen> {
           content: Text('Chat timed out. Relaunch from list.'),
           actions: <Widget>[
             TextButton(
-              child: const Text('Okay'),
+              child:  Text('Okay'),
               onPressed: () {
                 Navigator.pop(context, true);
                 Navigator.pop(context, true);

--- a/lib/screens/bazaar/chats/views/close_deal_view.dart
+++ b/lib/screens/bazaar/chats/views/close_deal_view.dart
@@ -12,11 +12,11 @@ class DisabledAdNotification extends StatelessWidget {
   Widget build(BuildContext context) {
     return Container(
       width: double.infinity,
-      padding: const EdgeInsets.symmetric(vertical: 10.0, horizontal: 10.0),
+      padding: EdgeInsets.symmetric(vertical: 10.0, horizontal: 10.0),
       decoration: BoxDecoration(
-        color: const Color(0xFF006590), // Blue background color
+        color: Theme.of(context).colorScheme.primary, // Blue background color
         border: Border.all(
-          color: Colors.grey.shade300,
+          color: Theme.of(context).colorScheme.outline,
           width: 1.0,
         ),
       ),
@@ -24,12 +24,12 @@ class DisabledAdNotification extends StatelessWidget {
         children: [
           Expanded(
             child: Container(
-              padding: const EdgeInsets.symmetric(vertical: 8.0, horizontal: 4.0),
+              padding: EdgeInsets.symmetric(vertical: 8.0, horizontal: 4.0),
               
-              child: const Text(
+              child:  Text(
                 'This ad has been disabled by the seller',
                 style: TextStyle(
-                  color: Colors.white,
+                  color: Theme.of(context).colorScheme.background,
                   fontSize: 16,
                   fontFamily: 'SFPro',
                   fontWeight: FontWeight.w400,
@@ -38,19 +38,19 @@ class DisabledAdNotification extends StatelessWidget {
               ),
             ),
           ),
-          const SizedBox(width: 16.0),
+          SizedBox(width: 16.0),
           TextButton(
             onPressed: onDelete,
             style: TextButton.styleFrom(
-              padding: const EdgeInsets.symmetric(
+              padding: EdgeInsets.symmetric(
                 horizontal: 16.0,
                 vertical: 8.0,
               ),
             ),
-            child: const Text(
+            child:  Text(
               'Delete',
               style: TextStyle(
-                color: Colors.white,
+                color: Theme.of(context).colorScheme.background,
                 fontSize: 16,
                 fontFamily: 'SFPro',
                 fontWeight: FontWeight.w600,

--- a/lib/screens/bazaar/chats/views/offer_price_bottom_sheet_view.dart
+++ b/lib/screens/bazaar/chats/views/offer_price_bottom_sheet_view.dart
@@ -3,7 +3,6 @@ import 'dart:ffi';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
-import 'package:oqdo_mobile_app/theme/oqdo_theme_data.dart';
 import 'package:oqdo_mobile_app/utils/constants.dart';
 import 'package:oqdo_mobile_app/utils/custom_text_view.dart';
 
@@ -44,22 +43,22 @@ class _OfferPriceBottomSheetViewState extends State<OfferPriceBottomSheetView> {
         mainAxisSize: MainAxisSize.min,
         children: [
           Padding(
-            padding: const EdgeInsets.symmetric(horizontal: 20.0),
+            padding: EdgeInsets.symmetric(horizontal: 20.0),
             child: CustomTextView(
               label: widget.title,
-              textStyle: Theme.of(context).textTheme.titleLarge!.copyWith(fontWeight: FontWeight.bold, fontSize: 18, color: OQDOThemeData.greyColor),
+              textStyle: Theme.of(context).textTheme.titleLarge!.copyWith(fontWeight: FontWeight.bold, fontSize: 18, color: Theme.of(context).colorScheme.onSurface),
             ),
           ),
-          const SizedBox(height: 15),
+          SizedBox(height: 15),
           Divider(
             thickness: 2,
             color: Color(0xFFD0D0D0),
           ),
-          const SizedBox(
+          SizedBox(
             height: 10,
           ),
           Padding(
-            padding: const EdgeInsets.symmetric(horizontal: 20),
+            padding: EdgeInsets.symmetric(horizontal: 20),
             child: Row(
               mainAxisAlignment: MainAxisAlignment.spaceBetween,
               children: [
@@ -72,10 +71,10 @@ class _OfferPriceBottomSheetViewState extends State<OfferPriceBottomSheetView> {
                       textStyle: Theme.of(context).textTheme.titleLarge!.copyWith(
                             fontSize: 30.0,
                             fontWeight: FontWeight.w400,
-                            color: OQDOThemeData.blackColor,
+                            color: Theme.of(context).colorScheme.onBackground,
                           ),
                     ),
-                    const SizedBox(width: 3),
+                    SizedBox(width: 3),
                     ConstrainedBox(
                       constraints: BoxConstraints(maxWidth: MediaQuery.sizeOf(context).width / 2),
                       child: IntrinsicWidth(
@@ -93,13 +92,13 @@ class _OfferPriceBottomSheetViewState extends State<OfferPriceBottomSheetView> {
                             hintStyle: Theme.of(context).textTheme.titleLarge!.copyWith(
                                   fontSize: 30.0,
                                   fontWeight: FontWeight.w400,
-                                  color: OQDOThemeData.filterDividerColor,
+                                  color: Theme.of(context).colorScheme.outline,
                                 ),
                           ),
                           style: Theme.of(context).textTheme.titleLarge!.copyWith(
                                 fontSize: 30.0,
                                 fontWeight: FontWeight.w400,
-                                color: OQDOThemeData.blackColor,
+                                color: Theme.of(context).colorScheme.onBackground,
                               ),
                         ),
                       ),
@@ -110,7 +109,7 @@ class _OfferPriceBottomSheetViewState extends State<OfferPriceBottomSheetView> {
                   color: Theme.of(context).colorScheme.primary,
                   child: CustomTextView(
                     label: 'Send',
-                    textStyle: Theme.of(context).textTheme.titleLarge!.copyWith(fontWeight: FontWeight.bold, fontSize: 18, color: OQDOThemeData.whiteColor),
+                    textStyle: Theme.of(context).textTheme.titleLarge!.copyWith(fontWeight: FontWeight.bold, fontSize: 18, color: Theme.of(context).colorScheme.background),
                   ),
                   onPressed: () {
                     if (widget.offerPriceController.text.isEmpty || double.parse(widget.offerPriceController.text) <= 0) {
@@ -125,7 +124,7 @@ class _OfferPriceBottomSheetViewState extends State<OfferPriceBottomSheetView> {
               ],
             ),
           ),
-          const SizedBox(
+          SizedBox(
             height: 20,
           ),
         ],

--- a/lib/screens/bazaar/sell/product/create_product_screen.dart
+++ b/lib/screens/bazaar/sell/product/create_product_screen.dart
@@ -13,7 +13,6 @@ import 'package:oqdo_mobile_app/screens/bazaar/sell/models/sell_equipment_respon
 import 'package:oqdo_mobile_app/screens/bazaar/sell/product/sell_product_detail_screen.dart';
 import 'package:oqdo_mobile_app/screens/bazaar/sell/viewmodel/sell_viewmodel.dart';
 import 'package:oqdo_mobile_app/screens/common_widget/view_image_screen.dart';
-import 'package:oqdo_mobile_app/theme/oqdo_theme_data.dart';
 import 'package:oqdo_mobile_app/utils/constants.dart';
 import 'package:oqdo_mobile_app/utils/custom_text_view.dart';
 import 'package:oqdo_mobile_app/utils/network_interceptor.dart';
@@ -117,28 +116,28 @@ class _CreateProductScreenState extends State<CreateProductScreen> {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        backgroundColor: Color(0xFF006590),
+        backgroundColor: Theme.of(context).colorScheme.primary,
         leading: IconButton(
           onPressed: () {
             Navigator.pop(context);
           },
-          icon: Icon(Icons.arrow_back, color: Colors.white),
+          icon: Icon(Icons.arrow_back, color: Theme.of(context).colorScheme.background),
         ),
         title: Text(
           'Used For',
-          style: Theme.of(context).textTheme.titleMedium!.copyWith(color: Colors.white, fontWeight: FontWeight.w600, fontSize: 20.0),
+          style: Theme.of(context).textTheme.titleMedium!.copyWith(color: Theme.of(context).colorScheme.background, fontWeight: FontWeight.w600, fontSize: 20.0),
         ),
       ),
       body: Container(
-        color: Colors.white,
+        color: Theme.of(context).colorScheme.background,
         child: SingleChildScrollView(
-          padding: const EdgeInsets.all(16),
+          padding: EdgeInsets.all(16),
           child: Form(
             key: _formKey,
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
-                const Text(
+                 Text(
                   'Category',
                   style: TextStyle(
                     fontSize: 16,
@@ -147,7 +146,7 @@ class _CreateProductScreenState extends State<CreateProductScreen> {
                     fontWeight: FontWeight.w600,
                   ),
                 ),
-                const SizedBox(height: 8),
+                SizedBox(height: 8),
                 Text(
                   widget.editViewEquipmentIntentModel.sellEquipmentResponseModel!.sellEquipmentCategory.name,
                   style: TextStyle(
@@ -157,8 +156,8 @@ class _CreateProductScreenState extends State<CreateProductScreen> {
                     color: Color(0xFF2B2B2B),
                   ),
                 ),
-                const SizedBox(height: 16),
-                const Text(
+                SizedBox(height: 16),
+                 Text(
                   'Used For',
                   style: TextStyle(
                     fontSize: 16,
@@ -167,24 +166,24 @@ class _CreateProductScreenState extends State<CreateProductScreen> {
                     fontWeight: FontWeight.w600,
                   ),
                 ),
-                const SizedBox(height: 8),
+                SizedBox(height: 8),
                 // Updated Activity Selection Section with FilterChips
                 Padding(
-                  padding: const EdgeInsets.only(top: 10.0),
+                  padding: EdgeInsets.only(top: 10.0),
                   child: Wrap(
                     spacing: 8.0,
                     runSpacing: 8.0,
                     children: widget.editViewEquipmentIntentModel.sellEquipmentResponseModel!.equipmentSubActivities.map((activity) {
                       return Container(
                         decoration: BoxDecoration(
-                          color: const Color(0xFFF1F5F9), // Light blue-grey background
+                          color: Theme.of(context).colorScheme.surfaceVariant, // Light blue-grey background
                           borderRadius: BorderRadius.circular(20),
                         ),
                         child: Padding(
-                          padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+                          padding: EdgeInsets.symmetric(horizontal: 12, vertical: 6),
                           child: Text(
                             activity.name,
-                            style: const TextStyle(
+                            style: TextStyle(
                               color: Color(0xFF475569), // Dark blue-grey text
                               fontSize: 14,
                               fontWeight: FontWeight.w500,
@@ -196,14 +195,14 @@ class _CreateProductScreenState extends State<CreateProductScreen> {
                     }).toList(),
                   ),
                 ),
-                const SizedBox(height: 24),
+                SizedBox(height: 24),
                 // Rest of the form fields...
                 _buildProductDetailsSection(),
-                const SizedBox(height: 24),
+                SizedBox(height: 24),
                 _buildImageUploadSection(),
-                const SizedBox(height: 16),
+                SizedBox(height: 16),
                 _buildTermsAndConditions(),
-                const SizedBox(height: 24),
+                SizedBox(height: 24),
                 _buildNextButton(),
               ],
             ),
@@ -217,16 +216,16 @@ class _CreateProductScreenState extends State<CreateProductScreen> {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        const Text(
+         Text(
           'Product Details',
           style: TextStyle(
             fontSize: 18,
-            color: Colors.black,
+            color: Theme.of(context).colorScheme.onBackground,
             fontFamily: 'SFPro',
             fontWeight: FontWeight.w400,
           ),
         ),
-        const SizedBox(height: 16),
+        SizedBox(height: 16),
         CustomTextFormField(
           labelText: 'Title',
           obscureText: false,
@@ -240,7 +239,7 @@ class _CreateProductScreenState extends State<CreateProductScreen> {
           validator: (value) => validateRequired(value, 'Title'),
           hintText: 'Enter Title',
         ),
-        const SizedBox(height: 16),
+        SizedBox(height: 16),
         CustomTextFormField(
           labelText: 'Brand',
           obscureText: false,
@@ -254,7 +253,7 @@ class _CreateProductScreenState extends State<CreateProductScreen> {
           validator: (value) => validateRequired(value, 'Brand'),
           hintText: 'Enter Brand Name',
         ),
-        const SizedBox(height: 16),
+        SizedBox(height: 16),
         CustomTextFormField(
           labelText: 'Description',
           obscureText: false,
@@ -266,7 +265,7 @@ class _CreateProductScreenState extends State<CreateProductScreen> {
           hintText: 'Enter Description',
           validator: (value) => validateRequired(value, 'Description'),
         ),
-        const SizedBox(height: 16),
+        SizedBox(height: 16),
         CustomTextFormField(
           labelText: 'Price',
           obscureText: false,
@@ -299,7 +298,7 @@ class _CreateProductScreenState extends State<CreateProductScreen> {
           hintText: 'Enter Price',
           validator: (value) => validatePrice(value),
         ),
-        const SizedBox(height: 25),
+        SizedBox(height: 25),
         _buildDropdownField(selectedCondition),
       ],
     );
@@ -340,7 +339,7 @@ class _CreateProductScreenState extends State<CreateProductScreen> {
               label: 'I have read and accept the terms & conditions',
               textStyle: Theme.of(context).textTheme.bodyLarge!.copyWith(
                     fontFamily: 'Montserrat',
-                    color: Color(0xFF006590),
+                    color: Theme.of(context).colorScheme.primary,
                     fontSize: 16.0,
                     fontWeight: FontWeight.w600,
                     decoration: TextDecoration.underline,
@@ -362,18 +361,18 @@ class _CreateProductScreenState extends State<CreateProductScreen> {
           }
         },
         style: ElevatedButton.styleFrom(
-          backgroundColor: const Color(0xFF006590),
+          backgroundColor: Theme.of(context).colorScheme.primary,
           minimumSize: const Size(double.infinity, 48),
           shape: RoundedRectangleBorder(
             borderRadius: BorderRadius.circular(8),
           ),
           elevation: 0,
-          padding: const EdgeInsets.symmetric(vertical: 14),
+          padding: EdgeInsets.symmetric(vertical: 14),
         ),
-        child: const Text(
+        child:  Text(
           'Next',
           style: TextStyle(
-            color: Colors.white,
+            color: Theme.of(context).colorScheme.background,
             fontSize: 16,
             fontFamily: 'SFPro',
             fontWeight: FontWeight.w500,
@@ -399,8 +398,8 @@ class _CreateProductScreenState extends State<CreateProductScreen> {
             content: CustomTextView(
                 label: entry.key,
                 maxLine: 5,
-                textStyle: Theme.of(context).textTheme.titleLarge!.copyWith(color: OQDOThemeData.whiteColor, fontSize: 16.0, fontWeight: FontWeight.w500)),
-            backgroundColor: OQDOThemeData.blackColor,
+                textStyle: Theme.of(context).textTheme.titleLarge!.copyWith(color: Theme.of(context).colorScheme.background, fontSize: 16.0, fontWeight: FontWeight.w500)),
+            backgroundColor: Theme.of(context).colorScheme.onBackground,
             behavior: SnackBarBehavior.floating);
 
         rootScaffoldMessangerKey.currentState?.removeCurrentSnackBar();
@@ -467,27 +466,27 @@ class _CreateProductScreenState extends State<CreateProductScreen> {
   /// [hint] - Placeholder text when no value selected
   Widget _buildDropdownField(EquipmentCondition condition) {
     return Padding(
-      padding: const EdgeInsets.only(bottom: 16),
+      padding: EdgeInsets.only(bottom: 16),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           Text(
             'Condition',
-            style: const TextStyle(
+            style: TextStyle(
               fontSize: 14,
-              color: Colors.black54,
+              color: Theme.of(context).colorScheme.onBackground.withOpacity(0.54),
             ),
           ),
-          const SizedBox(height: 8),
+          SizedBox(height: 8),
           InkWell(
             onTap: () {
               _showConditionBottomSheet();
               // The selected value will automatically update through setState in _buildConditionOption
             },
             child: Container(
-              padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+              padding: EdgeInsets.symmetric(horizontal: 16, vertical: 12),
               decoration: BoxDecoration(
-                border: Border.all(color: Color(0xFF006590)),
+                border: Border.all(color: Theme.of(context).colorScheme.primary),
                 borderRadius: BorderRadius.circular(8),
               ),
               child: Row(
@@ -496,10 +495,10 @@ class _CreateProductScreenState extends State<CreateProductScreen> {
                   Text(
                     selectedCondition.name.isNotEmpty ? selectedCondition.name : 'Select Condition',
                     style: TextStyle(
-                      color: selectedCondition.name.isEmpty ? Colors.grey[600] : Colors.black,
+                      color: selectedCondition.name.isEmpty ? Theme.of(context).colorScheme.onSurface.withOpacity(0.6) : Theme.of(context).colorScheme.onBackground,
                     ),
                   ),
-                  const Icon(Icons.keyboard_arrow_down, color: Color(0xFF006590)),
+                   Icon(Icons.keyboard_arrow_down, color: Theme.of(context).colorScheme.primary),
                 ],
               ),
             ),
@@ -514,7 +513,7 @@ class _CreateProductScreenState extends State<CreateProductScreen> {
   void _showConditionBottomSheet() {
     showModalBottomSheet(
       context: context,
-      backgroundColor: Colors.white,
+      backgroundColor: Theme.of(context).colorScheme.background,
       shape: const RoundedRectangleBorder(
         borderRadius: BorderRadius.vertical(top: Radius.circular(16)),
       ),
@@ -527,9 +526,9 @@ class _CreateProductScreenState extends State<CreateProductScreen> {
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
                 Padding(
-                  padding: const EdgeInsets.only(top: 10, left: 10, right: 10),
+                  padding: EdgeInsets.only(top: 10, left: 10, right: 10),
                   child: Container(
-                    padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+                    padding: EdgeInsets.symmetric(horizontal: 16, vertical: 12),
                     child: Stack(
                       children: [
                         Align(
@@ -537,7 +536,7 @@ class _CreateProductScreenState extends State<CreateProductScreen> {
                           child: IconButton(
                             padding: EdgeInsets.zero,
                             constraints: const BoxConstraints(),
-                            icon: const Icon(Icons.close),
+                            icon:  Icon(Icons.close),
                             onPressed: () => Navigator.pop(context),
                           ),
                         ),
@@ -564,7 +563,7 @@ class _CreateProductScreenState extends State<CreateProductScreen> {
                     },
                   ),
                 ),
-                const SizedBox(height: 16),
+                SizedBox(height: 16),
               ],
             );
           },
@@ -586,7 +585,7 @@ class _CreateProductScreenState extends State<CreateProductScreen> {
         Navigator.pop(context);
       },
       child: Padding(
-        padding: const EdgeInsets.symmetric(horizontal: 15, vertical: 10),
+        padding: EdgeInsets.symmetric(horizontal: 15, vertical: 10),
         child: Column(
           children: [
             Row(
@@ -598,20 +597,20 @@ class _CreateProductScreenState extends State<CreateProductScreen> {
                     children: [
                       Text(
                         condition.name,
-                        style: const TextStyle(
+                        style: TextStyle(
                           fontSize: 15,
                           fontFamily: 'Montserrat',
                           fontWeight: FontWeight.w600,
-                          color: Colors.black,
+                          color: Theme.of(context).colorScheme.onBackground,
                         ),
                       ),
-                      const SizedBox(height: 10),
+                      SizedBox(height: 10),
                       Text(
                         condition.description,
-                        style: const TextStyle(
+                        style: TextStyle(
                           fontSize: 13,
                           fontFamily: 'Montserrat',
-                          color: Colors.black,
+                          color: Theme.of(context).colorScheme.onBackground,
                           fontWeight: FontWeight.w400,
                           height: 1.2,
                         ),
@@ -628,8 +627,8 @@ class _CreateProductScreenState extends State<CreateProductScreen> {
                       shape: BoxShape.circle,
                       border: Border.all(
                         color: selectedCondition.name == condition.name
-                            ? const Color(0xFF006590) // Blue border when selected
-                            : const Color(0xFFB7B7B7), // Light gray border when unselected
+                            ? Theme.of(context).colorScheme.primary // Blue border when selected
+                            : Theme.of(context).colorScheme.outline, // Light gray border when unselected
                         width: 1.5,
                       ),
                     ),
@@ -638,17 +637,17 @@ class _CreateProductScreenState extends State<CreateProductScreen> {
                             child: Container(
                               width: 12,
                               height: 12,
-                              decoration: const BoxDecoration(
+                              decoration: BoxDecoration(
                                 shape: BoxShape.circle,
-                                color: Color(0xFF006590),
+                                color: Theme.of(context).colorScheme.primary,
                               ),
                               child: Center(
                                 child: Container(
                                   width: 0,
                                   height: 4,
-                                  decoration: const BoxDecoration(
+                                  decoration: BoxDecoration(
                                     shape: BoxShape.circle,
-                                    color: Colors.white,
+                                    color: Theme.of(context).colorScheme.background,
                                   ),
                                 ),
                               ),
@@ -659,10 +658,10 @@ class _CreateProductScreenState extends State<CreateProductScreen> {
                 )
               ],
             ),
-            const SizedBox(height: 10),
+            SizedBox(height: 10),
             Divider(
               height: 3,
-              color: Colors.black,
+              color: Theme.of(context).colorScheme.onBackground,
             ),
           ],
         ),
@@ -681,7 +680,7 @@ class _CreateProductScreenState extends State<CreateProductScreen> {
             textStyle: Theme.of(context).textTheme.bodyLarge!.copyWith(color: const Color(0xFF818181)),
           ),
         ),
-        const SizedBox(height: 8),
+        SizedBox(height: 8),
         Row(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
@@ -699,7 +698,7 @@ class _CreateProductScreenState extends State<CreateProductScreen> {
                 backgroundImage: AssetImage("assets/images/camera.png"),
               ),
             ),
-            const SizedBox(width: 10.0),
+            SizedBox(width: 10.0),
             certificateList.isNotEmpty
                 ? Expanded(
                     child: GridView.builder(
@@ -733,7 +732,7 @@ class _CreateProductScreenState extends State<CreateProductScreen> {
                               Container(
                                 decoration: BoxDecoration(
                                   borderRadius: BorderRadius.circular(8),
-                                  border: isMainImage ? Border.all(color: const Color(0xFF006590), width: 2) : null,
+                                  border: isMainImage ? Border.all(color: Theme.of(context).colorScheme.primary, width: 2) : null,
                                 ),
                                 child: ClipRRect(
                                   borderRadius: BorderRadius.circular(isMainImage ? 6 : 8),
@@ -767,15 +766,15 @@ class _CreateProductScreenState extends State<CreateProductScreen> {
                                   top: 4,
                                   left: 4,
                                   child: Container(
-                                    padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 2),
+                                    padding: EdgeInsets.symmetric(horizontal: 4, vertical: 2),
                                     decoration: BoxDecoration(
-                                      color: const Color(0xFF006590),
+                                      color: Theme.of(context).colorScheme.primary,
                                       borderRadius: BorderRadius.circular(2),
                                     ),
-                                    child: const Text(
+                                    child:  Text(
                                       'MAIN',
                                       style: TextStyle(
-                                        color: Colors.white,
+                                        color: Theme.of(context).colorScheme.background,
                                         fontSize: 8,
                                         fontWeight: FontWeight.bold,
                                       ),
@@ -831,12 +830,12 @@ class _CreateProductScreenState extends State<CreateProductScreen> {
                                     });
                                   },
                                   child: Container(
-                                    padding: const EdgeInsets.all(3),
+                                    padding: EdgeInsets.all(3),
                                     decoration: BoxDecoration(
-                                      color: Colors.white.withOpacity(0.7),
+                                      color: Theme.of(context).colorScheme.background.withOpacity(0.7),
                                       shape: BoxShape.circle,
                                     ),
-                                    child: const Icon(Icons.close, size: 14, color: Colors.black),
+                                    child:  Icon(Icons.close, size: 14, color: Theme.of(context).colorScheme.onBackground),
                                   ),
                                 ),
                               ),
@@ -846,7 +845,7 @@ class _CreateProductScreenState extends State<CreateProductScreen> {
                       },
                     ),
                   )
-                : const SizedBox(),
+                : SizedBox(),
           ],
         ),
       ],
@@ -885,7 +884,7 @@ class _CreateProductScreenState extends State<CreateProductScreen> {
   //               backgroundImage: AssetImage("assets/images/camera.png"),
   //             ),
   //           ),
-  //           const SizedBox(
+  //           SizedBox(
   //             width: 10.0,
   //           ),
   //           certificateList.isNotEmpty
@@ -915,7 +914,7 @@ class _CreateProductScreenState extends State<CreateProductScreen> {
   //                           child: Row(
   //                             children: [
   //                               IconButton(
-  //                                 icon: const Icon(Icons.close),
+  //                                 icon:  Icon(Icons.close),
   //                                 onPressed: () {
   //                                   certificateList.removeAt(index);
   //                                   certificateUploadId!.removeAt(index);
@@ -942,7 +941,7 @@ class _CreateProductScreenState extends State<CreateProductScreen> {
   //                                   errorBuilder: (context, error, trace) {
   //                                     return ClipRRect(
   //                                       borderRadius: BorderRadius.circular(10.0),
-  //                                       child: const SizedBox(
+  //                                       child: SizedBox(
   //                                         height: 70,
   //                                         width: 70,
   //                                         child: Icon(Icons.image_not_supported_outlined, size: 70),
@@ -956,7 +955,7 @@ class _CreateProductScreenState extends State<CreateProductScreen> {
   //                         );
   //                       }),
   //                 )
-  //               : const SizedBox(),
+  //               : SizedBox(),
   //         ],
   //       ),
   //     ],
@@ -1017,8 +1016,8 @@ class _CreateProductScreenState extends State<CreateProductScreen> {
             child: Wrap(
               children: <Widget>[
                 ListTile(
-                    leading: const Icon(Icons.photo_library),
-                    title: const Text(
+                    leading:  Icon(Icons.photo_library),
+                    title:  Text(
                       'Photo Library',
                       style: TextStyle(
                           // fontFamily: 'Fingbanger',
@@ -1047,8 +1046,8 @@ class _CreateProductScreenState extends State<CreateProductScreen> {
                       }
                     }),
                 ListTile(
-                    leading: const Icon(Icons.photo_camera),
-                    title: const Text(
+                    leading:  Icon(Icons.photo_camera),
+                    title:  Text(
                       'Camera',
                       style: TextStyle(
                           // fontFamily: 'Fingbanger',
@@ -1135,8 +1134,8 @@ class _CreateProductScreenState extends State<CreateProductScreen> {
     var mCroppedFile = await ImageCropper().cropImage(sourcePath: pickedFile.path, compressFormat: ImageCompressFormat.jpg, compressQuality: 100, uiSettings: [
       AndroidUiSettings(
           toolbarTitle: 'Cropper',
-          toolbarColor: OQDOThemeData.buttonColor,
-          toolbarWidgetColor: Colors.white,
+          toolbarColor: Theme.of(context).colorScheme.primary,
+          toolbarWidgetColor: Theme.of(context).colorScheme.background,
           initAspectRatio: CropAspectRatioPreset.square,
           lockAspectRatio: false),
       IOSUiSettings(
@@ -1505,7 +1504,7 @@ class _CreateProductScreenState extends State<CreateProductScreen> {
             width: double.infinity,
             decoration: BoxDecoration(
               borderRadius: BorderRadius.circular(10),
-              border: Border.all(color: const Color(0xFF006590), width: 2),
+              border: Border.all(color: Theme.of(context).colorScheme.primary, width: 2),
             ),
             child: ClipRRect(
               borderRadius: BorderRadius.circular(8),
@@ -1540,12 +1539,12 @@ class _CreateProductScreenState extends State<CreateProductScreen> {
                     left: 0,
                     right: 0,
                     child: Container(
-                      padding: const EdgeInsets.symmetric(vertical: 8, horizontal: 12),
-                      color: Colors.black.withOpacity(0.5),
+                      padding: EdgeInsets.symmetric(vertical: 8, horizontal: 12),
+                      color: Theme.of(context).colorScheme.onBackground.withOpacity(0.5),
                       child: Text(
                         titleController.text.isEmpty ? 'Main Image' : titleController.text,
-                        style: const TextStyle(
-                          color: Colors.white,
+                        style: TextStyle(
+                          color: Theme.of(context).colorScheme.background,
                           fontSize: 16,
                           fontWeight: FontWeight.bold,
                         ),
@@ -1560,15 +1559,15 @@ class _CreateProductScreenState extends State<CreateProductScreen> {
                     top: 8,
                     left: 8,
                     child: Container(
-                      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+                      padding: EdgeInsets.symmetric(horizontal: 8, vertical: 4),
                       decoration: BoxDecoration(
-                        color: const Color(0xFF006590),
+                        color: Theme.of(context).colorScheme.primary,
                         borderRadius: BorderRadius.circular(4),
                       ),
-                      child: const Text(
+                      child:  Text(
                         'MAIN IMAGE',
                         style: TextStyle(
-                          color: Colors.white,
+                          color: Theme.of(context).colorScheme.background,
                           fontSize: 10,
                           fontWeight: FontWeight.bold,
                         ),
@@ -1594,12 +1593,12 @@ class _CreateProductScreenState extends State<CreateProductScreen> {
                         setState(() {});
                       },
                       child: Container(
-                        padding: const EdgeInsets.all(4),
+                        padding: EdgeInsets.all(4),
                         decoration: BoxDecoration(
-                          color: Colors.white.withOpacity(0.7),
+                          color: Theme.of(context).colorScheme.background.withOpacity(0.7),
                           shape: BoxShape.circle,
                         ),
-                        child: const Icon(Icons.close, size: 20, color: Colors.black),
+                        child:  Icon(Icons.close, size: 20, color: Theme.of(context).colorScheme.onBackground),
                       ),
                     ),
                   ),
@@ -1688,15 +1687,15 @@ class _CreateProductScreenState extends State<CreateProductScreen> {
                     });
                   },
                   // child: Container(
-                  //   padding: const EdgeInsets.all(4),
+                  //   padding: EdgeInsets.all(4),
                   //   decoration: BoxDecoration(
-                  //     color: const Color(0xFF006590).withOpacity(0.8),
+                  //     color: Theme.of(context).colorScheme.primary.withOpacity(0.8),
                   //     borderRadius: BorderRadius.circular(4),
                   //   ),
-                  //   child: const Text(
+                  //   child:  Text(
                   //     'MAIN',
                   //     style: TextStyle(
-                  //       color: Colors.white,
+                  //       color: Theme.of(context).colorScheme.background,
                   //       fontSize: 8,
                   //       fontWeight: FontWeight.bold,
                   //     ),
@@ -1717,12 +1716,12 @@ class _CreateProductScreenState extends State<CreateProductScreen> {
                     });
                   },
                   child: Container(
-                    padding: const EdgeInsets.all(4),
+                    padding: EdgeInsets.all(4),
                     decoration: BoxDecoration(
-                      color: Colors.white.withOpacity(0.7),
+                      color: Theme.of(context).colorScheme.background.withOpacity(0.7),
                       shape: BoxShape.circle,
                     ),
-                    child: const Icon(Icons.close, size: 16, color: Colors.black),
+                    child:  Icon(Icons.close, size: 16, color: Theme.of(context).colorScheme.onBackground),
                   ),
                 ),
               ),

--- a/lib/screens/bazaar/sell/product/edit_sell_product_detail_screen.dart
+++ b/lib/screens/bazaar/sell/product/edit_sell_product_detail_screen.dart
@@ -58,11 +58,11 @@ class _SellProductDetailScreenState extends State<EditSellProductDetailScreen> {
         }
       },
       child: Scaffold(
-        backgroundColor: Colors.white,
+        backgroundColor: Theme.of(context).colorScheme.background,
         appBar: AppBar(
-          backgroundColor: const Color(0xFF006989),
+          backgroundColor: Theme.of(context).colorScheme.primary,
           leading: IconButton(
-            icon: const Icon(Icons.arrow_back, color: Colors.white),
+            icon:  Icon(Icons.arrow_back, color: Theme.of(context).colorScheme.background),
             onPressed: () {
               if (isAPICalled) {
                 Navigator.of(context).pop(true);
@@ -74,7 +74,7 @@ class _SellProductDetailScreenState extends State<EditSellProductDetailScreen> {
           title: Text(
             'Product List',
             style: Theme.of(context).textTheme.titleMedium!.copyWith(
-                  color: Colors.white,
+                  color: Theme.of(context).colorScheme.background,
                   fontWeight: FontWeight.w600,
                   fontSize: 20.0,
                 ),
@@ -97,14 +97,14 @@ class _SellProductDetailScreenState extends State<EditSellProductDetailScreen> {
           children: [
             Text(
               errorMessage!,
-              style: const TextStyle(
+              style: TextStyle(
                 fontSize: 16,
                 fontFamily: 'Montserrat',
-                color: Colors.grey,
+                color: Theme.of(context).colorScheme.onSurface,
               ),
               textAlign: TextAlign.center,
             ),
-            const SizedBox(height: 16),
+            SizedBox(height: 16),
             ElevatedButton(
               onPressed: () {
                 setState(() {
@@ -114,9 +114,9 @@ class _SellProductDetailScreenState extends State<EditSellProductDetailScreen> {
                 getSellEquipmentDetails();
               },
               style: ElevatedButton.styleFrom(
-                backgroundColor: const Color(0xFF006989),
+                backgroundColor: Theme.of(context).colorScheme.primary,
               ),
-              child: const Text('Retry'),
+              child:  Text('Retry'),
             ),
           ],
         ),
@@ -130,7 +130,7 @@ class _SellProductDetailScreenState extends State<EditSellProductDetailScreen> {
           style: TextStyle(
             fontSize: 16,
             fontFamily: 'Montserrat',
-            color: Colors.grey,
+            color: Theme.of(context).colorScheme.onSurface,
           ),
         ),
       );
@@ -141,11 +141,11 @@ class _SellProductDetailScreenState extends State<EditSellProductDetailScreen> {
         Expanded(
           child: SingleChildScrollView(
             child: Padding(
-              padding: const EdgeInsets.all(16.0),
+              padding: EdgeInsets.all(16.0),
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
-                  const Text(
+                   Text(
                     'Review your Details',
                     style: TextStyle(
                       fontSize: 18,
@@ -153,7 +153,7 @@ class _SellProductDetailScreenState extends State<EditSellProductDetailScreen> {
                       fontWeight: FontWeight.w400,
                     ),
                   ),
-                  const SizedBox(height: 16),
+                  SizedBox(height: 16),
 
                   // Image carousel
                   if (equipmentDetails!.equipmentImages.isNotEmpty)
@@ -164,7 +164,7 @@ class _SellProductDetailScreenState extends State<EditSellProductDetailScreen> {
                         controller: PageController(viewportFraction: 0.93),
                         itemBuilder: (context, index) {
                           return Container(
-                            margin: const EdgeInsets.symmetric(horizontal: 4),
+                            margin: EdgeInsets.symmetric(horizontal: 4),
                             child: ClipRRect(
                               borderRadius: BorderRadius.circular(8),
                               child: Image.network(
@@ -172,8 +172,8 @@ class _SellProductDetailScreenState extends State<EditSellProductDetailScreen> {
                                 fit: BoxFit.cover,
                                 errorBuilder: (context, error, stackTrace) {
                                   return Container(
-                                    color: Colors.grey[300],
-                                    child: const Icon(Icons.error),
+                                    color: Theme.of(context).colorScheme.outline,
+                                    child:  Icon(Icons.error),
                                   );
                                 },
                               ),
@@ -182,28 +182,28 @@ class _SellProductDetailScreenState extends State<EditSellProductDetailScreen> {
                         },
                       ),
                     ),
-                  const SizedBox(height: 16),
+                  SizedBox(height: 16),
 
                   // Product title
                   Text(
                     equipmentDetails!.title,
-                    style: const TextStyle(
+                    style: TextStyle(
                       fontSize: 18,
                       fontFamily: 'Montserrat',
                       fontWeight: FontWeight.bold,
                     ),
                   ),
-                  const SizedBox(height: 15),
+                  SizedBox(height: 15),
 
                   // Product price
                   Row(
                     children: [
                       Text(
                         'S\$ ${equipmentDetails!.price.toStringAsFixed(2)}',
-                        style: const TextStyle(
+                        style: TextStyle(
                           fontSize: 20,
                           fontWeight: FontWeight.bold,
-                          color: Color(0xFF006590),
+                          color: Theme.of(context).colorScheme.primary,
                         ),
                       ),
                       Spacer(),
@@ -217,7 +217,7 @@ class _SellProductDetailScreenState extends State<EditSellProductDetailScreen> {
                       ),
                     ],
                   ),
-                  const SizedBox(height: 20),
+                  SizedBox(height: 20),
 
                   // Category information
                   _buildInfoSection('Category', equipmentDetails!.sellEquipmentCategory.name),
@@ -226,7 +226,7 @@ class _SellProductDetailScreenState extends State<EditSellProductDetailScreen> {
                   Column(
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: [
-                      const Text(
+                       Text(
                         'Used For',
                         style: TextStyle(
                           fontSize: 18,
@@ -235,21 +235,21 @@ class _SellProductDetailScreenState extends State<EditSellProductDetailScreen> {
                           color: Color(0xFF2B2B2B),
                         ),
                       ),
-                      const SizedBox(height: 8),
+                      SizedBox(height: 8),
                       Wrap(
                         spacing: 8.0,
                         runSpacing: 8.0,
                         children: equipmentDetails!.equipmentSubActivities.map((activity) {
                           return Container(
                             decoration: BoxDecoration(
-                              color: const Color(0xFFF1F5F9), // Light blue-grey background
+                              color: Theme.of(context).colorScheme.surfaceVariant, // Light blue-grey background
                               borderRadius: BorderRadius.circular(20),
                             ),
                             child: Padding(
-                              padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+                              padding: EdgeInsets.symmetric(horizontal: 12, vertical: 6),
                               child: Text(
                                 activity.name,
-                                style: const TextStyle(
+                                style: TextStyle(
                                   color: Color(0xFF475569), // Dark blue-grey text
                                   fontSize: 14,
                                   fontWeight: FontWeight.w500,
@@ -262,26 +262,26 @@ class _SellProductDetailScreenState extends State<EditSellProductDetailScreen> {
                       )
                     ],
                   ),
-                  const SizedBox(height: 20),
+                  SizedBox(height: 20),
 
                   // Product details sections
                   _buildInfoSection('Description', equipmentDetails!.description),
-                  const SizedBox(height: 8),
+                  SizedBox(height: 8),
                   _buildInfoSection('Brand', equipmentDetails!.brand),
-                  const SizedBox(height: 8),
+                  SizedBox(height: 8),
                   _buildInfoSection('Condition', equipmentDetails!.sellEquipmentCondition.name),
 
                   if (equipmentDetails!.expiryDate != null)
                     Text(
                       'Post expiry date: ${DateFormat('dd/MM/yyyy').format(equipmentDetails!.expiryDate!)}',
-                      style: const TextStyle(
+                      style: TextStyle(
                         fontSize: 16,
                         fontWeight: FontWeight.w400,
                         fontFamily: 'Montserrat',
                         color: Color(0xFF808080),
                       ),
                     ),
-                  const SizedBox(height: 16),
+                  SizedBox(height: 16),
                 ],
               ),
             ),
@@ -291,7 +291,7 @@ class _SellProductDetailScreenState extends State<EditSellProductDetailScreen> {
         // Bottom button
         SafeArea(
           child: Padding(
-            padding: const EdgeInsets.all(10.0),
+            padding: EdgeInsets.all(10.0),
             child: Row(
               children: [
                 Expanded(
@@ -306,8 +306,8 @@ class _SellProductDetailScreenState extends State<EditSellProductDetailScreen> {
                       }
                     },
                     style: ElevatedButton.styleFrom(
-                      backgroundColor: const Color(0xFF006989),
-                      padding: const EdgeInsets.symmetric(vertical: 16),
+                      backgroundColor: Theme.of(context).colorScheme.primary,
+                      padding: EdgeInsets.symmetric(vertical: 16),
                       shape: RoundedRectangleBorder(
                         borderRadius: BorderRadius.circular(8),
                       ),
@@ -320,30 +320,30 @@ class _SellProductDetailScreenState extends State<EditSellProductDetailScreen> {
                       style: TextStyle(
                         fontSize: 16,
                         fontWeight: FontWeight.bold,
-                        color: Colors.white,
+                        color: Theme.of(context).colorScheme.background,
                       ),
                     ),
                   ),
                 ),
-                const SizedBox(width: 10),
+                SizedBox(width: 10),
                 Expanded(
                   child: ElevatedButton(
                     onPressed: () {
                       showDeleteConfirmationDialog(context, int.parse(widget.equipmentId));
                     },
                     style: ElevatedButton.styleFrom(
-                      backgroundColor: Colors.grey,
-                      padding: const EdgeInsets.symmetric(vertical: 16),
+                      backgroundColor: Theme.of(context).colorScheme.onSurface,
+                      padding: EdgeInsets.symmetric(vertical: 16),
                       shape: RoundedRectangleBorder(
                         borderRadius: BorderRadius.circular(8),
                       ),
                     ),
-                    child: const Text(
+                    child:  Text(
                       'Remove',
                       style: TextStyle(
                         fontSize: 16,
                         fontWeight: FontWeight.bold,
-                        color: Colors.white,
+                        color: Theme.of(context).colorScheme.background,
                       ),
                     ),
                   ),
@@ -362,24 +362,24 @@ class _SellProductDetailScreenState extends State<EditSellProductDetailScreen> {
       children: [
         Text(
           title,
-          style: const TextStyle(
+          style: TextStyle(
             fontSize: 20,
             fontFamily: 'Montserrat',
             fontWeight: FontWeight.bold,
             color: Color(0xFF2B2B2B),
           ),
         ),
-        const SizedBox(height: 8),
+        SizedBox(height: 8),
         Text(
           content,
-          style: const TextStyle(
+          style: TextStyle(
             fontSize: 16,
             fontFamily: 'Montserrat',
             fontWeight: FontWeight.w600,
             color: Color(0xFF2B2B2B),
           ),
         ),
-        const SizedBox(height: 16),
+        SizedBox(height: 16),
       ],
     );
   }
@@ -449,7 +449,7 @@ class _SellProductDetailScreenState extends State<EditSellProductDetailScreen> {
       case 'sold':
         return const Color(0xFF3C3C3C);
       default:
-        return Colors.black;
+        return Theme.of(context).colorScheme.onBackground;
     }
   }
 
@@ -491,10 +491,10 @@ class _SellProductDetailScreenState extends State<EditSellProductDetailScreen> {
                   ],
                 ),
               ),
-              const SizedBox(height: 8),
+              SizedBox(height: 8),
               const Divider(
                 height: 2,
-                color: Colors.black,
+                color: Theme.of(context).colorScheme.onBackground,
               ),
               IntrinsicHeight(
                 child: Row(
@@ -502,8 +502,8 @@ class _SellProductDetailScreenState extends State<EditSellProductDetailScreen> {
                     Expanded(
                       child: TextButton(
                         style: TextButton.styleFrom(
-                          foregroundColor: Colors.white,
-                          backgroundColor: Color(0xFF006590),
+                          foregroundColor: Theme.of(context).colorScheme.background,
+                          backgroundColor: Theme.of(context).colorScheme.primary,
                           padding: EdgeInsets.symmetric(vertical: 16),
                           shape: RoundedRectangleBorder(
                             borderRadius: BorderRadius.only(
@@ -515,14 +515,14 @@ class _SellProductDetailScreenState extends State<EditSellProductDetailScreen> {
                           Navigator.of(context).pop();
                           deleteEquipment(equipmentId);
                         },
-                        child: const Text('Yes'),
+                        child:  Text('Yes'),
                       ),
                     ),
                     const VerticalDivider(width: 1),
                     Expanded(
                       child: TextButton(
                         style: TextButton.styleFrom(
-                          foregroundColor: Colors.black87,
+                          foregroundColor: Theme.of(context).colorScheme.onBackground.withOpacity(0.87),
                           padding: EdgeInsets.symmetric(vertical: 16),
                           shape: RoundedRectangleBorder(
                             borderRadius: BorderRadius.only(
@@ -531,7 +531,7 @@ class _SellProductDetailScreenState extends State<EditSellProductDetailScreen> {
                           ),
                         ),
                         onPressed: () => Navigator.of(context).pop(false),
-                        child: const Text('No'),
+                        child:  Text('No'),
                       ),
                     ),
                   ],
@@ -645,7 +645,7 @@ class _SellProductDetailScreenState extends State<EditSellProductDetailScreen> {
           content: Text(message),
           actions: <Widget>[
             TextButton(
-              child: const Text('Okay'),
+              child:  Text('Okay'),
               onPressed: () {
                 Navigator.of(context).pop(true);
                 Navigator.of(context).pop(true);

--- a/lib/screens/bazaar/sell/product/sell_product_detail_screen.dart
+++ b/lib/screens/bazaar/sell/product/sell_product_detail_screen.dart
@@ -48,17 +48,17 @@ class _SellProductDetailScreenState extends State<SellProductDetailScreen> {
     final product = widget.editViewEquipmentIntentModel.sellEquipmentResponseModel!;
 
     return Scaffold(
-      backgroundColor: Colors.white,
+      backgroundColor: Theme.of(context).colorScheme.background,
       appBar: AppBar(
-        backgroundColor: const Color(0xFF006989),
+        backgroundColor: Theme.of(context).colorScheme.primary,
         leading: IconButton(
-          icon: const Icon(Icons.arrow_back, color: Colors.white),
+          icon:  Icon(Icons.arrow_back, color: Theme.of(context).colorScheme.background),
           onPressed: () => Navigator.pop(context),
         ),
         title: Text(
           'Product List',
           style: Theme.of(context).textTheme.titleMedium!.copyWith(
-                color: Colors.white,
+                color: Theme.of(context).colorScheme.background,
                 fontWeight: FontWeight.w600,
                 fontSize: 20.0,
               ),
@@ -69,11 +69,11 @@ class _SellProductDetailScreenState extends State<SellProductDetailScreen> {
           Expanded(
             child: SingleChildScrollView(
               child: Padding(
-                padding: const EdgeInsets.all(16.0),
+                padding: EdgeInsets.all(16.0),
                 child: Column(
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
-                    const Text(
+                     Text(
                       'Review your Details',
                       style: TextStyle(
                         fontSize: 18,
@@ -81,7 +81,7 @@ class _SellProductDetailScreenState extends State<SellProductDetailScreen> {
                         fontWeight: FontWeight.w400,
                       ),
                     ),
-                    const SizedBox(height: 16),
+                    SizedBox(height: 16),
 
                     // Image carousel
                     if (product.equipmentImages.isNotEmpty) ...[
@@ -92,7 +92,7 @@ class _SellProductDetailScreenState extends State<SellProductDetailScreen> {
                           controller: PageController(viewportFraction: 0.93),
                           itemBuilder: (context, index) {
                             return Container(
-                              margin: const EdgeInsets.symmetric(horizontal: 4),
+                              margin: EdgeInsets.symmetric(horizontal: 4),
                               child: ClipRRect(
                                 borderRadius: BorderRadius.circular(8),
                                 child: Image.network(
@@ -105,26 +105,26 @@ class _SellProductDetailScreenState extends State<SellProductDetailScreen> {
                           },
                         ),
                       ),
-                      const SizedBox(height: 16),
+                      SizedBox(height: 16),
                     ],
 
                     // Product title
                     Text(
                       product.title,
-                      style: const TextStyle(fontSize: 25, fontFamily: 'Montserrat', fontWeight: FontWeight.bold, color: Colors.black),
+                      style: TextStyle(fontSize: 25, fontFamily: 'Montserrat', fontWeight: FontWeight.bold, color: Theme.of(context).colorScheme.onBackground),
                     ),
-                    const SizedBox(height: 8),
+                    SizedBox(height: 8),
 
                     // Product price
                     Text(
                       'S\$ ${product.price.toStringAsFixed(2)}',
-                      style: const TextStyle(
+                      style: TextStyle(
                         fontSize: 20,
                         fontWeight: FontWeight.w700,
-                        color: Color(0xFF006590),
+                        color: Theme.of(context).colorScheme.primary,
                       ),
                     ),
-                    const SizedBox(height: 16),
+                    SizedBox(height: 16),
 
                     // Category information
                     _buildInfoSection('Category', product.sellEquipmentCategory.name),
@@ -133,7 +133,7 @@ class _SellProductDetailScreenState extends State<SellProductDetailScreen> {
                     Column(
                       crossAxisAlignment: CrossAxisAlignment.start,
                       children: [
-                        const Text(
+                         Text(
                           'Used For',
                           style: TextStyle(
                             fontSize: 16,
@@ -142,7 +142,7 @@ class _SellProductDetailScreenState extends State<SellProductDetailScreen> {
                             color: Color(0xFF2B2B2B),
                           ),
                         ),
-                        const SizedBox(height: 8),
+                        SizedBox(height: 8),
                         Wrap(
                           spacing: 8.0,
                           runSpacing: 8.0,
@@ -152,7 +152,7 @@ class _SellProductDetailScreenState extends State<SellProductDetailScreen> {
                               label: Text(
                                 activity.name,
                                 style: TextStyle(
-                                  color: selectedActivities.contains(activity.name) ? Colors.white : Theme.of(context).extension<CustomColors>()!.chipText,
+                                  color: selectedActivities.contains(activity.name) ? Theme.of(context).colorScheme.background : Theme.of(context).extension<CustomColors>()!.chipText,
                                   fontSize: 13.0,
                                   fontWeight: FontWeight.w400,
                                 ),
@@ -165,7 +165,7 @@ class _SellProductDetailScreenState extends State<SellProductDetailScreen> {
                                   color: selectedActivities.contains(activity.name) ? Theme.of(context).primaryColor : Theme.of(context).extension<CustomColors>()!.chipBackground,
                                 ),
                               ),
-                              padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+                              padding: EdgeInsets.symmetric(horizontal: 16, vertical: 8),
                               showCheckmark: false,
                               onSelected: (bool selected) {
                                 setState(() {
@@ -181,7 +181,7 @@ class _SellProductDetailScreenState extends State<SellProductDetailScreen> {
                         ),
                       ],
                     ),
-                    const SizedBox(height: 16),
+                    SizedBox(height: 16),
 
                     // Product details
                     _buildInfoSection('Description', product.description),
@@ -194,14 +194,14 @@ class _SellProductDetailScreenState extends State<SellProductDetailScreen> {
                       postExpiryDate.isEmpty
                           ? 'Post expiry date: ${DateFormat('dd/MM/yyyy').format(product.expiryDate!)}'
                           : 'Post expiry date: ${DateFormat('dd/MM/yyyy').format(DateTime.parse(postExpiryDate))}',
-                      style: const TextStyle(
+                      style: TextStyle(
                         fontSize: 16,
                         fontWeight: FontWeight.w400,
                         fontFamily: 'Montserrat',
                         color: Color(0xFF808080),
                       ),
                     ),
-                    const SizedBox(height: 16),
+                    SizedBox(height: 16),
                     // ],
                   ],
                 ),
@@ -212,24 +212,24 @@ class _SellProductDetailScreenState extends State<SellProductDetailScreen> {
           // Post button
           SafeArea(
             child: Padding(
-              padding: const EdgeInsets.all(10.0),
+              padding: EdgeInsets.all(10.0),
               child: SizedBox(
                 width: double.infinity,
                 child: ElevatedButton(
                   onPressed: () => postProduct(),
                   style: ElevatedButton.styleFrom(
-                    backgroundColor: const Color(0xFF006989),
-                    padding: const EdgeInsets.symmetric(vertical: 16),
+                    backgroundColor: Theme.of(context).colorScheme.primary,
+                    padding: EdgeInsets.symmetric(vertical: 16),
                     shape: RoundedRectangleBorder(
                       borderRadius: BorderRadius.circular(8),
                     ),
                   ),
-                  child: const Text(
+                  child:  Text(
                     'Post Now',
                     style: TextStyle(
                       fontSize: 16,
                       fontWeight: FontWeight.bold,
-                      color: Colors.white,
+                      color: Theme.of(context).colorScheme.background,
                     ),
                   ),
                 ),
@@ -247,23 +247,23 @@ class _SellProductDetailScreenState extends State<SellProductDetailScreen> {
       children: [
         Text(
           title,
-          style: const TextStyle(
+          style: TextStyle(
             fontSize: 16,
             fontFamily: 'Montserrat',
             fontWeight: FontWeight.w600,
             color: Color(0xFF2B2B2B),
           ),
         ),
-        const SizedBox(height: 8),
+        SizedBox(height: 8),
         Text(
           content,
-          style: const TextStyle(
+          style: TextStyle(
             fontSize: 16,
             fontFamily: 'Montserrat',
             fontWeight: FontWeight.w400,
           ),
         ),
-        const SizedBox(height: 16),
+        SizedBox(height: 16),
       ],
     );
   }

--- a/lib/screens/bazaar/sell/product_category_screen.dart
+++ b/lib/screens/bazaar/sell/product_category_screen.dart
@@ -136,7 +136,7 @@ class _ProductCategoryScreenState extends State<ProductCategoryScreen> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      backgroundColor: Colors.white,
+      backgroundColor: Theme.of(context).colorScheme.background,
       appBar: AppBar(
         centerTitle: true,
         elevation: 0.0,
@@ -144,38 +144,38 @@ class _ProductCategoryScreenState extends State<ProductCategoryScreen> {
           onPressed: () {
             Navigator.pop(context);
           },
-          icon: const Icon(
+          icon:  Icon(
             Icons.arrow_back,
-            color: Colors.white,
+            color: Theme.of(context).colorScheme.background,
           ),
         ),
-        title: const Text(
+        title:  Text(
           "Bazaar",
           style: TextStyle(
-            color: Colors.white,
+            color: Theme.of(context).colorScheme.background,
             fontFamily: 'SFPro',
             fontWeight: FontWeight.w700,
             fontSize: 17,
           ),
         ),
-        backgroundColor: const Color(0xFF006590),
+        backgroundColor: Theme.of(context).colorScheme.primary,
       ),
       body: Container(
-        padding: const EdgeInsets.all(16),
-        color: Colors.white,
+        padding: EdgeInsets.all(16),
+        color: Theme.of(context).colorScheme.background,
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            const Text(
+             Text(
               'Select Product Category',
               style: TextStyle(
                 fontSize: 18,
                 fontFamily: 'SFPro',
-                color: Colors.black,
+                color: Theme.of(context).colorScheme.onBackground,
                 fontWeight: FontWeight.w400,
               ),
             ),
-            const SizedBox(height: 16),
+            SizedBox(height: 16),
             Expanded(
               child: isLoading
                   ? const Center(child: CircularProgressIndicator())

--- a/lib/screens/bazaar/sell/sell_product_category_screen.dart
+++ b/lib/screens/bazaar/sell/sell_product_category_screen.dart
@@ -8,7 +8,6 @@ import 'package:oqdo_mobile_app/screens/bazaar/ads_screen/model/subactivyt_and_a
 import 'package:oqdo_mobile_app/screens/bazaar/sell/models/edit_view_equipment_intent_model.dart';
 import 'package:oqdo_mobile_app/screens/bazaar/sell/models/sell_equipment_response_model.dart';
 import 'package:oqdo_mobile_app/screens/bazaar/sell/viewmodel/sell_viewmodel.dart';
-import 'package:oqdo_mobile_app/theme/oqdo_theme_data.dart';
 import 'package:oqdo_mobile_app/utils/constants.dart';
 import 'package:oqdo_mobile_app/utils/custom_text_view.dart';
 import 'package:oqdo_mobile_app/utils/network_interceptor.dart';
@@ -55,25 +54,25 @@ class _SellProductCategoryScreenState extends State<SellProductCategoryScreen> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      backgroundColor: Colors.white,
+      backgroundColor: Theme.of(context).colorScheme.background,
       appBar: CustomAppBar(
         title: 'Product Category',
         onBack: () => Navigator.pop(context),
         isIconColorBlack: false,
-        backgroundColor: const Color(0xFF006989),
+        backgroundColor: Theme.of(context).colorScheme.primary,
       ),
       body: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           Padding(
-            padding: const EdgeInsets.all(16),
+            padding: EdgeInsets.all(16),
             child: Text(
               'Used For',
               style: TextStyle(
                 fontSize: 18,
                 fontFamily: 'SFPro',
                 fontWeight: FontWeight.w400,
-                color: Colors.black,
+                color: Theme.of(context).colorScheme.onBackground,
               ),
             ),
           ),
@@ -84,7 +83,7 @@ class _SellProductCategoryScreenState extends State<SellProductCategoryScreen> {
                 Container(
                   width: 150,
                   decoration: BoxDecoration(
-                    color: Colors.white,
+                    color: Theme.of(context).colorScheme.background,
                     border: Border(
                       right: BorderSide(color: Color(0xFFE3E3E3)),
                     ),
@@ -101,9 +100,9 @@ class _SellProductCategoryScreenState extends State<SellProductCategoryScreen> {
                           });
                         },
                         child: Container(
-                          padding: const EdgeInsets.all(16),
+                          padding: EdgeInsets.all(16),
                           decoration: BoxDecoration(
-                            color: categories[index].isExpanded ? Colors.white : Colors.transparent,
+                            color: categories[index].isExpanded ? Theme.of(context).colorScheme.background : Colors.transparent,
                             border: Border(
                               bottom: BorderSide(color: Color(0xFFE3E3E3)),
                             ),
@@ -140,7 +139,7 @@ class _SellProductCategoryScreenState extends State<SellProductCategoryScreen> {
                                 final subActivity = category.subActivities[subIndex];
 
                                 return Container(
-                                  padding: const EdgeInsets.only(left: 10.0, right: 20.0, top: 20.0),
+                                  padding: EdgeInsets.only(left: 10.0, right: 20.0, top: 20.0),
                                   child: Row(
                                     mainAxisSize: MainAxisSize.min,
                                     children: [
@@ -161,7 +160,7 @@ class _SellProductCategoryScreenState extends State<SellProductCategoryScreen> {
                                           },
                                         ),
                                       ),
-                                      const SizedBox(width: 15.0),
+                                      SizedBox(width: 15.0),
                                       Expanded(
                                         child: CustomTextView(
                                           label: subActivity.name,
@@ -169,7 +168,7 @@ class _SellProductCategoryScreenState extends State<SellProductCategoryScreen> {
                                           textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(
                                                 fontSize: 18.0,
                                                 fontWeight: FontWeight.w500,
-                                                color: OQDOThemeData.greyColor,
+                                                color: Theme.of(context).colorScheme.onSurface,
                                               ),
                                         ),
                                       ),
@@ -192,7 +191,7 @@ class _SellProductCategoryScreenState extends State<SellProductCategoryScreen> {
                                 //     });
                                 //   },
                                 //   controlAffinity: ListTileControlAffinity.leading,
-                                //   activeColor: Color(0xFF006989),
+                                //   activeColor: Theme.of(context).colorScheme.primary,
                                 //   contentPadding: EdgeInsets.symmetric(horizontal: 16),
                                 // );
                               },
@@ -208,9 +207,9 @@ class _SellProductCategoryScreenState extends State<SellProductCategoryScreen> {
           ),
           Container(
             decoration: BoxDecoration(
-              color: Colors.white,
+              color: Theme.of(context).colorScheme.background,
               border: Border(
-                top: BorderSide(color: Colors.grey[300]!),
+                top: BorderSide(color: Theme.of(context).colorScheme.outline),
               ),
             ),
             child: Row(
@@ -220,13 +219,13 @@ class _SellProductCategoryScreenState extends State<SellProductCategoryScreen> {
                     height: 70.0,
                     child: ElevatedButton(
                       style: ButtonStyle(
-                        foregroundColor: WidgetStateProperty.all<Color>(const Color(0xFFCECECE)),
-                        backgroundColor: WidgetStateProperty.all<Color>(const Color(0xFFCECECE)),
+                        foregroundColor: WidgetStateProperty.all<Color>(Theme.of(context).colorScheme.outline),
+                        backgroundColor: WidgetStateProperty.all<Color>(Theme.of(context).colorScheme.outline),
                         shape: WidgetStateProperty.all<RoundedRectangleBorder>(
                           const RoundedRectangleBorder(
                             borderRadius: BorderRadius.zero,
                             side: BorderSide(
-                              color: Color(0xFFCECECE),
+                              color: Theme.of(context).colorScheme.outline,
                             ),
                           ),
                         ),
@@ -238,7 +237,7 @@ class _SellProductCategoryScreenState extends State<SellProductCategoryScreen> {
                               fontWeight: FontWeight.w400,
                               fontSize: 16.0,
                               decoration: TextDecoration.underline,
-                              color: OQDOThemeData.blackColor,
+                              color: Theme.of(context).colorScheme.onBackground,
                               fontFamily: 'SFPro',
                             ),
                       ),
@@ -250,13 +249,13 @@ class _SellProductCategoryScreenState extends State<SellProductCategoryScreen> {
                     height: 70.0,
                     child: ElevatedButton(
                       style: ButtonStyle(
-                        foregroundColor: WidgetStateProperty.all<Color>(const Color(0xFF006590)),
-                        backgroundColor: WidgetStateProperty.all<Color>(selectedSubActivities.isEmpty ? const Color(0xFFCECECE) : const Color(0xFF006590)),
+                        foregroundColor: WidgetStateProperty.all<Color>(Theme.of(context).colorScheme.primary),
+                        backgroundColor: WidgetStateProperty.all<Color>(selectedSubActivities.isEmpty ? Theme.of(context).colorScheme.outline : Theme.of(context).colorScheme.primary),
                         shape: WidgetStateProperty.all<RoundedRectangleBorder>(
                           RoundedRectangleBorder(
                             borderRadius: BorderRadius.zero,
                             side: BorderSide(
-                              color: selectedSubActivities.isEmpty ? const Color(0xFFCECECE) : const Color(0xFF006590),
+                              color: selectedSubActivities.isEmpty ? Theme.of(context).colorScheme.outline : Theme.of(context).colorScheme.primary,
                             ),
                           ),
                         ),
@@ -320,7 +319,7 @@ class _SellProductCategoryScreenState extends State<SellProductCategoryScreen> {
                         textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(
                               fontWeight: FontWeight.w600,
                               fontSize: 16.0,
-                              color: selectedSubActivities.isEmpty ? Colors.grey[600] : OQDOThemeData.whiteColor,
+                              color: selectedSubActivities.isEmpty ? Theme.of(context).colorScheme.onSurface.withOpacity(0.6) : Theme.of(context).colorScheme.background,
                               fontFamily: 'SFPro',
                             ),
                       ),

--- a/lib/screens/bazaar/sell/sell_screen.dart
+++ b/lib/screens/bazaar/sell/sell_screen.dart
@@ -77,7 +77,7 @@ class _SellScreenState extends State<SellScreen> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      backgroundColor: Colors.white,
+      backgroundColor: Theme.of(context).colorScheme.background,
       body: Column(
         children: [
           _searchbar(),
@@ -87,14 +87,14 @@ class _SellScreenState extends State<SellScreen> {
         ],
       ),
       floatingActionButton: FloatingActionButton(
-        backgroundColor: const Color(0xFF006590),
+        backgroundColor: Theme.of(context).colorScheme.primary,
         onPressed: () {
           var intentModel = EditViewEquipmentIntentModel(isEdit: false, equipmentId: 0, sellEquipmentResponseModel: null);
           Navigator.pushNamed(context, Constants.sellProductListScreen, arguments: intentModel);
         },
-        child: const Icon(
+        child:  Icon(
           Icons.add,
-          color: Colors.white,
+          color: Theme.of(context).colorScheme.background,
         ),
       ),
     );
@@ -114,22 +114,22 @@ class _SellScreenState extends State<SellScreen> {
 
   Widget _searchbar() {
     return Container(
-      color: const Color(0xFF006590),
-      padding: const EdgeInsets.only(left: 16, right: 16, top: 0, bottom: 16),
+      color: Theme.of(context).colorScheme.primary,
+      padding: EdgeInsets.only(left: 16, right: 16, top: 0, bottom: 16),
       child: TextField(
         controller: _searchController,
         onChanged: _onSearchChanged,
         decoration: InputDecoration(
           hintText: "Search Equipment's",
-          prefixIcon: const Icon(
+          prefixIcon:  Icon(
             Icons.search,
-            color: Color(0xFF006590),
+            color: Theme.of(context).colorScheme.primary,
           ),
           border: OutlineInputBorder(
             borderRadius: BorderRadius.circular(8.0),
           ),
           filled: true,
-          fillColor: Colors.white,
+          fillColor: Theme.of(context).colorScheme.background,
         ),
       ),
     );
@@ -138,7 +138,7 @@ class _SellScreenState extends State<SellScreen> {
   Widget _equipmentGridView(List<EquipmentData> equipments) {
     return GridView.builder(
       controller: _scrollController,
-      padding: const EdgeInsets.all(2.0),
+      padding: EdgeInsets.all(2.0),
       gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
         crossAxisCount: 2,
         childAspectRatio: 0.8,
@@ -298,10 +298,10 @@ class _SellScreenState extends State<SellScreen> {
                   ],
                 ),
               ),
-              const SizedBox(height: 8),
+              SizedBox(height: 8),
               const Divider(
                 height: 2,
-                color: Colors.black,
+                color: Theme.of(context).colorScheme.onBackground,
               ),
               IntrinsicHeight(
                 child: Row(
@@ -309,8 +309,8 @@ class _SellScreenState extends State<SellScreen> {
                     Expanded(
                       child: TextButton(
                         style: TextButton.styleFrom(
-                          foregroundColor: Colors.white,
-                          backgroundColor: Color(0xFF006590),
+                          foregroundColor: Theme.of(context).colorScheme.background,
+                          backgroundColor: Theme.of(context).colorScheme.primary,
                           padding: EdgeInsets.symmetric(vertical: 16),
                           shape: RoundedRectangleBorder(
                             borderRadius: BorderRadius.only(
@@ -322,14 +322,14 @@ class _SellScreenState extends State<SellScreen> {
                           Navigator.of(context).pop();
                           deleteEquipment(equipmentId);
                         },
-                        child: const Text('Yes'),
+                        child:  Text('Yes'),
                       ),
                     ),
                     const VerticalDivider(width: 1),
                     Expanded(
                       child: TextButton(
                         style: TextButton.styleFrom(
-                          foregroundColor: Colors.black87,
+                          foregroundColor: Theme.of(context).colorScheme.onBackground.withOpacity(0.87),
                           padding: EdgeInsets.symmetric(vertical: 16),
                           shape: RoundedRectangleBorder(
                             borderRadius: BorderRadius.only(
@@ -338,7 +338,7 @@ class _SellScreenState extends State<SellScreen> {
                           ),
                         ),
                         onPressed: () => Navigator.of(context).pop(false),
-                        child: const Text('No'),
+                        child:  Text('No'),
                       ),
                     ),
                   ],

--- a/lib/screens/bazaar/sell/views/equipment_card.dart
+++ b/lib/screens/bazaar/sell/views/equipment_card.dart
@@ -32,7 +32,7 @@ class EquipmentCard extends StatelessWidget {
       case 'sold':
         return const Color(0xFF3C3C3C);
       default:
-        return Colors.black;
+        return Theme.of(context).colorScheme.onBackground;
     }
   }
 
@@ -67,7 +67,7 @@ class EquipmentCard extends StatelessWidget {
                 ),
               ),
               Padding(
-                padding: const EdgeInsets.all(8.0),
+                padding: EdgeInsets.all(8.0),
                 child: Column(
                   crossAxisAlignment: CrossAxisAlignment.start,
                   mainAxisSize: MainAxisSize.min,
@@ -80,7 +80,7 @@ class EquipmentCard extends StatelessWidget {
                             Expanded(
                               child: Text(
                                 equipment.title,
-                                style: const TextStyle(
+                                style: TextStyle(
                                   fontWeight: FontWeight.bold,
                                   fontFamily: 'Montserrat',
                                   fontSize: 15,
@@ -91,7 +91,7 @@ class EquipmentCard extends StatelessWidget {
                                 overflow: TextOverflow.ellipsis,
                               ),
                             ),
-                            const SizedBox(width: 8),
+                            SizedBox(width: 8),
                             ((equipment.equipmentStatus!.code == EquipmentStatusCode.sold.toString()) ||
                                     (equipment.equipmentStatus!.code == EquipmentStatusCode.expired.toString()))
                                 ? SizedBox(
@@ -99,9 +99,9 @@ class EquipmentCard extends StatelessWidget {
                                     height: 24,
                                     child: PopupMenuButton<String>(
                                       padding: EdgeInsets.zero,
-                                      icon: const Icon(
+                                      icon:  Icon(
                                         Icons.more_vert,
-                                        color: Color(0xFF006590),
+                                        color: Theme.of(context).colorScheme.primary,
                                         size: 20,
                                       ),
                                       onSelected: (String choice) {
@@ -132,9 +132,9 @@ class EquipmentCard extends StatelessWidget {
                                     height: 24,
                                     child: PopupMenuButton<String>(
                                       padding: EdgeInsets.zero,
-                                      icon: const Icon(
+                                      icon:  Icon(
                                         Icons.more_vert,
-                                        color: Color(0xFF006590),
+                                        color: Theme.of(context).colorScheme.primary,
                                         size: 20,
                                       ),
                                       onSelected: (String choice) {
@@ -170,7 +170,7 @@ class EquipmentCard extends StatelessWidget {
                         );
                       },
                     ),
-                    const SizedBox(height: 4),
+                    SizedBox(height: 4),
                     Row(
                       mainAxisAlignment: MainAxisAlignment.spaceBetween,
                       children: [
@@ -189,7 +189,7 @@ class EquipmentCard extends StatelessWidget {
                           equipment.expiryDate == null
                               ? ''
                               : 'Expiry: ${equipment.expiryDate == null ? '' : DateFormat('dd/MM/yyyy').format(equipment.expiryDate!)}',
-                          style: const TextStyle(
+                          style: TextStyle(
                             fontFamily: 'Montserrat',
                             fontWeight: FontWeight.w600,
                             color: Color(0xFF6B6B6B),
@@ -198,13 +198,13 @@ class EquipmentCard extends StatelessWidget {
                         ),
                       ],
                     ),
-                    const SizedBox(height: 8),
+                    SizedBox(height: 8),
                     Text(
                       'S\$ - ${equipment.price.toStringAsFixed(2)}',
-                      style: const TextStyle(
+                      style: TextStyle(
                         fontWeight: FontWeight.w600,
                         fontFamily: 'Montserrat',
-                        color: Color(0xFF006590),
+                        color: Theme.of(context).colorScheme.primary,
                         fontSize: 16,
                       ),
                     ),

--- a/lib/screens/bazaar/sell/views/product_category.dart
+++ b/lib/screens/bazaar/sell/views/product_category.dart
@@ -22,7 +22,7 @@ class CategoryCard extends StatelessWidget {
       shape: RoundedRectangleBorder(
         borderRadius: BorderRadius.circular(8),
         side: BorderSide(
-          color: isSelected ? const Color(0xFF006590) : Colors.transparent,
+          color: isSelected ? Theme.of(context).colorScheme.primary : Colors.transparent,
           width: isSelected ? 2 : 0,
         ),
       ),
@@ -37,13 +37,13 @@ class CategoryCard extends StatelessWidget {
               width: 80,
               height: 80,
             ),
-            const SizedBox(height: 8),
+            SizedBox(height: 8),
             Padding(
-              padding: const EdgeInsets.symmetric(horizontal: 8),
+              padding: EdgeInsets.symmetric(horizontal: 8),
               child: Text(
                 title,
                 textAlign: TextAlign.center,
-                style: const TextStyle(
+                style: TextStyle(
                   fontSize: 16,
                   fontFamily: 'Montserrat',
                   fontWeight: FontWeight.bold,


### PR DESCRIPTION
## Summary
- Replace hardcoded colors with Theme.of(context).colorScheme across bazaar screens
- Remove obsolete theme imports after migration

## Testing
- `dart format lib/screens/bazaar` *(fails: command not found)*
- `dart run scripts/migration_analyzer.dart lib/screens/bazaar` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68c10d3c1574833288fa909ae9b360d8