### PR TITLE
feat: apply theme colors to transaction history

### DIFF
--- a/lib/screens/home/all_transaction_list.dart
+++ b/lib/screens/home/all_transaction_list.dart
@@ -60,7 +60,7 @@ class _AllTransactionListState extends State<AllTransactionList> with AutomaticK
     return Container(
       width: width,
       height: height,
-      color: Theme.of(context).colorScheme.onBackground,
+      color: Theme.of(context).extension<CustomColors>()!.white,
       child: Padding(
         padding: const EdgeInsets.fromLTRB(15, 8, 15, 0),
         child: transactions.isNotEmpty
@@ -89,7 +89,7 @@ class _AllTransactionListState extends State<AllTransactionList> with AutomaticK
                                 Expanded(
                                   child: Text(
                                     "$formattedDate $time",
-                                    style: const TextStyle(fontWeight: FontWeight.w600, color: Colors.black, fontSize: 15),
+                                    style: TextStyle(fontWeight: FontWeight.w600, color: Theme.of(context).colorScheme.onBackground, fontSize: 15),
                                     overflow: TextOverflow.ellipsis,
                                   ),
                                 ),
@@ -123,7 +123,7 @@ class _AllTransactionListState extends State<AllTransactionList> with AutomaticK
                               child: Text(
                                 'Booking No. ${transactions[index].bookingNo!}',
                                 maxLines: 3,
-                                style: const TextStyle(fontSize: 14, color: Colors.black87, fontWeight: FontWeight.w500),
+                                style: TextStyle(fontSize: 14, color: Theme.of(context).colorScheme.onBackground, fontWeight: FontWeight.w500),
                                 overflow: TextOverflow.ellipsis,
                               ),
                             ),
@@ -155,7 +155,7 @@ class _AllTransactionListState extends State<AllTransactionList> with AutomaticK
                       );
                     },
                     separatorBuilder: (context, index) {
-                      return const Divider();
+                      return Divider(color: Theme.of(context).extension<CustomColors>()!.filterDivider);
                     },
                   ),
                   isLoading
@@ -178,10 +178,11 @@ class _AllTransactionListState extends State<AllTransactionList> with AutomaticK
                       valueColor: AlwaysStoppedAnimation(Theme.of(context).colorScheme.primary),
                     ),
                   )
-                : const Center(
+                : Center(
                     child: Padding(
-                    padding: EdgeInsets.all(40.0),
-                    child: Text('No Transaction Found!'),
+                    padding: const EdgeInsets.all(40.0),
+                    child: Text('No Transaction Found!',
+                        style: TextStyle(color: Theme.of(context).colorScheme.onBackground)),
                   )),
       ),
     );

--- a/lib/screens/home/refund_transaction_list.dart
+++ b/lib/screens/home/refund_transaction_list.dart
@@ -60,7 +60,7 @@ class _RefundTransactionListState extends State<RefundTransactionList> with Auto
     return Container(
         width: width,
         height: height,
-        color: Theme.of(context).colorScheme.onBackground,
+        color: Theme.of(context).extension<CustomColors>()!.white,
         child: Padding(
           padding: const EdgeInsets.fromLTRB(15, 8, 15, 0),
           child: transactions.isNotEmpty
@@ -92,7 +92,7 @@ class _RefundTransactionListState extends State<RefundTransactionList> with Auto
                                   Expanded(
                                     child: Text(
                                       "$formattedDate $time",
-                                      style: const TextStyle(fontWeight: FontWeight.w600, color: Colors.black, fontSize: 15),
+                                      style: TextStyle(fontWeight: FontWeight.w600, color: Theme.of(context).colorScheme.onBackground, fontSize: 15),
                                       overflow: TextOverflow.ellipsis,
                                     ),
                                   ),
@@ -126,7 +126,7 @@ class _RefundTransactionListState extends State<RefundTransactionList> with Auto
                                 child: Text(
                                   'Booking No. ${transactions[index].bookingNo!}',
                                   maxLines: 3,
-                                  style: const TextStyle(fontSize: 14, color: Colors.black87, fontWeight: FontWeight.w500),
+                                  style: TextStyle(fontSize: 14, color: Theme.of(context).colorScheme.onBackground, fontWeight: FontWeight.w500),
                                   overflow: TextOverflow.ellipsis,
                                 ),
                               ),
@@ -139,7 +139,7 @@ class _RefundTransactionListState extends State<RefundTransactionList> with Auto
                                     child: Text(
                                       "Date : ${bookFormatDate.toString()},",
                                       maxLines: 3,
-                                      style: const TextStyle(fontSize: 14, color: Colors.black87, fontWeight: FontWeight.w500),
+                                      style: TextStyle(fontSize: 14, color: Theme.of(context).colorScheme.onBackground, fontWeight: FontWeight.w500),
                                       overflow: TextOverflow.ellipsis,
                                     ),
                                   ),
