### PR TITLE
feat: support theme colors for calendar screens

### DIFF
--- a/lib/screens/home/end_user_calendar_screen.dart
+++ b/lib/screens/home/end_user_calendar_screen.dart
@@ -8,7 +8,7 @@ import 'package:intl/intl.dart';
 import 'package:oqdo_mobile_app/model/end_user_appoinments_model.dart';
 import 'package:oqdo_mobile_app/oqdo_application.dart';
 import 'package:oqdo_mobile_app/screens/buddies/features/meetups/data/meetup_response_model.dart';
-import 'package:oqdo_mobile_app/theme/oqdo_theme_data.dart';
+import 'package:oqdo_mobile_app/theme/custom_colors.dart';
 import 'package:oqdo_mobile_app/utils/constants.dart';
 import 'package:oqdo_mobile_app/utils/custom_text_view.dart';
 import 'package:oqdo_mobile_app/utils/network_interceptor.dart';
@@ -64,7 +64,7 @@ class _EndUserCalendarViewScreenState extends State<EndUserCalendarViewScreen> {
   Widget build(BuildContext context) {
     return SafeArea(
       child: Container(
-        color: OQDOThemeData.whiteColor,
+        color: Theme.of(context).colorScheme.background,
         width: MediaQuery.of(context).size.width,
         height: MediaQuery.of(context).size.height,
         child: SingleChildScrollView(
@@ -81,14 +81,20 @@ class _EndUserCalendarViewScreenState extends State<EndUserCalendarViewScreen> {
               ),
               CustomTextView(
                 label: '${_currentDay.split("-")[0]} ${_currentDay.split('-')[1]} ${_currentDay.split('-')[2]}',
-                textStyle: Theme.of(context).textTheme.titleLarge!.copyWith(fontSize: 21, color: const Color(0xFF333333), fontWeight: FontWeight.w500),
+                textStyle: Theme.of(context).textTheme.titleLarge!.copyWith(
+                      fontSize: 21,
+                      color: Theme.of(context).colorScheme.onBackground,
+                      fontWeight: FontWeight.w500),
               ),
               const SizedBox(
                 height: 3,
               ),
               CustomTextView(
                 label: initSelectedDate,
-                textStyle: Theme.of(context).textTheme.titleLarge!.copyWith(fontSize: 21, color: const Color(0xFF333333), fontWeight: FontWeight.w500),
+                textStyle: Theme.of(context).textTheme.titleLarge!.copyWith(
+                      fontSize: 21,
+                      color: Theme.of(context).colorScheme.onBackground,
+                      fontWeight: FontWeight.w500),
               ),
               Padding(
                 padding: const EdgeInsets.only(top: 40, left: 25, right: 25),
@@ -101,14 +107,17 @@ class _EndUserCalendarViewScreenState extends State<EndUserCalendarViewScreen> {
                   daysOfWeekVisible: true,
                   eventLoader: (day) => calendarDateList.where((element) => isSameDay(element, day)).toList(),
                   currentDay: kToday,
-                  daysOfWeekStyle: const DaysOfWeekStyle(
-                      weekdayStyle: TextStyle(color: Color(0xFF006590), fontWeight: FontWeight.w500),
-                      weekendStyle: TextStyle(color: Color(0xFF006590), fontWeight: FontWeight.w500)),
+                  daysOfWeekStyle: DaysOfWeekStyle(
+                      weekdayStyle: TextStyle(color: Theme.of(context).colorScheme.primary, fontWeight: FontWeight.w500),
+                      weekendStyle: TextStyle(color: Theme.of(context).colorScheme.primary, fontWeight: FontWeight.w500)),
                   calendarStyle: CalendarStyle(
                     isTodayHighlighted: true,
                     outsideDaysVisible: false,
                     selectedDecoration: BoxDecoration(color: Theme.of(context).colorScheme.primary, shape: BoxShape.circle),
-                    defaultTextStyle: const TextStyle(fontSize: 15, fontWeight: FontWeight.w400, color: Colors.black),
+                    defaultTextStyle: TextStyle(
+                        fontSize: 15,
+                        fontWeight: FontWeight.w400,
+                        color: Theme.of(context).colorScheme.onSurface),
                   ),
                   onCalendarCreated: (controller) {
                     _pageController = controller;
@@ -156,13 +165,17 @@ class _EndUserCalendarViewScreenState extends State<EndUserCalendarViewScreen> {
                               child: ElevatedButton(
                                 style: ButtonStyle(
                                   backgroundColor: MaterialStateProperty.all<Color>(
-                                    const Color(0xffED8000),
+                                    Theme.of(context)
+                                        .extension<CustomColors>()!
+                                        .meetupButtonColor,
                                   ),
                                   shape: MaterialStateProperty.all<RoundedRectangleBorder>(
                                     RoundedRectangleBorder(
                                         borderRadius: BorderRadius.circular(18.0),
-                                        side: const BorderSide(
-                                          color: Color(0xffED8000),
+                                        side: BorderSide(
+                                          color: Theme.of(context)
+                                              .extension<CustomColors>()!
+                                              .meetupButtonColor,
                                         )),
                                   ),
                                 ),
@@ -177,7 +190,10 @@ class _EndUserCalendarViewScreenState extends State<EndUserCalendarViewScreen> {
                                 },
                                 child: CustomTextView(
                                   label: meetupStr,
-                                  textStyle: const TextStyle(fontWeight: FontWeight.w600, fontSize: 18, color: Colors.white),
+                                  textStyle: TextStyle(
+                                      fontWeight: FontWeight.w600,
+                                      fontSize: 18,
+                                      color: Theme.of(context).colorScheme.onPrimary),
                                 ),
                               ),
                             ),
@@ -191,13 +207,13 @@ class _EndUserCalendarViewScreenState extends State<EndUserCalendarViewScreen> {
                               child: ElevatedButton(
                                 style: ButtonStyle(
                                   backgroundColor: MaterialStateProperty.all<Color>(
-                                    const Color(0xff006590),
+                                    Theme.of(context).colorScheme.primary,
                                   ),
                                   shape: MaterialStateProperty.all<RoundedRectangleBorder>(
                                     RoundedRectangleBorder(
                                       borderRadius: BorderRadius.circular(18.0),
-                                      side: const BorderSide(
-                                        color: Color(0xff006590),
+                                      side: BorderSide(
+                                        color: Theme.of(context).colorScheme.primary,
                                       ),
                                     ),
                                   ),
@@ -207,7 +223,10 @@ class _EndUserCalendarViewScreenState extends State<EndUserCalendarViewScreen> {
                                 },
                                 child: CustomTextView(
                                   label: appointmentStr,
-                                  textStyle: const TextStyle(fontWeight: FontWeight.w600, fontSize: 18, color: Colors.white),
+                                  textStyle: TextStyle(
+                                      fontWeight: FontWeight.w600,
+                                      fontSize: 18,
+                                      color: Theme.of(context).colorScheme.onPrimary),
                                 ),
                               ),
                             ),
@@ -235,14 +254,20 @@ class _EndUserCalendarViewScreenState extends State<EndUserCalendarViewScreen> {
             children: [
               CustomTextView(
                 label: headerText.split(' ')[0],
-                textStyle: Theme.of(context).textTheme.titleLarge!.copyWith(fontSize: 21, fontWeight: FontWeight.w700, color: const Color(0xFF333333)),
+                textStyle: Theme.of(context).textTheme.titleLarge!.copyWith(
+                    fontSize: 21,
+                    fontWeight: FontWeight.w700,
+                    color: Theme.of(context).colorScheme.onBackground),
               ),
               const SizedBox(
                 height: 5,
               ),
               CustomTextView(
                 label: headerText.split(' ')[1],
-                textStyle: Theme.of(context).textTheme.titleLarge!.copyWith(fontSize: 21, fontWeight: FontWeight.w700, color: const Color(0xFF333333)),
+                textStyle: Theme.of(context).textTheme.titleLarge!.copyWith(
+                    fontSize: 21,
+                    fontWeight: FontWeight.w700,
+                    color: Theme.of(context).colorScheme.onBackground),
               ),
             ],
           ),

--- a/lib/screens/home/service_provider_calendar_screen.dart
+++ b/lib/screens/home/service_provider_calendar_screen.dart
@@ -6,7 +6,6 @@ import 'package:oqdo_mobile_app/components/my_button.dart';
 import 'package:oqdo_mobile_app/model/coach_appointments_response_model.dart';
 import 'package:oqdo_mobile_app/model/facility_appointment_resopnse_model.dart';
 import 'package:oqdo_mobile_app/oqdo_application.dart';
-import 'package:oqdo_mobile_app/theme/oqdo_theme_data.dart';
 import 'package:oqdo_mobile_app/utils/constants.dart';
 import 'package:oqdo_mobile_app/utils/custom_text_view.dart';
 import 'package:oqdo_mobile_app/utils/network_interceptor.dart';
@@ -55,7 +54,7 @@ class _ServiceProviderCalendarScreenState extends State<ServiceProviderCalendarS
   Widget build(BuildContext context) {
     return SafeArea(
       child: Container(
-        color: OQDOThemeData.whiteColor,
+        color: Theme.of(context).colorScheme.background,
         width: MediaQuery.of(context).size.width,
         height: MediaQuery.of(context).size.height,
         child: SingleChildScrollView(
@@ -72,14 +71,20 @@ class _ServiceProviderCalendarScreenState extends State<ServiceProviderCalendarS
               ),
               CustomTextView(
                 label: '${_currentDay.split("-")[0]} ${_currentDay.split('-')[1]} ${_currentDay.split('-')[2]}',
-                textStyle: Theme.of(context).textTheme.titleLarge!.copyWith(fontSize: 21, color: const Color(0xFF333333), fontWeight: FontWeight.w500),
+                textStyle: Theme.of(context).textTheme.titleLarge!.copyWith(
+                    fontSize: 21,
+                    color: Theme.of(context).colorScheme.onBackground,
+                    fontWeight: FontWeight.w500),
               ),
               const SizedBox(
                 height: 3,
               ),
               CustomTextView(
                 label: initSelectedDate,
-                textStyle: Theme.of(context).textTheme.titleLarge!.copyWith(fontSize: 21, color: const Color(0xFF333333), fontWeight: FontWeight.w500),
+                textStyle: Theme.of(context).textTheme.titleLarge!.copyWith(
+                    fontSize: 21,
+                    color: Theme.of(context).colorScheme.onBackground,
+                    fontWeight: FontWeight.w500),
               ),
               Padding(
                 padding: const EdgeInsets.only(top: 40, left: 25, right: 25),
@@ -92,14 +97,17 @@ class _ServiceProviderCalendarScreenState extends State<ServiceProviderCalendarS
                   daysOfWeekVisible: true,
                   eventLoader: (day) => calendarDateList.where((element) => isSameDay(element, day)).toList(),
                   currentDay: kToday,
-                  daysOfWeekStyle: const DaysOfWeekStyle(
-                      weekdayStyle: TextStyle(color: Color(0xFF006590), fontWeight: FontWeight.w500),
-                      weekendStyle: TextStyle(color: Color(0xFF006590), fontWeight: FontWeight.w500)),
+                  daysOfWeekStyle: DaysOfWeekStyle(
+                      weekdayStyle: TextStyle(color: Theme.of(context).colorScheme.primary, fontWeight: FontWeight.w500),
+                      weekendStyle: TextStyle(color: Theme.of(context).colorScheme.primary, fontWeight: FontWeight.w500)),
                   calendarStyle: CalendarStyle(
                     isTodayHighlighted: true,
                     outsideDaysVisible: false,
                     selectedDecoration: BoxDecoration(color: Theme.of(context).colorScheme.primary, shape: BoxShape.circle),
-                    defaultTextStyle: const TextStyle(fontSize: 15, fontWeight: FontWeight.w400, color: Colors.black),
+                    defaultTextStyle: TextStyle(
+                        fontSize: 15,
+                        fontWeight: FontWeight.w400,
+                        color: Theme.of(context).colorScheme.onSurface),
                   ),
                   onCalendarCreated: (controller) {
                     _pageController = controller;
@@ -161,14 +169,20 @@ class _ServiceProviderCalendarScreenState extends State<ServiceProviderCalendarS
             children: [
               CustomTextView(
                 label: headerText.split(' ')[0],
-                textStyle: Theme.of(context).textTheme.titleLarge!.copyWith(fontSize: 21, fontWeight: FontWeight.w700, color: const Color(0xFF333333)),
+                textStyle: Theme.of(context).textTheme.titleLarge!.copyWith(
+                    fontSize: 21,
+                    fontWeight: FontWeight.w700,
+                    color: Theme.of(context).colorScheme.onBackground),
               ),
               const SizedBox(
                 height: 5,
               ),
               CustomTextView(
                 label: headerText.split(' ')[1],
-                textStyle: Theme.of(context).textTheme.titleLarge!.copyWith(fontSize: 21, fontWeight: FontWeight.w700, color: const Color(0xFF333333)),
+                textStyle: Theme.of(context).textTheme.titleLarge!.copyWith(
+                    fontSize: 21,
+                    fontWeight: FontWeight.w700,
+                    color: Theme.of(context).colorScheme.onBackground),
               ),
             ],
           ),

--- a/lib/theme/custom_colors.dart
+++ b/lib/theme/custom_colors.dart
@@ -31,6 +31,7 @@ class CustomColors extends ThemeExtension<CustomColors> {
     required this.buddiesCard,
     required this.buddiesBorder,
     required this.myButtonBgColor,
+    required this.meetupButtonColor,
     required this.coachFacilityFavIconColor,
     required this.showTextColorForCancelAppointment,
     required this.bazaarTabBackground,
@@ -66,6 +67,7 @@ class CustomColors extends ThemeExtension<CustomColors> {
   final Color buddiesCard;
   final Color buddiesBorder;
   final Color myButtonBgColor;
+  final Color meetupButtonColor;
   final Color coachFacilityFavIconColor;
   final Color showTextColorForCancelAppointment;
   final Color bazaarTabBackground;
@@ -101,6 +103,7 @@ class CustomColors extends ThemeExtension<CustomColors> {
     buddiesCard: Color(0xFFF1F1F1),
     buddiesBorder: Color(0xFFCFCFCF),
     myButtonBgColor: Color(0xFF006590),
+    meetupButtonColor: Color(0xFFED8000),
     coachFacilityFavIconColor: Color(0xFFF1F1F1),
     showTextColorForCancelAppointment: Color(0xFFFFFFFF),
     bazaarTabBackground: Color(0xFFD4EEF9),
@@ -137,6 +140,7 @@ class CustomColors extends ThemeExtension<CustomColors> {
     buddiesCard: Color(0xFF333333),
     buddiesBorder: Color(0xFF404040),
     myButtonBgColor : Color(0xFF006590),
+    meetupButtonColor: Color(0xFFFFB74D),
     coachFacilityFavIconColor: Color(0xFFFFFFFF),
     showTextColorForCancelAppointment: Color(0xFFFFFFFF),
     bazaarTabBackground: Color(0xFF2A3540),
@@ -174,6 +178,7 @@ class CustomColors extends ThemeExtension<CustomColors> {
     Color? buddiesCard,
     Color? buddiesBorder,
     Color? myButtonBgColor,
+    Color? meetupButtonColor,
     Color? coachFacilityFavIconColor,
     Color? showTextColorForCancelAppointment,
     Color? bazaarTabBackground,
@@ -209,6 +214,7 @@ class CustomColors extends ThemeExtension<CustomColors> {
       buddiesCard: buddiesCard ?? this.buddiesCard,
       buddiesBorder: buddiesBorder ?? this.buddiesBorder,
       myButtonBgColor: myButtonBgColor ?? this.myButtonBgColor,
+      meetupButtonColor: meetupButtonColor ?? this.meetupButtonColor,
       coachFacilityFavIconColor: coachFacilityFavIconColor ?? this.coachFacilityFavIconColor,
       showTextColorForCancelAppointment: showTextColorForCancelAppointment ?? this.showTextColorForCancelAppointment,
       bazaarTabBackground: bazaarTabBackground ?? this.bazaarTabBackground,
@@ -249,6 +255,7 @@ class CustomColors extends ThemeExtension<CustomColors> {
       buddiesCard: Color.lerp(buddiesCard, other.buddiesCard, t)!,
       buddiesBorder: Color.lerp(buddiesBorder, other.buddiesBorder, t)!,
       myButtonBgColor: Color.lerp(myButtonBgColor, other.myButtonBgColor, t)!,
+      meetupButtonColor: Color.lerp(meetupButtonColor, other.meetupButtonColor, t)!,
       coachFacilityFavIconColor: Color.lerp(coachFacilityFavIconColor, other.coachFacilityFavIconColor, t)!,
       showTextColorForCancelAppointment: Color.lerp(showTextColorForCancelAppointment, other.showTextColorForCancelAppointment, t)!,
       bazaarTabBackground: Color.lerp(bazaarTabBackground, other.bazaarTabBackground, t)!,


### PR DESCRIPTION
## Summary
- integrate theme-aware colors for end-user and service provider calendar screens
- add `meetupButtonColor` to custom colors for themed orange button

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c3aafa93808332b9caa62ad7526816