### PR TITLE
feat: apply theme to meetup screens

### DIFF
--- a/lib/screens/buddies/features/meetups/presentation/add_meetup_screen.dart
+++ b/lib/screens/buddies/features/meetups/presentation/add_meetup_screen.dart
@@ -9,7 +9,6 @@ import 'package:oqdo_mobile_app/components/my_button.dart';
 import 'package:oqdo_mobile_app/oqdo_application.dart';
 import 'package:oqdo_mobile_app/screens/buddies/features/meetups/data/friend_list_repsonse_model.dart';
 import 'package:oqdo_mobile_app/screens/buddies/features/meetups/data/meet_up_repository.dart';
-import 'package:oqdo_mobile_app/theme/oqdo_theme_data.dart';
 import 'package:oqdo_mobile_app/utils/constants.dart';
 import 'package:oqdo_mobile_app/utils/custom_text_view.dart';
 import 'package:oqdo_mobile_app/utils/network_interceptor.dart';
@@ -65,7 +64,7 @@ class _AddMeetupScreenState extends State<AddMeetupScreen> {
         child: Container(
           height: MediaQuery.of(context).size.height,
           width: MediaQuery.of(context).size.width,
-          color: OQDOThemeData.whiteColor,
+          color: Theme.of(context).colorScheme.background,
           padding: const EdgeInsets.only(top: 20, left: 20, right: 20, bottom: 20),
           child: SingleChildScrollView(
             child: Column(
@@ -508,8 +507,8 @@ class _AddMeetupScreenState extends State<AddMeetupScreen> {
                   height: 10,
                 ),
                 ListView.separated(
-                  separatorBuilder: (context, index) => const Divider(
-                    color: OQDOThemeData.greyColor,
+                  separatorBuilder: (context, index) => Divider(
+                    color: Theme.of(context).extension<CustomColors>()!.buddiesBorder,
                     height: 1,
                   ),
                   shrinkWrap: true,
@@ -587,7 +586,7 @@ class _AddMeetupScreenState extends State<AddMeetupScreen> {
             label: '${frindListResponse.firstName} ${frindListResponse.lastName}',
             maxLine: 2,
             textOverFlow: TextOverflow.ellipsis,
-            textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 18.0, fontWeight: FontWeight.w500, color: OQDOThemeData.greyColor),
+            textStyle: Theme.of(context).textTheme.titleMedium!.copyWith(fontSize: 18.0, fontWeight: FontWeight.w500, color: Theme.of(context).extension<CustomColors>()!.chipText),
           ),
         ),
       ],

--- a/lib/screens/buddies/features/meetups/presentation/meetup_details_screen.dart
+++ b/lib/screens/buddies/features/meetups/presentation/meetup_details_screen.dart
@@ -10,7 +10,6 @@ import 'package:oqdo_mobile_app/helper/helpers.dart';
 import 'package:oqdo_mobile_app/oqdo_application.dart';
 import 'package:oqdo_mobile_app/screens/buddies/features/meetups/data/meet_up_repository.dart';
 import 'package:oqdo_mobile_app/screens/buddies/features/meetups/data/meetup_response_model.dart';
-import 'package:oqdo_mobile_app/theme/oqdo_theme_data.dart';
 import 'package:oqdo_mobile_app/utils/constants.dart';
 import 'package:oqdo_mobile_app/utils/custom_text_view.dart';
 import 'package:oqdo_mobile_app/utils/network_interceptor.dart';
@@ -64,7 +63,7 @@ class _MeetupDetailsScreenState extends State<MeetupDetailsScreen> {
         child: Container(
           width: MediaQuery.of(context).size.width,
           height: MediaQuery.of(context).size.height,
-          color: OQDOThemeData.whiteColor,
+          color: Theme.of(context).colorScheme.background,
           child: SingleChildScrollView(
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
@@ -86,12 +85,12 @@ class _MeetupDetailsScreenState extends State<MeetupDetailsScreen> {
                                       Expanded(
                                         child: SimpleButton(
                                           text: "Deny",
-                                          textcolor: OQDOThemeData.buttonColor,
+                                          textcolor: Theme.of(context).colorScheme.primary,
                                           textsize: 13,
                                           fontWeight: FontWeight.w600,
                                           letterspacing: 0.7,
-                                          buttoncolor: OQDOThemeData.whiteColor,
-                                          buttonbordercolor: OQDOThemeData.buttonColor,
+                                          buttoncolor: Theme.of(context).colorScheme.background,
+                                          buttonbordercolor: Theme.of(context).colorScheme.primary,
                                           buttonheight: 50,
                                           buttonwidth: MediaQuery.of(context).size.width / 2,
                                           radius: 0,
@@ -102,7 +101,7 @@ class _MeetupDetailsScreenState extends State<MeetupDetailsScreen> {
                                                   return Dialog(
                                                     shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(20.0)), //this right here
                                                     child: Container(
-                                                      color: OQDOThemeData.whiteColor,
+                                                      color: Theme.of(context).colorScheme.background,
                                                       height: 300,
                                                       child: Padding(
                                                         padding: const EdgeInsets.all(12.0),
@@ -118,7 +117,7 @@ class _MeetupDetailsScreenState extends State<MeetupDetailsScreen> {
                                                               textStyle: Theme.of(context)
                                                                   .textTheme
                                                                   .bodyMedium!
-                                                                  .copyWith(fontSize: 18, color: OQDOThemeData.blackColor, fontWeight: FontWeight.bold),
+                                                                  .copyWith(fontSize: 18, color: Theme.of(context).colorScheme.onBackground, fontWeight: FontWeight.bold),
                                                             ),
                                                             const SizedBox(
                                                               height: 10,
@@ -143,12 +142,12 @@ class _MeetupDetailsScreenState extends State<MeetupDetailsScreen> {
                                                                 Expanded(
                                                                   child: SimpleButton(
                                                                     text: "Cancel",
-                                                                    textcolor: OQDOThemeData.buttonColor,
+                                                                    textcolor: Theme.of(context).colorScheme.primary,
                                                                     textsize: 13,
                                                                     fontWeight: FontWeight.w600,
                                                                     letterspacing: 0.7,
-                                                                    buttoncolor: OQDOThemeData.whiteColor,
-                                                                    buttonbordercolor: OQDOThemeData.buttonColor,
+                                                                    buttoncolor: Theme.of(context).colorScheme.background,
+                                                                    buttonbordercolor: Theme.of(context).colorScheme.primary,
                                                                     buttonheight: 50,
                                                                     buttonwidth: MediaQuery.of(context).size.width / 2,
                                                                     radius: 0,
@@ -160,12 +159,12 @@ class _MeetupDetailsScreenState extends State<MeetupDetailsScreen> {
                                                                 Expanded(
                                                                   child: SimpleButton(
                                                                     text: 'Send',
-                                                                    textcolor: OQDOThemeData.whiteColor,
+                                                                    textcolor: Theme.of(context).colorScheme.onPrimary,
                                                                     textsize: 13,
                                                                     fontWeight: FontWeight.w600,
                                                                     letterspacing: 0.7,
-                                                                    buttoncolor: OQDOThemeData.buttonColor,
-                                                                    buttonbordercolor: OQDOThemeData.buttonColor,
+                                                                    buttoncolor: Theme.of(context).colorScheme.primary,
+                                                                    buttonbordercolor: Theme.of(context).colorScheme.primary,
                                                                     buttonheight: 50,
                                                                     buttonwidth: MediaQuery.of(context).size.width / 2,
                                                                     radius: 0,
@@ -189,12 +188,12 @@ class _MeetupDetailsScreenState extends State<MeetupDetailsScreen> {
                                       Expanded(
                                         child: SimpleButton(
                                           text: 'Accept',
-                                          textcolor: OQDOThemeData.whiteColor,
+                                          textcolor: Theme.of(context).colorScheme.onPrimary,
                                           textsize: 13,
                                           fontWeight: FontWeight.w600,
                                           letterspacing: 0.7,
-                                          buttoncolor: OQDOThemeData.buttonColor,
-                                          buttonbordercolor: OQDOThemeData.buttonColor,
+                                          buttoncolor: Theme.of(context).colorScheme.primary,
+                                          buttonbordercolor: Theme.of(context).colorScheme.primary,
                                           buttonheight: 50,
                                           buttonwidth: MediaQuery.of(context).size.width / 2,
                                           radius: 0,
@@ -352,12 +351,12 @@ class _MeetupDetailsScreenState extends State<MeetupDetailsScreen> {
                             alignment: Alignment.center,
                             child: SimpleButton(
                               text: "Cancel Meetup",
-                              textcolor: OQDOThemeData.buttonColor,
+                              textcolor: Theme.of(context).colorScheme.primary,
                               textsize: 13,
                               fontWeight: FontWeight.w600,
                               letterspacing: 0.7,
-                              buttoncolor: OQDOThemeData.whiteColor,
-                              buttonbordercolor: OQDOThemeData.buttonColor,
+                              buttoncolor: Theme.of(context).colorScheme.background,
+                              buttonbordercolor: Theme.of(context).colorScheme.primary,
                               buttonheight: 50,
                               buttonwidth: MediaQuery.of(context).size.width / 2,
                               radius: 0,
@@ -368,7 +367,7 @@ class _MeetupDetailsScreenState extends State<MeetupDetailsScreen> {
                                       return Dialog(
                                         shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(20.0)), //this right here
                                         child: Container(
-                                          color: OQDOThemeData.whiteColor,
+                                          color: Theme.of(context).colorScheme.background,
                                           height: 300,
                                           child: Padding(
                                             padding: const EdgeInsets.all(12.0),
@@ -384,7 +383,7 @@ class _MeetupDetailsScreenState extends State<MeetupDetailsScreen> {
                                                   textStyle: Theme.of(context)
                                                       .textTheme
                                                       .bodyMedium!
-                                                      .copyWith(fontSize: 18, color: OQDOThemeData.blackColor, fontWeight: FontWeight.bold),
+                                                      .copyWith(fontSize: 18, color: Theme.of(context).colorScheme.onBackground, fontWeight: FontWeight.bold),
                                                 ),
                                                 const SizedBox(
                                                   height: 10,
@@ -409,12 +408,12 @@ class _MeetupDetailsScreenState extends State<MeetupDetailsScreen> {
                                                     Expanded(
                                                       child: SimpleButton(
                                                         text: "Cancel",
-                                                        textcolor: OQDOThemeData.buttonColor,
+                                                        textcolor: Theme.of(context).colorScheme.primary,
                                                         textsize: 13,
                                                         fontWeight: FontWeight.w600,
                                                         letterspacing: 0.7,
-                                                        buttoncolor: OQDOThemeData.whiteColor,
-                                                        buttonbordercolor: OQDOThemeData.buttonColor,
+                                                        buttoncolor: Theme.of(context).colorScheme.background,
+                                                        buttonbordercolor: Theme.of(context).colorScheme.primary,
                                                         buttonheight: 50,
                                                         buttonwidth: MediaQuery.of(context).size.width / 2,
                                                         radius: 0,
@@ -426,12 +425,12 @@ class _MeetupDetailsScreenState extends State<MeetupDetailsScreen> {
                                                     Expanded(
                                                       child: SimpleButton(
                                                         text: 'Send',
-                                                        textcolor: OQDOThemeData.whiteColor,
+                                                        textcolor: Theme.of(context).colorScheme.onPrimary,
                                                         textsize: 13,
                                                         fontWeight: FontWeight.w600,
                                                         letterspacing: 0.7,
-                                                        buttoncolor: OQDOThemeData.buttonColor,
-                                                        buttonbordercolor: OQDOThemeData.buttonColor,
+                                                        buttoncolor: Theme.of(context).colorScheme.primary,
+                                                        buttonbordercolor: Theme.of(context).colorScheme.primary,
                                                         buttonheight: 50,
                                                         buttonwidth: MediaQuery.of(context).size.width / 2,
                                                         radius: 0,
@@ -480,7 +479,7 @@ class _MeetupDetailsScreenState extends State<MeetupDetailsScreen> {
               Container(
                 decoration: BoxDecoration(
                   shape: BoxShape.rectangle,
-                  border: Border.all(width: 7.0, color: const Color.fromRGBO(0, 101, 144, 0.5)),
+                  border: Border.all(width: 7.0, color: Theme.of(context).colorScheme.primary.withOpacity(0.5)),
                 ),
               ),
               const SizedBox(width: 20.0),
@@ -518,7 +517,7 @@ class _MeetupDetailsScreenState extends State<MeetupDetailsScreen> {
               ),
               CustomTextView(
                 label: widget.meetupResponse!.name,
-                textStyle: Theme.of(context).textTheme.titleSmall!.copyWith(fontWeight: FontWeight.w500, fontSize: 18.0, color: OQDOThemeData.greyColor),
+                textStyle: Theme.of(context).textTheme.titleSmall!.copyWith(fontWeight: FontWeight.w500, fontSize: 18.0, color: Theme.of(context).extension<CustomColors>()!.chipText),
               ),
             ],
           ),

--- a/lib/screens/buddies/features/meetups/presentation/meetup_list_screen.dart
+++ b/lib/screens/buddies/features/meetups/presentation/meetup_list_screen.dart
@@ -6,7 +6,6 @@ import 'package:intl/intl.dart';
 import 'package:oqdo_mobile_app/components/custom_app_bar.dart';
 import 'package:oqdo_mobile_app/screens/buddies/features/meetups/data/meet_up_repository.dart';
 import 'package:oqdo_mobile_app/screens/buddies/features/meetups/data/meetup_response_model.dart';
-import 'package:oqdo_mobile_app/theme/oqdo_theme_data.dart';
 import 'package:oqdo_mobile_app/utils/constants.dart';
 import 'package:oqdo_mobile_app/utils/custom_text_view.dart';
 import 'package:oqdo_mobile_app/utils/network_interceptor.dart';
@@ -92,7 +91,7 @@ class _MeetupListScreenState extends State<MeetupListScreen> {
         ),
         body: SafeArea(
             child: Container(
-          color: OQDOThemeData.whiteColor,
+          color: Theme.of(context).colorScheme.background,
           height: MediaQuery.of(context).size.height,
           width: MediaQuery.of(context).size.width,
           child: Column(
@@ -141,7 +140,7 @@ class _MeetupListScreenState extends State<MeetupListScreen> {
                                             padding: const EdgeInsets.all(2.0),
                                             child: Card(
                                               semanticContainer: true,
-                                              color: const Color.fromRGBO(237, 237, 237, 1),
+                                              color: Theme.of(context).extension<CustomColors>()!.meetupEmptyCard,
                                               clipBehavior: Clip.antiAliasWithSaveLayer,
                                               elevation: 4.0,
                                               shape: const RoundedRectangleBorder(borderRadius: BorderRadius.all(Radius.circular(10))),
@@ -189,7 +188,7 @@ class _MeetupListScreenState extends State<MeetupListScreen> {
                                                         textStyle: Theme.of(context)
                                                             .textTheme
                                                             .titleSmall!
-                                                            .copyWith(fontWeight: FontWeight.w500, fontSize: 15.0, color: OQDOThemeData.greyColor),
+                                                            .copyWith(fontWeight: FontWeight.w500, fontSize: 15.0, color: Theme.of(context).extension<CustomColors>()!.chipText),
                                                       ),
                                                     ],
                                                   ),
@@ -220,7 +219,7 @@ class _MeetupListScreenState extends State<MeetupListScreen> {
                                 textStyle: Theme.of(context)
                                     .textTheme
                                     .titleMedium!
-                                    .copyWith(fontSize: 16, color: OQDOThemeData.greyColor, fontWeight: FontWeight.w500),
+                                    .copyWith(fontSize: 16, color: Theme.of(context).extension<CustomColors>()!.chipText, fontWeight: FontWeight.w500),
                               ),
                             ],
                           ),
@@ -389,7 +388,9 @@ class _MeetupListScreenState extends State<MeetupListScreen> {
           padding: const EdgeInsets.all(2.0),
           child: Card(
             semanticContainer: true,
-            color: model.isCreator! ? const Color.fromRGBO(255, 250, 235, 1) : const Color.fromRGBO(234, 242, 246, 1),
+            color: model.isCreator!
+                ? Theme.of(context).extension<CustomColors>()!.meetupCreatorCard
+                : Theme.of(context).extension<CustomColors>()!.meetupParticipantCard,
             clipBehavior: Clip.antiAliasWithSaveLayer,
             elevation: 4.0,
             shape: const RoundedRectangleBorder(borderRadius: BorderRadius.all(Radius.circular(10))),
@@ -440,7 +441,7 @@ class _MeetupListScreenState extends State<MeetupListScreen> {
                         maxLine: 2,
                         textOverFlow: TextOverflow.ellipsis,
                         textStyle:
-                            Theme.of(context).textTheme.titleSmall!.copyWith(fontWeight: FontWeight.w500, fontSize: 15.0, color: OQDOThemeData.greyColor),
+                            Theme.of(context).textTheme.titleSmall!.copyWith(fontWeight: FontWeight.w500, fontSize: 15.0, color: Theme.of(context).extension<CustomColors>()!.chipText),
                       ),
                       const SizedBox(
                         height: 8.0,
@@ -448,7 +449,7 @@ class _MeetupListScreenState extends State<MeetupListScreen> {
                       CustomTextView(
                         label: '${model.startFrom} - ${model.endAt}',
                         textStyle:
-                            Theme.of(context).textTheme.titleSmall!.copyWith(fontSize: 14.0, fontWeight: FontWeight.w400, color: OQDOThemeData.greyColor),
+                            Theme.of(context).textTheme.titleSmall!.copyWith(fontSize: 14.0, fontWeight: FontWeight.w400, color: Theme.of(context).extension<CustomColors>()!.chipText),
                       )
                     ],
                   ),

--- a/lib/theme/custom_colors.dart
+++ b/lib/theme/custom_colors.dart
@@ -36,6 +36,9 @@ class CustomColors extends ThemeExtension<CustomColors> {
     required this.showTextColorForCancelAppointment,
     required this.bazaarTabBackground,
     required this.bazaarChatBackground,
+    required this.meetupCreatorCard,
+    required this.meetupParticipantCard,
+    required this.meetupEmptyCard,
   });
 
   final Color greyButton;
@@ -72,6 +75,9 @@ class CustomColors extends ThemeExtension<CustomColors> {
   final Color showTextColorForCancelAppointment;
   final Color bazaarTabBackground;
   final Color bazaarChatBackground;
+  final Color meetupCreatorCard;
+  final Color meetupParticipantCard;
+  final Color meetupEmptyCard;
 
   static const CustomColors light = CustomColors(
     greyButton: Color(0xFFEFEFEF),
@@ -108,6 +114,9 @@ class CustomColors extends ThemeExtension<CustomColors> {
     showTextColorForCancelAppointment: Color(0xFFFFFFFF),
     bazaarTabBackground: Color(0xFFD4EEF9),
     bazaarChatBackground: Color(0xFFEAF3F7),
+    meetupCreatorCard: Color(0xFFFFFAEB),
+    meetupParticipantCard: Color(0xFFEAF2F6),
+    meetupEmptyCard: Color(0xFFEDEDED),
   );
 
   static const CustomColors dark = CustomColors(
@@ -145,6 +154,9 @@ class CustomColors extends ThemeExtension<CustomColors> {
     showTextColorForCancelAppointment: Color(0xFFFFFFFF),
     bazaarTabBackground: Color(0xFF2A3540),
     bazaarChatBackground: Color(0xFF2A2A2A),
+    meetupCreatorCard: Color(0xFF3B3628),
+    meetupParticipantCard: Color(0xFF2A3540),
+    meetupEmptyCard: Color(0xFF2A2A2A),
   );
 
   @override
@@ -183,6 +195,9 @@ class CustomColors extends ThemeExtension<CustomColors> {
     Color? showTextColorForCancelAppointment,
     Color? bazaarTabBackground,
     Color? bazaarChatBackground,
+    Color? meetupCreatorCard,
+    Color? meetupParticipantCard,
+    Color? meetupEmptyCard,
   }) {
     return CustomColors(
       greyButton: greyButton ?? this.greyButton,
@@ -219,6 +234,9 @@ class CustomColors extends ThemeExtension<CustomColors> {
       showTextColorForCancelAppointment: showTextColorForCancelAppointment ?? this.showTextColorForCancelAppointment,
       bazaarTabBackground: bazaarTabBackground ?? this.bazaarTabBackground,
       bazaarChatBackground: bazaarChatBackground ?? this.bazaarChatBackground,
+      meetupCreatorCard: meetupCreatorCard ?? this.meetupCreatorCard,
+      meetupParticipantCard: meetupParticipantCard ?? this.meetupParticipantCard,
+      meetupEmptyCard: meetupEmptyCard ?? this.meetupEmptyCard,
     );
   }
 
@@ -257,10 +275,14 @@ class CustomColors extends ThemeExtension<CustomColors> {
       myButtonBgColor: Color.lerp(myButtonBgColor, other.myButtonBgColor, t)!,
       meetupButtonColor: Color.lerp(meetupButtonColor, other.meetupButtonColor, t)!,
       coachFacilityFavIconColor: Color.lerp(coachFacilityFavIconColor, other.coachFacilityFavIconColor, t)!,
-      showTextColorForCancelAppointment: Color.lerp(showTextColorForCancelAppointment, other.showTextColorForCancelAppointment, t)!,
+      showTextColorForCancelAppointment:
+          Color.lerp(showTextColorForCancelAppointment, other.showTextColorForCancelAppointment, t)!,
       bazaarTabBackground: Color.lerp(bazaarTabBackground, other.bazaarTabBackground, t)!,
       bazaarChatBackground: Color.lerp(bazaarChatBackground, other.bazaarChatBackground, t)!,
+      meetupCreatorCard: Color.lerp(meetupCreatorCard, other.meetupCreatorCard, t)!,
+      meetupParticipantCard: Color.lerp(meetupParticipantCard, other.meetupParticipantCard, t)!,
+      meetupEmptyCard: Color.lerp(meetupEmptyCard, other.meetupEmptyCard, t)!,
     );
+    }
   }
-}
 


### PR DESCRIPTION
## Summary
- add meetup card colors for light and dark themes
- migrate meetup screens to use Theme/CustomColors

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c3b027358483328140ddb6a7731d4b