@@ -148,7 +148,7 @@ class _RefundTransactionListState extends State<RefundTransactionList> with Auto
                                     child: Text(
                                       "${transactions[index].startTime.toString()} - ${transactions[index].endTime.toString()}",
                                       maxLines: 3,
-                                      style: const TextStyle(fontSize: 14, color: Colors.black87, fontWeight: FontWeight.w600),
+                                      style: TextStyle(fontSize: 14, color: Theme.of(context).colorScheme.onBackground, fontWeight: FontWeight.w600),
                                       overflow: TextOverflow.ellipsis,
                                     ),
                                   ),
@@ -162,7 +162,7 @@ class _RefundTransactionListState extends State<RefundTransactionList> with Auto
                                 child: Text(
                                   'Cancellation Reason : ${transactions[index].cancelReason == null || transactions[index].cancelReason!.isEmpty ? transactions[index].otherReason ?? "" : transactions[index].cancelReason ?? ""}',
                                   maxLines: 3,
-                                  style: const TextStyle(fontSize: 14, color: Colors.black87, fontWeight: FontWeight.w500),
+                                  style: TextStyle(fontSize: 14, color: Theme.of(context).colorScheme.onBackground, fontWeight: FontWeight.w500),
                                   overflow: TextOverflow.ellipsis,
                                 ),
                               ),
@@ -194,7 +194,7 @@ class _RefundTransactionListState extends State<RefundTransactionList> with Auto
                         );
                       },
                       separatorBuilder: (context, index) {
-                        return const Divider();
+                        return Divider(color: Theme.of(context).extension<CustomColors>()!.filterDivider);
                       },
                     ),
                     isLoading
@@ -217,10 +217,11 @@ class _RefundTransactionListState extends State<RefundTransactionList> with Auto
                         valueColor: AlwaysStoppedAnimation(Theme.of(context).colorScheme.primary),
                       ),
                     )
-                  : const Center(
+                  : Center(
                       child: Padding(
-                      padding: EdgeInsets.all(40.0),
-                      child: Text('No Refund Found!'),
+                      padding: const EdgeInsets.all(40.0),
+                      child: Text('No Refund Found!',
+                          style: TextStyle(color: Theme.of(context).colorScheme.onBackground)),
                     )),
         ));
   }

--- a/lib/screens/home/transaction_history_page.dart
+++ b/lib/screens/home/transaction_history_page.dart
@@ -56,7 +56,7 @@ class _TransactionHistoryPageState extends State<TransactionHistoryPage> with Si
     return DefaultTabController(
       length: 2,
       child: Scaffold(
-          backgroundColor: Colors.white,
+          backgroundColor: Theme.of(context).extension<CustomColors>()!.white,
           appBar: CustomAppBar(
               title: 'Transaction History',
               onBack: () {


### PR DESCRIPTION
## Summary
- use theme extension colors for TransactionHistoryPage background
- replace hardcoded colors in AllTransactionList and RefundTransactionList with theme-driven values
- ensure empty states and dividers respect current theme

## Testing
- `dart format lib/screens/home/transaction_history_page.dart lib/screens/home/all_transaction_list.dart lib/screens/home/refund_transaction_list.dart` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c3c58e05d483329d8f87b491235d2f