### PR TITLE
feat: add bazaar theme colors

### DIFF
--- a/lib/screens/bazaar/ads_screen/ads_screen.dart
+++ b/lib/screens/bazaar/ads_screen/ads_screen.dart
@@ -50,7 +50,6 @@ class _AdsScreenState extends State<AdsScreen> with SingleTickerProviderStateMix
                   padding: EdgeInsets.fromLTRB(10.0, 20, 10, 0),
                   child: SegmentedView(
                     segments: segments,
-                    backgroundColor: Color(0xFFD4EEF9),
                     onSegmentSelected: (p0) {
                       selectedSegment = p0;
                       setState(() {});

--- a/lib/screens/bazaar/ads_screen/widgets/segmented_view.dart
+++ b/lib/screens/bazaar/ads_screen/widgets/segmented_view.dart
@@ -1,12 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:oqdo_mobile_app/screens/bazaar/ads_screen/model/advertisement_type_response_model.dart';
+import 'package:oqdo_mobile_app/theme/custom_colors.dart';
 
 class SegmentedView extends StatefulWidget {
   final List<AdvertisementTypeResponse> segments;
   final void Function(AdvertisementTypeResponse)? onSegmentSelected;
-  final Color selectedColor;
-  final Color unselectedColor;
-  final Color backgroundColor;
   final int initialIndex;
   final VoidCallback? onPressed;
 
@@ -15,9 +13,6 @@ class SegmentedView extends StatefulWidget {
     required this.segments,
     this.onSegmentSelected,
     this.onPressed,
-    this.selectedColor = Theme.of(context).colorScheme.primary,
-    this.unselectedColor = const Color(0xFFD4EEF9),
-    this.backgroundColor = const Color(0xFFE0E0E0),
     this.initialIndex = 0,
   });
 
@@ -59,6 +54,7 @@ class _SegmentedViewState extends State<SegmentedView> {
 
   @override
   Widget build(BuildContext context) {
+    final customColors = Theme.of(context).extension<CustomColors>()!;
     return Container(
       padding: EdgeInsets.all(8.0),
       child: Row(
@@ -66,7 +62,7 @@ class _SegmentedViewState extends State<SegmentedView> {
           Expanded(
             child: Container(
               decoration: BoxDecoration(
-                color: widget.backgroundColor,
+                color: customColors.bazaarTabBackground,
                 borderRadius: BorderRadius.circular(20.0),
               ),
               child: widget.segments.length <= 2
@@ -99,6 +95,7 @@ class _SegmentedViewState extends State<SegmentedView> {
   Widget _buildSegment(int index) {
     final segment = widget.segments[index];
     final bool isSelected = selectedIndex == index;
+    final customColors = Theme.of(context).extension<CustomColors>()!;
 
     return Expanded(
       flex: widget.segments.length <= 2 ? 1 : 0,
@@ -116,7 +113,9 @@ class _SegmentedViewState extends State<SegmentedView> {
         child: Container(
           padding: EdgeInsets.symmetric(vertical: 12.0),
           decoration: BoxDecoration(
-            color: isSelected ? widget.selectedColor : widget.unselectedColor,
+            color: isSelected
+                ? Theme.of(context).colorScheme.primary
+                : customColors.bazaarTabBackground,
             borderRadius: BorderRadius.circular(20.0),
           ),
           child: Row(

--- a/lib/screens/bazaar/chats/buying/buying_chat_screen.dart
+++ b/lib/screens/bazaar/chats/buying/buying_chat_screen.dart
@@ -18,6 +18,7 @@ import 'package:progress_dialog_null_safe/progress_dialog_null_safe.dart';
 import 'package:provider/provider.dart';
 import 'package:logging/logging.dart';
 import 'package:oqdo_mobile_app/oqdo_application.dart';
+import 'package:oqdo_mobile_app/theme/custom_colors.dart';
 
 class BuyingChatScreen extends StatefulWidget {
   const BuyingChatScreen({super.key, required this.equipmentDetails});
@@ -155,7 +156,7 @@ class _BuyingChatScreenState extends State<BuyingChatScreen> {
       },
       child: Scaffold(
         resizeToAvoidBottomInset: true,
-        backgroundColor: Color(0xFFEAF3F7),
+        backgroundColor: Theme.of(context).extension<CustomColors>()!.bazaarChatBackground,
         appBar: AppBar(
           toolbarHeight: 80,
           centerTitle: false,
@@ -341,7 +342,7 @@ class _BuyingChatScreenState extends State<BuyingChatScreen> {
                   : (((!isSentByMe) && isOfferAcceptanceMessage))
                       ? Theme.of(context).colorScheme.background
                       : isSentByMe
-                          ? const Color(0xFFC7DDE7)
+                          ? Theme.of(context).extension<CustomColors>()!.messageLeft
                           : Theme.of(context).colorScheme.background,
               borderRadius: BorderRadius.circular(10),
               boxShadow: [

--- a/lib/screens/bazaar/chats/chats_screen.dart
+++ b/lib/screens/bazaar/chats/chats_screen.dart
@@ -6,6 +6,7 @@ import 'package:oqdo_mobile_app/screens/bazaar/chats/socket_service.dart';
 import 'package:oqdo_mobile_app/screens/bazaar/chats/viewmodel/chat_view_model.dart';
 import 'package:provider/provider.dart';
 import 'package:oqdo_mobile_app/oqdo_application.dart';
+import 'package:oqdo_mobile_app/theme/custom_colors.dart';
 
 class ChatsScreen extends StatefulWidget {
   const ChatsScreen({super.key});
@@ -113,7 +114,7 @@ class _ChatsScreenState extends State<ChatsScreen> with SingleTickerProviderStat
                     color: Theme.of(context).colorScheme.background,
                     child: Container(
                       decoration: BoxDecoration(
-                        color: Color(0xFFD4EEF9),
+                        color: Theme.of(context).extension<CustomColors>()!.bazaarTabBackground,
                         borderRadius: BorderRadius.circular(30.0),
                       ),
                       child: Padding(

--- a/lib/screens/bazaar/chats/selling/selling_chat_screen.dart
+++ b/lib/screens/bazaar/chats/selling/selling_chat_screen.dart
@@ -19,6 +19,7 @@ import 'package:oqdo_mobile_app/utils/network_interceptor.dart';
 import 'package:oqdo_mobile_app/utils/string_manager.dart';
 import 'package:progress_dialog_null_safe/progress_dialog_null_safe.dart';
 import 'package:provider/provider.dart';
+import 'package:oqdo_mobile_app/theme/custom_colors.dart';
 
 class SellingChatScreen extends StatefulWidget {
   const SellingChatScreen({super.key, required this.equipmentDetails});
@@ -143,7 +144,7 @@ class _SellingChatScreenState extends State<SellingChatScreen> {
       },
       child: Scaffold(
         resizeToAvoidBottomInset: true,
-        backgroundColor: Color(0xFFEAF3F7),
+        backgroundColor: Theme.of(context).extension<CustomColors>()!.bazaarChatBackground,
         appBar: AppBar(
           toolbarHeight: 80,
           centerTitle: false,
@@ -330,7 +331,7 @@ class _SellingChatScreenState extends State<SellingChatScreen> {
                   : (((!isSentByMe) && isOfferAcceptanceMessage))
                       ? Theme.of(context).colorScheme.background
                       : isSentByMe
-                          ? const Color(0xFFC7DDE7)
+                          ? Theme.of(context).extension<CustomColors>()!.messageLeft
                           : Theme.of(context).colorScheme.background,
               borderRadius: BorderRadius.circular(10),
               boxShadow: [

--- a/lib/theme/custom_colors.dart
+++ b/lib/theme/custom_colors.dart
@@ -33,6 +33,8 @@ class CustomColors extends ThemeExtension<CustomColors> {
     required this.myButtonBgColor,
     required this.coachFacilityFavIconColor,
     required this.showTextColorForCancelAppointment,
+    required this.bazaarTabBackground,
+    required this.bazaarChatBackground,
   });
 
   final Color greyButton;
@@ -66,6 +68,8 @@ class CustomColors extends ThemeExtension<CustomColors> {
   final Color myButtonBgColor;
   final Color coachFacilityFavIconColor;
   final Color showTextColorForCancelAppointment;
+  final Color bazaarTabBackground;
+  final Color bazaarChatBackground;
 
   static const CustomColors light = CustomColors(
     greyButton: Color(0xFFEFEFEF),
@@ -99,6 +103,8 @@ class CustomColors extends ThemeExtension<CustomColors> {
     myButtonBgColor: Color(0xFF006590),
     coachFacilityFavIconColor: Color(0xFFF1F1F1),
     showTextColorForCancelAppointment: Color(0xFFFFFFFF),
+    bazaarTabBackground: Color(0xFFD4EEF9),
+    bazaarChatBackground: Color(0xFFEAF3F7),
   );
 
   static const CustomColors dark = CustomColors(
@@ -133,6 +139,8 @@ class CustomColors extends ThemeExtension<CustomColors> {
     myButtonBgColor : Color(0xFF006590),
     coachFacilityFavIconColor: Color(0xFFFFFFFF),
     showTextColorForCancelAppointment: Color(0xFFFFFFFF),
+    bazaarTabBackground: Color(0xFF2A3540),
+    bazaarChatBackground: Color(0xFF2A2A2A),
   );
 
   @override
@@ -168,6 +176,8 @@ class CustomColors extends ThemeExtension<CustomColors> {
     Color? myButtonBgColor,
     Color? coachFacilityFavIconColor,
     Color? showTextColorForCancelAppointment,
+    Color? bazaarTabBackground,
+    Color? bazaarChatBackground,
   }) {
     return CustomColors(
       greyButton: greyButton ?? this.greyButton,
@@ -201,6 +211,8 @@ class CustomColors extends ThemeExtension<CustomColors> {
       myButtonBgColor: myButtonBgColor ?? this.myButtonBgColor,
       coachFacilityFavIconColor: coachFacilityFavIconColor ?? this.coachFacilityFavIconColor,
       showTextColorForCancelAppointment: showTextColorForCancelAppointment ?? this.showTextColorForCancelAppointment,
+      bazaarTabBackground: bazaarTabBackground ?? this.bazaarTabBackground,
+      bazaarChatBackground: bazaarChatBackground ?? this.bazaarChatBackground,
     );
   }
 
@@ -239,6 +251,8 @@ class CustomColors extends ThemeExtension<CustomColors> {
       myButtonBgColor: Color.lerp(myButtonBgColor, other.myButtonBgColor, t)!,
       coachFacilityFavIconColor: Color.lerp(coachFacilityFavIconColor, other.coachFacilityFavIconColor, t)!,
       showTextColorForCancelAppointment: Color.lerp(showTextColorForCancelAppointment, other.showTextColorForCancelAppointment, t)!,
+      bazaarTabBackground: Color.lerp(bazaarTabBackground, other.bazaarTabBackground, t)!,
+      bazaarChatBackground: Color.lerp(bazaarChatBackground, other.bazaarChatBackground, t)!,
     );
   }
 }


### PR DESCRIPTION
## Summary
- add bazaarTabBackground and bazaarChatBackground colors in CustomColors
- apply theme-based colors to segmented view and bazaar chat screens

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c110bbe1f88332b2a7ef321ecfd585