### PR TITLE
feat: add theme support to facility setup screens

### DIFF
--- a/lib/screens/setup/facility_setup/view/create_facility_setup_page.dart
+++ b/lib/screens/setup/facility_setup/view/create_facility_setup_page.dart
@@ -9,7 +9,6 @@ import 'package:oqdo_mobile_app/screens/setup/facility_setup/viewmodel/stepper_m
 import 'package:oqdo_mobile_app/screens/setup/setups_bottom_sheets/Show24HrsAleartBottomSheet.dart';
 import 'package:oqdo_mobile_app/screens/setup/setups_bottom_sheets/ShowEditFacilityCoachChangesBottomSheet.dart';
 import 'package:oqdo_mobile_app/screens/setup/setups_bottom_sheets/ShowSaveDiscardBottomSheet.dart';
-import 'package:oqdo_mobile_app/theme/oqdo_theme_data.dart';
 import 'package:oqdo_mobile_app/utils/constants.dart';
 import 'package:progress_dialog_null_safe/progress_dialog_null_safe.dart';
 import 'package:provider/provider.dart';
@@ -82,7 +81,7 @@ class CreateFacilitySetupPage extends StatelessWidget {
         ),
       ),
       clipBehavior: Clip.antiAliasWithSaveLayer,
-      backgroundColor: OQDOThemeData.whiteColor,
+      backgroundColor: Theme.of(context).colorScheme.surface,
       builder: (ctx) => const Show24HrsAlearBottomSheet(),
     ).then((value) {
       if (value != null) {
@@ -113,7 +112,7 @@ class CreateFacilitySetupPage extends StatelessWidget {
           ),
         ),
         clipBehavior: Clip.antiAliasWithSaveLayer,
-        backgroundColor: OQDOThemeData.whiteColor,
+        backgroundColor: Theme.of(context).colorScheme.surface,
         builder: (ctx) => ShowEditFacilityCoachChangesBottomSheet(
           type: 'F',
         ),
@@ -132,7 +131,7 @@ class CreateFacilitySetupPage extends StatelessWidget {
                 ),
               ),
               clipBehavior: Clip.antiAliasWithSaveLayer,
-              backgroundColor: OQDOThemeData.whiteColor,
+              backgroundColor: Theme.of(context).colorScheme.surface,
               builder: (ctx) => const Show24HrsAlearBottomSheet(),
             ).then((value) {
               if (value != null) {
@@ -180,7 +179,7 @@ class CreateFacilitySetupPage extends StatelessWidget {
                       ),
                     ),
                     clipBehavior: Clip.antiAliasWithSaveLayer,
-                    backgroundColor: OQDOThemeData.whiteColor,
+                    backgroundColor: Theme.of(context).colorScheme.surface,
                     builder: (ctx) => const Show24HrsAlearBottomSheet(),
                   ).then((value) {
                     if (value != null) {
@@ -228,7 +227,7 @@ class CreateFacilitySetupPage extends StatelessWidget {
           ),
         ),
         clipBehavior: Clip.antiAliasWithSaveLayer,
-        backgroundColor: OQDOThemeData.whiteColor,
+        backgroundColor: Theme.of(context).colorScheme.surface,
         builder: (ctx) => const Show24HrsAlearBottomSheet(),
       ).then((value) {
         if (value != null) {

--- a/lib/screens/setup/facility_setup/view/facility_training_preview_page.dart
+++ b/lib/screens/setup/facility_setup/view/facility_training_preview_page.dart
@@ -3,7 +3,7 @@ import 'package:oqdo_mobile_app/components/custom_button.dart';
 import 'package:oqdo_mobile_app/oqdo_application.dart';
 import 'package:oqdo_mobile_app/screens/setup/facility_setup/models/facility_preview_model.dart';
 import 'package:oqdo_mobile_app/screens/setup/facility_setup/view/widgets/base_container.dart';
-import 'package:oqdo_mobile_app/utils/colorsUtils.dart';
+import 'package:oqdo_mobile_app/theme/custom_colors.dart';
 import 'package:oqdo_mobile_app/utils/constants.dart';
 
 class FacilityTrainingPreviewPage extends StatelessWidget {
@@ -15,16 +15,18 @@ class FacilityTrainingPreviewPage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    final customColors = Theme.of(context).extension<CustomColors>()!;
     return Scaffold(
-      backgroundColor: ColorsUtils.white,
+      backgroundColor: colorScheme.surface,
       appBar: AppBar(
-        backgroundColor: ColorsUtils.white,
+        backgroundColor: colorScheme.surface,
         elevation: 0,
         titleSpacing: 0,
         leading: IconButton(
           icon: Icon(
             Icons.arrow_back,
-            color: ColorsUtils.black,
+            color: colorScheme.onSurface,
             size: 24,
           ),
           onPressed: () => Navigator.of(context).pop(),
@@ -32,7 +34,7 @@ class FacilityTrainingPreviewPage extends StatelessWidget {
         title: Text(
           "Training Preview",
           style: TextStyle(
-            color: ColorsUtils.chipText,
+            color: customColors.chipText,
             fontFamily: 'Montserrat',
             fontSize: 18,
             fontWeight: FontWeight.w600,
@@ -46,17 +48,17 @@ class FacilityTrainingPreviewPage extends StatelessWidget {
             mainAxisAlignment: MainAxisAlignment.start,
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
-              _buildTrainingPreviewCard(),
+              _buildTrainingPreviewCard(context),
               const SizedBox(height: 20.0),
-              _buildAddressAndContactInfo(),
+              _buildAddressAndContactInfo(context),
               const SizedBox(height: 20.0),
-              _buildAvailableBookingSlotsView(),
+              _buildAvailableBookingSlotsView(context),
               const SizedBox(height: 20.0),
-              _buildFacilityDescription(),
+              _buildFacilityDescription(context),
               const SizedBox(height: 20.0),
               _buildGoToListViewButton(context),
               const SizedBox(height: 20.0),
-              _buildBottomText(),
+              _buildBottomText(context),
             ],
           ),
         ),
@@ -64,10 +66,12 @@ class FacilityTrainingPreviewPage extends StatelessWidget {
     );
   }
 
-  Widget _buildTrainingPreviewCard() {
+  Widget _buildTrainingPreviewCard(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    final customColors = Theme.of(context).extension<CustomColors>()!;
     return BaseContainer(
-      borderColor: ColorsUtils.primary,
-      bgColor: ColorsUtils.selectedGridItemColor,
+      borderColor: colorScheme.primary,
+      bgColor: customColors.selectedGridItemColor,
       child: Column(
         mainAxisAlignment: MainAxisAlignment.start,
         crossAxisAlignment: CrossAxisAlignment.start,
@@ -76,7 +80,7 @@ class FacilityTrainingPreviewPage extends StatelessWidget {
             facilityDetails.title,
             style: TextStyle(
               fontFamily: 'Inter',
-              color: ColorsUtils.primary,
+              color: colorScheme.primary,
               fontWeight: FontWeight.w600,
               fontSize: 18,
             ),
@@ -86,7 +90,7 @@ class FacilityTrainingPreviewPage extends StatelessWidget {
             facilityDetails.subTitle,
             style: TextStyle(
               fontFamily: 'Inter',
-              color: ColorsUtils.black,
+              color: colorScheme.onSurface,
               fontWeight: FontWeight.w500,
               fontSize: 14,
             ),
@@ -103,7 +107,7 @@ class FacilityTrainingPreviewPage extends StatelessWidget {
                   overflow: TextOverflow.ellipsis,
                   style: TextStyle(
                     fontFamily: 'Inter',
-                    color: ColorsUtils.chipText,
+                    color: customColors.chipText,
                     fontWeight: FontWeight.w500,
                     fontSize: 14,
                   ),
@@ -114,14 +118,14 @@ class FacilityTrainingPreviewPage extends StatelessWidget {
                 padding: EdgeInsets.symmetric(horizontal: 8.0, vertical: 4.0),
                 decoration: BoxDecoration(
                   borderRadius: BorderRadius.circular(20.0),
-                  color: facilityDetails.isPrivateRental ? ColorsUtils.green : ColorsUtils.darkRed,
+                  color: facilityDetails.isPrivateRental ? customColors.green : customColors.darkRed,
                 ),
                 child: Text(
                   facilityDetails.isPrivateRental ? 'Shared Rental' : 'Private Rental',
                   style: TextStyle(
                     fontSize: 12,
                     fontWeight: FontWeight.w500,
-                    color: ColorsUtils.white,
+                    color: customColors.onAccentText,
                     fontFamily: 'Montserrat',
                   ),
                 ),
@@ -138,7 +142,7 @@ class FacilityTrainingPreviewPage extends StatelessWidget {
                   mainAxisAlignment: MainAxisAlignment.start,
                   crossAxisAlignment: CrossAxisAlignment.center,
                   children: [
-                    Icon(Icons.access_time, size: 20, color: ColorsUtils.chipText),
+                    Icon(Icons.access_time, size: 20, color: customColors.chipText),
                     SizedBox(width: 5),
                     Text(
                       '${facilityDetails.slotDuration} slots',
@@ -146,7 +150,7 @@ class FacilityTrainingPreviewPage extends StatelessWidget {
                         fontSize: 14,
                         fontFamily: 'Montserrat',
                         fontWeight: FontWeight.w600,
-                        color: ColorsUtils.chipText,
+                        color: customColors.chipText,
                       ),
                     ),
                   ],
@@ -168,7 +172,7 @@ class FacilityTrainingPreviewPage extends StatelessWidget {
                         fontSize: 14,
                         fontFamily: 'Montserrat',
                         fontWeight: FontWeight.w600,
-                        color: ColorsUtils.chipText,
+                        color: customColors.chipText,
                       ),
                     ),
                   ],
@@ -191,7 +195,7 @@ class FacilityTrainingPreviewPage extends StatelessWidget {
                           fontSize: 14,
                           fontFamily: 'Montserrat',
                           fontWeight: FontWeight.w600,
-                          color: ColorsUtils.chipText,
+                          color: customColors.chipText,
                         ),
                       ),
                     ],
@@ -204,10 +208,12 @@ class FacilityTrainingPreviewPage extends StatelessWidget {
     );
   }
 
-  Widget _buildAddressAndContactInfo() {
+  Widget _buildAddressAndContactInfo(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    final customColors = Theme.of(context).extension<CustomColors>()!;
     return BaseContainer(
-      borderColor: ColorsUtils.borderColor,
-      bgColor: ColorsUtils.buttonBg,
+      borderColor: customColors.borderColor,
+      bgColor: customColors.buttonBg,
       child: Row(
         mainAxisAlignment: MainAxisAlignment.start,
         crossAxisAlignment: CrossAxisAlignment.start,
@@ -221,7 +227,7 @@ class FacilityTrainingPreviewPage extends StatelessWidget {
                   OQDOApplication.instance.userName ?? "",
                   style: TextStyle(
                     fontFamily: 'Inter',
-                    color: ColorsUtils.black,
+                    color: colorScheme.onSurface,
                     fontWeight: FontWeight.w600,
                     fontSize: 18,
                   ),
@@ -231,7 +237,7 @@ class FacilityTrainingPreviewPage extends StatelessWidget {
                   "Address",
                   style: TextStyle(
                     fontFamily: 'Inter',
-                    color: ColorsUtils.black,
+                    color: colorScheme.onSurface,
                     fontWeight: FontWeight.w500,
                     fontSize: 14,
                   ),
@@ -241,7 +247,7 @@ class FacilityTrainingPreviewPage extends StatelessWidget {
                   "Venue address will be provided after booking",
                   style: TextStyle(
                     fontFamily: 'Inter',
-                    color: ColorsUtils.black,
+                    color: colorScheme.onSurface,
                     fontWeight: FontWeight.w600,
                     fontSize: 14,
                   ),
@@ -251,7 +257,7 @@ class FacilityTrainingPreviewPage extends StatelessWidget {
                   "Contact Number",
                   style: TextStyle(
                     fontFamily: 'Inter',
-                    color: ColorsUtils.black,
+                    color: colorScheme.onSurface,
                     fontWeight: FontWeight.w500,
                     fontSize: 14,
                   ),
@@ -261,7 +267,7 @@ class FacilityTrainingPreviewPage extends StatelessWidget {
                   OQDOApplication.instance.phone ?? "",
                   style: TextStyle(
                     fontFamily: 'Inter',
-                    color: ColorsUtils.black,
+                    color: colorScheme.onSurface,
                     fontWeight: FontWeight.w600,
                     fontSize: 14,
                   ),
@@ -274,10 +280,12 @@ class FacilityTrainingPreviewPage extends StatelessWidget {
     );
   }
 
-  Widget _buildAvailableBookingSlotsView() {
+  Widget _buildAvailableBookingSlotsView(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    final customColors = Theme.of(context).extension<CustomColors>()!;
     return BaseContainer(
-      borderColor: ColorsUtils.borderColor,
-      bgColor: ColorsUtils.white,
+      borderColor: customColors.borderColor,
+      bgColor: customColors.containerBG,
       child: Row(
         mainAxisAlignment: MainAxisAlignment.start,
         crossAxisAlignment: CrossAxisAlignment.start,
@@ -291,7 +299,7 @@ class FacilityTrainingPreviewPage extends StatelessWidget {
                   "Available Booking Slots",
                   style: TextStyle(
                     fontFamily: 'Inter',
-                    color: ColorsUtils.black,
+                    color: colorScheme.onSurface,
                     fontWeight: FontWeight.w600,
                     fontSize: 14,
                   ),
@@ -304,7 +312,7 @@ class FacilityTrainingPreviewPage extends StatelessWidget {
                   itemBuilder: (context, index) {
                     final slotDetails = facilityDetails.slotsList[index];
                     return BaseContainer(
-                      bgColor: ColorsUtils.buttonBg,
+                      bgColor: customColors.buttonBg,
                       child: Row(
                         mainAxisAlignment: MainAxisAlignment.spaceBetween,
                         crossAxisAlignment: CrossAxisAlignment.center,
@@ -323,13 +331,16 @@ class FacilityTrainingPreviewPage extends StatelessWidget {
                                         children: slotDetails.sortedSelectedDays.map((day) {
                                           return Container(
                                             padding: EdgeInsets.symmetric(horizontal: 10.0, vertical: 4.0),
-                                            decoration: BoxDecoration(borderRadius: BorderRadius.circular(20.0), color: ColorsUtils.white),
+                                            decoration: BoxDecoration(
+                                              borderRadius: BorderRadius.circular(20.0),
+                                              color: customColors.containerBG,
+                                            ),
                                             child: Text(
                                               day.title,
                                               style: TextStyle(
                                                 fontSize: 14,
                                                 fontWeight: FontWeight.w400,
-                                                color: ColorsUtils.black,
+                                                color: colorScheme.onSurface,
                                                 fontFamily: 'Inter',
                                               ),
                                             ),
@@ -345,7 +356,7 @@ class FacilityTrainingPreviewPage extends StatelessWidget {
                                   "${slotDetails.startTimeFormatted} → ${slotDetails.endTimeFormatted}",
                                   style: TextStyle(
                                     fontFamily: 'Inter',
-                                    color: ColorsUtils.black,
+                                    color: colorScheme.onSurface,
                                     fontWeight: FontWeight.w500,
                                     fontSize: 14,
                                   ),
@@ -362,7 +373,7 @@ class FacilityTrainingPreviewPage extends StatelessWidget {
                                 "S\$ ${parseDoubleToRoundString(slotDetails.ratePerHour ?? 0)}/hr",
                                 style: TextStyle(
                                   fontFamily: 'Inter',
-                                  color: ColorsUtils.primary,
+                                  color: colorScheme.primary,
                                   fontWeight: FontWeight.w500,
                                   fontSize: 16,
                                 ),
@@ -372,7 +383,7 @@ class FacilityTrainingPreviewPage extends StatelessWidget {
                                 "${slotDetails.tempNumberOfSlots} ${((slotDetails.tempNumberOfSlots) > 1) ? "Slots" : "Slot"}",
                                 style: TextStyle(
                                   fontFamily: 'Inter',
-                                  color: ColorsUtils.textGray,
+                                  color: customColors.textGray,
                                   fontWeight: FontWeight.w500,
                                   fontSize: 14,
                                 ),
@@ -393,10 +404,12 @@ class FacilityTrainingPreviewPage extends StatelessWidget {
     );
   }
 
-  Widget _buildFacilityDescription() {
+  Widget _buildFacilityDescription(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    final customColors = Theme.of(context).extension<CustomColors>()!;
     return BaseContainer(
-      borderColor: ColorsUtils.borderColor,
-      bgColor: ColorsUtils.white,
+      borderColor: customColors.borderColor,
+      bgColor: customColors.containerBG,
       child: Row(
         mainAxisAlignment: MainAxisAlignment.start,
         crossAxisAlignment: CrossAxisAlignment.start,
@@ -410,7 +423,7 @@ class FacilityTrainingPreviewPage extends StatelessWidget {
                   "Facility Description",
                   style: TextStyle(
                     fontFamily: 'Montserrat',
-                    color: ColorsUtils.black,
+                    color: colorScheme.onSurface,
                     fontWeight: FontWeight.w600,
                     fontSize: 14,
                   ),
@@ -420,7 +433,7 @@ class FacilityTrainingPreviewPage extends StatelessWidget {
                   facilityDetails.description,
                   style: TextStyle(
                     fontFamily: 'Inter',
-                    color: ColorsUtils.textGray,
+                    color: customColors.textGray,
                     fontWeight: FontWeight.w500,
                     fontSize: 12,
                   ),
@@ -435,7 +448,7 @@ class FacilityTrainingPreviewPage extends StatelessWidget {
                         "Maximum Group Size",
                         style: TextStyle(
                           fontFamily: 'Inter',
-                          color: ColorsUtils.textGray,
+                          color: customColors.textGray,
                           fontWeight: FontWeight.w500,
                           fontSize: 14,
                         ),
@@ -445,7 +458,7 @@ class FacilityTrainingPreviewPage extends StatelessWidget {
                         facilityDetails.maxCapacityOrGroupSize,
                         style: TextStyle(
                           fontFamily: 'Inter',
-                          color: ColorsUtils.black,
+                          color: colorScheme.onSurface,
                           fontWeight: FontWeight.w600,
                           fontSize: 14,
                         ),
@@ -461,10 +474,11 @@ class FacilityTrainingPreviewPage extends StatelessWidget {
   }
 
   Widget _buildGoToListViewButton(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
     return CustomButton(
       text: "Go to List",
-      textcolor: ColorsUtils.white,
-      buttonColor: ColorsUtils.primary,
+      textcolor: colorScheme.onPrimary,
+      buttonColor: colorScheme.primary,
       textsize: 16,
       fontWeight: FontWeight.bold,
       buttonheight: 50,
@@ -474,13 +488,14 @@ class FacilityTrainingPreviewPage extends StatelessWidget {
     );
   }
 
-  Widget _buildBottomText() {
+  Widget _buildBottomText(BuildContext context) {
+    final customColors = Theme.of(context).extension<CustomColors>()!;
     return Text(
       "Need a different time slot? Contact the instructor directly for custom scheduling.",
       textAlign: TextAlign.center,
       style: TextStyle(
         fontFamily: 'Inter',
-        color: ColorsUtils.textGray,
+        color: customColors.textGray,
         fontWeight: FontWeight.w400,
         fontSize: 12,
       ),

--- a/lib/screens/setup/facility_setup/view/widgets/base_container.dart
+++ b/lib/screens/setup/facility_setup/view/widgets/base_container.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:oqdo_mobile_app/utils/colorsUtils.dart';
+import 'package:oqdo_mobile_app/theme/custom_colors.dart';
 
 class BaseContainer extends StatelessWidget {
   const BaseContainer({super.key, required this.child, this.bgColor, this.width, this.borderColor});
@@ -11,13 +11,14 @@ class BaseContainer extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final customColors = Theme.of(context).extension<CustomColors>()!;
     return Container(
       width: width,
       padding: EdgeInsets.all(10.0),
       decoration: BoxDecoration(
-        color: bgColor ?? ColorsUtils.containerBG,
+        color: bgColor ?? customColors.containerBG,
         borderRadius: BorderRadius.circular(5.0),
-        border: Border.all(color: borderColor ?? ColorsUtils.borderColor, width: 1),
+        border: Border.all(color: borderColor ?? customColors.borderColor, width: 1),
       ),
       child: child,
     );

--- a/lib/screens/setup/facility_setup/view/widgets/base_stepper_screen.dart
+++ b/lib/screens/setup/facility_setup/view/widgets/base_stepper_screen.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:oqdo_mobile_app/components/custom_button.dart';
 import 'package:oqdo_mobile_app/screens/setup/facility_setup/models/stepper_config_model.dart';
-import 'package:oqdo_mobile_app/utils/colorsUtils.dart';
+import 'package:oqdo_mobile_app/theme/custom_colors.dart';
 
 class StepperBaseScreen extends StatelessWidget {
   final int currentStep;
@@ -19,6 +19,7 @@ class StepperBaseScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
     return PopScope(
       canPop: false,
       onPopInvokedWithResult: (didPop, asd) {
@@ -32,14 +33,14 @@ class StepperBaseScreen extends StatelessWidget {
       },
       child: Scaffold(
         // resizeToAvoidBottomInset: false,
-        backgroundColor: ColorsUtils.white,
+        backgroundColor: colorScheme.surface,
         appBar: _buildAppBar(context),
         body: Column(
           mainAxisAlignment: MainAxisAlignment.start,
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             // Progress Indicator
-            _buildProgressIndicator(),
+            _buildProgressIndicator(context),
 
             // Step Content (Green highlighted area)
             Expanded(
@@ -55,14 +56,16 @@ class StepperBaseScreen extends StatelessWidget {
   }
 
   PreferredSizeWidget _buildAppBar(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    final customColors = Theme.of(context).extension<CustomColors>()!;
     return AppBar(
-      backgroundColor: ColorsUtils.white,
+      backgroundColor: colorScheme.surface,
       elevation: 0,
       titleSpacing: 0,
       leading: IconButton(
         icon: Icon(
           Icons.arrow_back,
-          color: ColorsUtils.black,
+          color: colorScheme.onSurface,
           size: 24,
         ),
         onPressed: config.onBackPressed ?? () => Navigator.of(context).pop(),
@@ -70,7 +73,7 @@ class StepperBaseScreen extends StatelessWidget {
       title: Text(
         config.appBarTitle,
         style: TextStyle(
-          color: ColorsUtils.chipText,
+          color: customColors.chipText,
           fontFamily: 'Montserrat',
           fontSize: 18,
           fontWeight: FontWeight.w600,
@@ -79,7 +82,9 @@ class StepperBaseScreen extends StatelessWidget {
     );
   }
 
-  Widget _buildProgressIndicator() {
+  Widget _buildProgressIndicator(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    final customColors = Theme.of(context).extension<CustomColors>()!;
     double progress = currentStep / totalSteps;
     int progressPercentage = (progress * 100).round();
 
@@ -88,8 +93,8 @@ class StepperBaseScreen extends StatelessWidget {
       child: Container(
         padding: const EdgeInsets.all(10.0),
         decoration: BoxDecoration(
-          color: ColorsUtils.white,
-          border: Border.all(color: ColorsUtils.borderColor, width: 1),
+          color: customColors.containerBG,
+          border: Border.all(color: customColors.borderColor, width: 1),
           borderRadius: BorderRadius.all(
             Radius.circular(5.0),
           ),
@@ -105,19 +110,22 @@ class StepperBaseScreen extends StatelessWidget {
                   style: TextStyle(
                     fontSize: 14,
                     fontWeight: FontWeight.w600,
-                    color: ColorsUtils.black,
+                    color: colorScheme.onSurface,
                     fontFamily: 'Inter',
                   ),
                 ),
                 Container(
                   padding: EdgeInsets.symmetric(horizontal: 8.0, vertical: 2.0),
-                  decoration: BoxDecoration(borderRadius: BorderRadius.circular(20.0), color: ColorsUtils.lightBlueBGColor),
+                  decoration: BoxDecoration(
+                    borderRadius: BorderRadius.circular(20.0),
+                    color: customColors.lightBlueBGColor,
+                  ),
                   child: Text(
                     '$progressPercentage%',
                     style: TextStyle(
                       fontSize: 12,
                       fontWeight: FontWeight.w500,
-                      color: ColorsUtils.primary,
+                      color: colorScheme.primary,
                       fontFamily: 'Montserrat',
                     ),
                   ),
@@ -129,8 +137,8 @@ class StepperBaseScreen extends StatelessWidget {
               borderRadius: BorderRadius.circular(15.0),
               child: LinearProgressIndicator(
                 value: progress,
-                backgroundColor: ColorsUtils.greyBG,
-                valueColor: const AlwaysStoppedAnimation<Color>(ColorsUtils.primary),
+                backgroundColor: customColors.greyBG,
+                valueColor: AlwaysStoppedAnimation<Color>(colorScheme.primary),
                 minHeight: 10,
               ),
             ),
@@ -156,8 +164,11 @@ class StepperBaseScreen extends StatelessWidget {
     bool isFirstStep = currentStep == 1;
     bool isLastStep = currentStep == totalSteps;
 
+    final colorScheme = Theme.of(context).colorScheme;
+    final customColors = Theme.of(context).extension<CustomColors>()!;
+
     return Container(
-      color: Colors.white,
+      color: colorScheme.surface,
       padding: const EdgeInsets.all(16.0),
       child: SafeArea(
         child: Row(
@@ -169,8 +180,8 @@ class StepperBaseScreen extends StatelessWidget {
               Expanded(
                 child: CustomButton(
                   text: config.previousButtonText,
-                  textcolor: ColorsUtils.black,
-                  buttonColor: ColorsUtils.buttonBg,
+                  textcolor: colorScheme.onSurface,
+                  buttonColor: customColors.buttonBg,
                   textsize: 16,
                   fontWeight: FontWeight.bold,
                   buttonheight: 50,
@@ -186,8 +197,8 @@ class StepperBaseScreen extends StatelessWidget {
             Expanded(
               child: CustomButton(
                 text: isLastStep ? config.completeButtonText : config.nextButtonText,
-                textcolor: ColorsUtils.white,
-                buttonColor: ColorsUtils.primary,
+                textcolor: colorScheme.onPrimary,
+                buttonColor: colorScheme.primary,
                 textsize: 16,
                 fontWeight: FontWeight.bold,
                 buttonheight: 50,

--- a/lib/screens/setup/facility_setup/view/widgets/duration_input_field.dart
+++ b/lib/screens/setup/facility_setup/view/widgets/duration_input_field.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
-import 'package:oqdo_mobile_app/utils/colorsUtils.dart';
+import 'package:oqdo_mobile_app/theme/custom_colors.dart';
 
 class DurationInputField extends StatefulWidget {
   final TextEditingController controller;
@@ -354,7 +354,7 @@ class DurationInputFieldState extends State<DurationInputField> {
               style: TextStyle(
                 fontSize: 14,
                 fontWeight: FontWeight.w500,
-                color: ColorsUtils.chipText,
+                color: Theme.of(context).extension<CustomColors>()!.chipText,
                 fontFamily: 'Inter',
               ),
             ),
@@ -363,11 +363,15 @@ class DurationInputFieldState extends State<DurationInputField> {
               height: 48,
               decoration: BoxDecoration(
                 border: Border.all(
-                  color: field.hasError ? ColorsUtils.redColor : ColorsUtils.borderColor,
+                  color: field.hasError
+                      ? Theme.of(context).extension<CustomColors>()!.redColor
+                      : Theme.of(context).extension<CustomColors>()!.borderColor,
                   width: 1,
                 ),
                 borderRadius: BorderRadius.circular(6),
-                color: widget.readOnly ? ColorsUtils.buttonColorGrey : ColorsUtils.white,
+                color: widget.readOnly
+                    ? Theme.of(context).extension<CustomColors>()!.buttonColorGrey
+                    : Theme.of(context).extension<CustomColors>()!.containerBG,
               ),
               child: Row(
                 children: [
@@ -397,14 +401,16 @@ class DurationInputFieldState extends State<DurationInputField> {
                               ],
                         style: TextStyle(
                           fontSize: 14,
-                          color: widget.readOnly ? ColorsUtils.textGray : ColorsUtils.black,
+                          color: widget.readOnly
+                              ? Theme.of(context).extension<CustomColors>()!.textGray
+                              : Theme.of(context).colorScheme.onSurface,
                           fontFamily: 'Inter',
                           fontWeight: FontWeight.w600,
                         ),
                         decoration: InputDecoration(
                           hintText: widget.hintText,
                           hintStyle: TextStyle(
-                            color: ColorsUtils.hintTextColor,
+                            color: Theme.of(context).extension<CustomColors>()!.hintTextColor,
                             fontSize: 14,
                             fontFamily: 'Inter',
                             fontWeight: FontWeight.w400,
@@ -454,7 +460,7 @@ class DurationInputFieldState extends State<DurationInputField> {
                 field.errorText!,
                 style: TextStyle(
                   fontSize: 12,
-                  color: ColorsUtils.redColor,
+                  color: Theme.of(context).extension<CustomColors>()!.redColor,
                   fontFamily: 'Inter',
                   fontWeight: FontWeight.w400,
                 ),

--- a/lib/screens/setup/facility_setup/view/widgets/facility_step_one.dart
+++ b/lib/screens/setup/facility_setup/view/widgets/facility_step_one.dart
@@ -3,8 +3,7 @@ import 'package:oqdo_mobile_app/model/get_all_activity_and_sub_activity_response
 import 'package:oqdo_mobile_app/screens/setup/facility_setup/view/widgets/base_container.dart';
 import 'package:oqdo_mobile_app/screens/setup/facility_setup/view/widgets/setup_grid_view_item.dart';
 import 'package:oqdo_mobile_app/screens/setup/facility_setup/viewmodel/create_facility_view_model.dart';
-import 'package:oqdo_mobile_app/theme/oqdo_theme_data.dart';
-import 'package:oqdo_mobile_app/utils/colorsUtils.dart';
+import 'package:oqdo_mobile_app/theme/custom_colors.dart';
 import 'package:oqdo_mobile_app/utils/constants.dart';
 import 'package:oqdo_mobile_app/utils/custom_text_field.dart';
 import 'package:oqdo_mobile_app/utils/custom_text_view.dart';
@@ -52,6 +51,8 @@ class FacilityStepOne extends StatelessWidget {
   }
 
   Widget _buildTitleAndFacilityTitleView(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    final customColors = Theme.of(context).extension<CustomColors>()!;
     return Column(
       mainAxisAlignment: MainAxisAlignment.start,
       crossAxisAlignment: CrossAxisAlignment.start,
@@ -61,7 +62,7 @@ class FacilityStepOne extends StatelessWidget {
           "Activity & Type Setup",
           style: TextStyle(
             fontFamily: 'SFPro',
-            color: ColorsUtils.primary,
+            color: colorScheme.primary,
             fontWeight: FontWeight.w600,
             fontSize: 16,
           ),
@@ -78,7 +79,7 @@ class FacilityStepOne extends StatelessWidget {
                   "Facility Title",
                   style: TextStyle(
                     fontFamily: 'Montserrat',
-                    color: ColorsUtils.chipText,
+                    color: customColors.chipText,
                     fontWeight: FontWeight.w600,
                     fontSize: 14,
                   ),
@@ -86,7 +87,7 @@ class FacilityStepOne extends StatelessWidget {
                 const SizedBox(height: 15.0),
                 CommonTextField(
                   maxLength: 50,
-                  fillColor: ColorsUtils.white,
+                  fillColor: customColors.containerBG,
                   borderRadius: 6,
                   hint: "Facility Title",
                   labelText: "Facility Title",
@@ -95,7 +96,7 @@ class FacilityStepOne extends StatelessWidget {
                   textStyle: TextStyle(
                     fontSize: 16,
                     fontFamily: "Inter",
-                    color: ColorsUtils.black,
+                    color: colorScheme.onSurface,
                     fontWeight: FontWeight.w500,
                   ),
                   validator: (value) {
@@ -110,7 +111,7 @@ class FacilityStepOne extends StatelessWidget {
                   "Give your facility a catchy name.",
                   style: TextStyle(
                     fontFamily: 'Inter',
-                    color: ColorsUtils.hintTextColor,
+                    color: customColors.hintTextColor,
                     fontWeight: FontWeight.w400,
                     fontSize: 12,
                   ),
@@ -118,7 +119,7 @@ class FacilityStepOne extends StatelessWidget {
                 const SizedBox(height: 15.0),
                 CommonTextField(
                   maxLength: 50,
-                  fillColor: ColorsUtils.white,
+                  fillColor: customColors.containerBG,
                   borderRadius: 6,
                   hint: "Subtitle",
                   labelText: "Subtitle",
@@ -127,7 +128,7 @@ class FacilityStepOne extends StatelessWidget {
                   textStyle: TextStyle(
                     fontSize: 16,
                     fontFamily: "Inter",
-                    color: ColorsUtils.black,
+                    color: colorScheme.onSurface,
                     fontWeight: FontWeight.w500,
                   ),
                   validator: (value) {
@@ -142,7 +143,7 @@ class FacilityStepOne extends StatelessWidget {
                   "A brief tagline describing your facility.",
                   style: TextStyle(
                     fontFamily: 'Inter',
-                    color: ColorsUtils.hintTextColor,
+                    color: customColors.hintTextColor,
                     fontWeight: FontWeight.w400,
                     fontSize: 12,
                   ),
@@ -156,13 +157,15 @@ class FacilityStepOne extends StatelessWidget {
   }
 
   Widget _buildChooseYourActivityView(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    final customColors = Theme.of(context).extension<CustomColors>()!;
     return Column(
       mainAxisAlignment: MainAxisAlignment.start,
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         const SizedBox(height: 20),
         BaseContainer(
-          bgColor: ColorsUtils.white,
+          bgColor: customColors.containerBG,
           child: Column(
             mainAxisAlignment: MainAxisAlignment.start,
             crossAxisAlignment: CrossAxisAlignment.start,
@@ -172,7 +175,7 @@ class FacilityStepOne extends StatelessWidget {
                 "${context.read<CreateFacilityViewModel>().isEdit ? "" : "Choose "}Your Activity",
                 style: TextStyle(
                   fontFamily: 'Montserrat',
-                  color: ColorsUtils.chipText,
+                  color: customColors.chipText,
                   fontWeight: FontWeight.w600,
                   fontSize: 14,
                 ),
@@ -192,6 +195,7 @@ class FacilityStepOne extends StatelessWidget {
                     isSelected: isSelected,
                     isEnabled: !context.read<CreateFacilityViewModel>().isEdit,
                     onTap: () => context.read<CreateFacilityViewModel>().onSelectActivity(item),
+                    unSelectedColor: customColors.containerBG,
                   );
                 },
               ),
@@ -200,7 +204,7 @@ class FacilityStepOne extends StatelessWidget {
                 "${context.read<CreateFacilityViewModel>().isEdit ? "The" : "Choose the"} main category your facility belongs to.",
                 style: TextStyle(
                   fontFamily: 'Inter',
-                  color: ColorsUtils.hintTextColor,
+                  color: customColors.hintTextColor,
                   fontWeight: FontWeight.w400,
                   fontSize: 12,
                 ),
@@ -213,9 +217,9 @@ class FacilityStepOne extends StatelessWidget {
                     const SizedBox(height: 10.0),
                     Container(
                       decoration: BoxDecoration(
-                        border: Border.all(color: ColorsUtils.borderColor),
+                        border: Border.all(color: customColors.borderColor),
                         borderRadius: BorderRadius.circular(15),
-                        color: OQDOThemeData.backgroundColor,
+                        color: customColors.containerBG,
                       ),
                       child: Padding(
                         padding: const EdgeInsets.only(left: 10, right: 10),
@@ -223,15 +227,15 @@ class FacilityStepOne extends StatelessWidget {
                             isExpanded: true,
                             icon: Icon(Icons.keyboard_arrow_down_rounded,
                                 color: context.watch<CreateFacilityViewModel>().isEdit
-                                    ? Colors.grey.shade400 // Disabled icon color
-                                    : OQDOThemeData.blackColor),
-                            dropdownColor: ColorsUtils.white,
+                                    ? Theme.of(context).disabledColor // Disabled icon color
+                                    : colorScheme.onSurface),
+                            dropdownColor: customColors.containerBG,
                             underline: const SizedBox(),
                             borderRadius: BorderRadius.circular(15),
                             hint: CustomTextView(
                               label: context.watch<CreateFacilityViewModel>().subActivityHint,
                               textStyle: TextStyle(
-                                color: ColorsUtils.hintTextColor,
+                                color: customColors.hintTextColor,
                                 fontSize: 14,
                                 fontWeight: FontWeight.w400,
                                 fontFamily: 'Inter',
@@ -244,7 +248,7 @@ class FacilityStepOne extends StatelessWidget {
                                 child: CustomTextView(
                                   label: subActivity.Name ?? "",
                                   textStyle: TextStyle(
-                                    color: ColorsUtils.black,
+                                    color: colorScheme.onSurface,
                                     fontSize: 14,
                                     fontWeight: FontWeight.w500,
                                     fontFamily: 'Inter',
@@ -260,7 +264,7 @@ class FacilityStepOne extends StatelessWidget {
                       "${context.read<CreateFacilityViewModel>().isEdit ? "The" : "Select the"} specific activity your facility specializes in.",
                       style: TextStyle(
                         fontFamily: 'Inter',
-                        color: ColorsUtils.hintTextColor,
+                        color: customColors.hintTextColor,
                         fontWeight: FontWeight.w400,
                         fontSize: 12,
                       ),
@@ -275,6 +279,7 @@ class FacilityStepOne extends StatelessWidget {
   }
 
   Widget _buildChooseBookingTypeView(BuildContext context) {
+    final customColors = Theme.of(context).extension<CustomColors>()!;
     return Column(
       mainAxisAlignment: MainAxisAlignment.start,
       crossAxisAlignment: CrossAxisAlignment.start,
@@ -294,7 +299,7 @@ class FacilityStepOne extends StatelessWidget {
                     "Choose Booking Type",
                     style: TextStyle(
                       fontFamily: 'Montserrat',
-                      color: ColorsUtils.chipText,
+                      color: customColors.chipText,
                       fontWeight: FontWeight.w600,
                       fontSize: 14,
                     ),
@@ -306,7 +311,7 @@ class FacilityStepOne extends StatelessWidget {
                 "Choose how users can book your facility.",
                 style: TextStyle(
                   fontFamily: 'Inter',
-                  color: ColorsUtils.hintTextColor,
+                  color: customColors.hintTextColor,
                   fontWeight: FontWeight.w400,
                   fontSize: 12,
                 ),
@@ -322,7 +327,7 @@ class FacilityStepOne extends StatelessWidget {
                   final isSelected = (context.watch<CreateFacilityViewModel>().selectedBookingType?.id == item.id);
                   return SetupGridViewItem(
                     title: item.title,
-                    unSelectedColor: ColorsUtils.white,
+                    unSelectedColor: customColors.containerBG,
                     imagePath: item.imagePath,
                     isSelected: isSelected,
                     isEnabled: true,
@@ -335,7 +340,7 @@ class FacilityStepOne extends StatelessWidget {
                 (context.watch<CreateFacilityViewModel>().selectedBookingType?.id == 2) ? "Shared access with other users" : "Exclusive access to the facility",
                 style: TextStyle(
                   fontFamily: 'Inter',
-                  color: ColorsUtils.hintTextColor,
+                  color: customColors.hintTextColor,
                   fontWeight: FontWeight.w400,
                   fontSize: 12,
                 ),

--- a/lib/screens/setup/facility_setup/view/widgets/facility_step_three.dart
+++ b/lib/screens/setup/facility_setup/view/widgets/facility_step_three.dart
@@ -6,7 +6,7 @@ import 'package:oqdo_mobile_app/screens/setup/facility_setup/view/facility_train
 import 'package:oqdo_mobile_app/screens/setup/facility_setup/view/widgets/base_container.dart';
 import 'package:oqdo_mobile_app/screens/setup/facility_setup/view/widgets/time_input_field.dart';
 import 'package:oqdo_mobile_app/screens/setup/facility_setup/viewmodel/create_facility_view_model.dart';
-import 'package:oqdo_mobile_app/utils/colorsUtils.dart';
+import 'package:oqdo_mobile_app/theme/custom_colors.dart';
 import 'package:oqdo_mobile_app/utils/constants.dart';
 import 'package:oqdo_mobile_app/utils/custom_text_field.dart';
 import 'package:provider/provider.dart';
@@ -75,14 +75,14 @@ class FacilityStepThree extends StatelessWidget {
           "Booking Schedule",
           style: TextStyle(
             fontFamily: 'SFPro',
-            color: ColorsUtils.primary,
+            color: Theme.of(context).colorScheme.primary,
             fontWeight: FontWeight.w600,
             fontSize: 16,
           ),
         ),
         const SizedBox(height: 15.0),
         BaseContainer(
-          bgColor: ColorsUtils.white,
+          bgColor: Theme.of(context).extension<CustomColors>()!.containerBG,
           child: Column(
             mainAxisAlignment: MainAxisAlignment.start,
             crossAxisAlignment: CrossAxisAlignment.start,
@@ -92,7 +92,7 @@ class FacilityStepThree extends StatelessWidget {
                 "Rate Settings",
                 style: TextStyle(
                   fontFamily: 'Montserrat',
-                  color: ColorsUtils.chipText,
+                  color: Theme.of(context).extension<CustomColors>()!.chipText,
                   fontWeight: FontWeight.w600,
                   fontSize: 14,
                 ),
@@ -110,7 +110,7 @@ class FacilityStepThree extends StatelessWidget {
                         "Same Rate for Slots",
                         style: TextStyle(
                           fontFamily: 'Montserrat',
-                          color: ColorsUtils.chipText,
+                          color: Theme.of(context).extension<CustomColors>()!.chipText,
                           fontWeight: FontWeight.w600,
                           fontSize: 14,
                         ),
@@ -120,7 +120,7 @@ class FacilityStepThree extends StatelessWidget {
                         "Apply one rate to all time slots",
                         style: TextStyle(
                           fontFamily: 'Inter',
-                          color: ColorsUtils.hintTextColor,
+                          color: Theme.of(context).extension<CustomColors>()!.hintTextColor,
                           fontWeight: FontWeight.w400,
                           fontSize: 12,
                         ),
@@ -179,7 +179,7 @@ class FacilityStepThree extends StatelessWidget {
                               style: TextStyle(
                                 fontSize: 14,
                                 fontFamily: "Inter",
-                                color: ColorsUtils.darkGrey,
+                                color: Theme.of(context).extension<CustomColors>()!.darkGrey,
                                 fontWeight: FontWeight.w400,
                               ),
                             ),
@@ -188,7 +188,7 @@ class FacilityStepThree extends StatelessWidget {
                           Expanded(
                             child: CommonTextField(
                               maxLength: 6,
-                              fillColor: ColorsUtils.white,
+                              fillColor: Theme.of(context).extension<CustomColors>()!.containerBG,
                               isDouble: true,
                               borderRadius: 6,
                               hint: "Enter hourly rate",
@@ -198,7 +198,7 @@ class FacilityStepThree extends StatelessWidget {
                               textStyle: TextStyle(
                                 fontSize: 16,
                                 fontFamily: "Inter",
-                                color: ColorsUtils.black,
+                                color: Theme.of(context).colorScheme.onSurface,
                                 fontWeight: FontWeight.w500,
                               ),
                               validator: (value) {
@@ -243,9 +243,9 @@ class FacilityStepThree extends StatelessWidget {
               CustomButton(
                 text: "Add Time Slot",
                 leadingIcon: Icon(Icons.add, size: 18),
-                textcolor: ColorsUtils.black,
-                buttonColor: ColorsUtils.buttonColorGrey,
-                borderColor: ColorsUtils.borderColor,
+                textcolor: Theme.of(context).colorScheme.onSurface,
+                buttonColor: Theme.of(context).extension<CustomColors>()!.buttonColorGrey,
+                borderColor: Theme.of(context).extension<CustomColors>()!.borderColor,
                 textsize: 16,
                 fontWeight: FontWeight.bold,
                 buttonheight: 50,
@@ -263,7 +263,7 @@ class FacilityStepThree extends StatelessWidget {
                 "Add available rental time slots.",
                 style: TextStyle(
                   fontFamily: 'Inter',
-                  color: ColorsUtils.hintTextColor,
+                  color: Theme.of(context).extension<CustomColors>()!.hintTextColor,
                   fontWeight: FontWeight.w400,
                   fontSize: 12,
                 ),
@@ -282,10 +282,10 @@ class FacilityStepThree extends StatelessWidget {
                       strokeWidth: 1.5,
                       radius: const Radius.circular(5),
                       dashPattern: const [3, 3],
-                      color: ColorsUtils.messageRight,
+                      color: Theme.of(context).extension<CustomColors>()!.messageRight,
                       child: Container(
                         decoration: BoxDecoration(
-                          color: ColorsUtils.buttonColorGrey,
+                          color: Theme.of(context).extension<CustomColors>()!.buttonColorGrey,
                           borderRadius: BorderRadius.all(
                             Radius.circular(5),
                           ),
@@ -306,13 +306,13 @@ class FacilityStepThree extends StatelessWidget {
                                     children: slotDetails.sortedSelectedDays.map((day) {
                                       return Container(
                                         padding: EdgeInsets.symmetric(horizontal: 10.0, vertical: 4.0),
-                                        decoration: BoxDecoration(borderRadius: BorderRadius.circular(20.0), color: ColorsUtils.primary),
+                                        decoration: BoxDecoration(borderRadius: BorderRadius.circular(20.0), color: Theme.of(context).colorScheme.primary),
                                         child: Text(
                                           day.title,
                                           style: TextStyle(
                                             fontSize: 14,
                                             fontWeight: FontWeight.w400,
-                                            color: ColorsUtils.white,
+                                            color: Theme.of(context).extension<CustomColors>()!.onAccentText,
                                             fontFamily: 'Inter',
                                           ),
                                         ),
@@ -329,7 +329,7 @@ class FacilityStepThree extends StatelessWidget {
                                     padding: EdgeInsets.all(4.0),
                                     child: Image.asset(
                                       "assets/images/ic_cancel_appointment.png",
-                                      color: ColorsUtils.black,
+                                      color: Theme.of(context).colorScheme.onSurface,
                                     ),
                                   ),
                                 )
@@ -383,7 +383,7 @@ class FacilityStepThree extends StatelessWidget {
               style: TextStyle(
                 fontSize: 14,
                 fontWeight: FontWeight.w400,
-                color: ColorsUtils.black,
+                color: Theme.of(context).colorScheme.onSurface,
                 fontFamily: 'Inter',
               ),
             ),
@@ -393,7 +393,7 @@ class FacilityStepThree extends StatelessWidget {
               style: TextStyle(
                 fontSize: 14,
                 fontWeight: FontWeight.w600,
-                color: ColorsUtils.black,
+                color: Theme.of(context).colorScheme.onSurface,
                 fontFamily: 'Inter',
               ),
             ),
@@ -431,7 +431,7 @@ class FacilityStepThree extends StatelessWidget {
                       // Remove fixed height - let content determine height
                       padding: EdgeInsets.all(15.0),
                       decoration: BoxDecoration(
-                        color: ColorsUtils.white,
+                        color: Theme.of(context).extension<CustomColors>()!.containerBG,
                         borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
                       ),
                       child: Column(
@@ -446,7 +446,7 @@ class FacilityStepThree extends StatelessWidget {
                                 style: TextStyle(
                                   fontSize: 18,
                                   fontWeight: FontWeight.w600,
-                                  color: ColorsUtils.black,
+                                  color: Theme.of(context).colorScheme.onSurface,
                                   fontFamily: 'Montserrat',
                                 ),
                               ),
@@ -497,7 +497,7 @@ class FacilityStepThree extends StatelessWidget {
                                       'Select multiple days when the same availability applies',
                                       style: TextStyle(
                                         fontSize: 12,
-                                        color: ColorsUtils.textGray,
+                                        color: Theme.of(context).extension<CustomColors>()!.textGray,
                                         fontFamily: 'Inter',
                                         fontWeight: FontWeight.w400,
                                       ),
@@ -517,7 +517,7 @@ class FacilityStepThree extends StatelessWidget {
                                                 style: TextStyle(
                                                   fontSize: 14,
                                                   fontFamily: "Inter",
-                                                  color: ColorsUtils.darkGrey,
+                                                  color: Theme.of(context).extension<CustomColors>()!.darkGrey,
                                                   fontWeight: FontWeight.w400,
                                                 ),
                                               ),
@@ -526,7 +526,7 @@ class FacilityStepThree extends StatelessWidget {
                                                 child: CommonTextField(
                                                   maxLength: 6,
                                                   autovalidateMode: AutovalidateMode.onUserInteraction,
-                                                  fillColor: ColorsUtils.white,
+                                                  fillColor: Theme.of(context).extension<CustomColors>()!.containerBG,
                                                   isDouble: true,
                                                   borderRadius: 6,
                                                   hint: "Enter hourly rate",
@@ -534,7 +534,7 @@ class FacilityStepThree extends StatelessWidget {
                                                   textStyle: TextStyle(
                                                     fontSize: 16,
                                                     fontFamily: "Inter",
-                                                    color: ColorsUtils.black,
+                                                    color: Theme.of(context).colorScheme.onSurface,
                                                     fontWeight: FontWeight.w500,
                                                   ),
                                                   validator: (value) {
@@ -566,7 +566,7 @@ class FacilityStepThree extends StatelessWidget {
                                       children: [
                                         Row(
                                           children: [
-                                            Icon(Icons.access_time, size: 20, color: ColorsUtils.chipText),
+                                            Icon(Icons.access_time, size: 20, color: Theme.of(context).extension<CustomColors>()!.chipText),
                                             SizedBox(width: 8),
                                             Text(
                                               'Booking Slots (6 AM - 10 PM)',
@@ -574,7 +574,7 @@ class FacilityStepThree extends StatelessWidget {
                                                 fontSize: 14,
                                                 fontFamily: 'Montserrat',
                                                 fontWeight: FontWeight.w600,
-                                                color: ColorsUtils.chipText,
+                                                color: Theme.of(context).extension<CustomColors>()!.chipText,
                                               ),
                                             ),
                                           ],
@@ -585,11 +585,11 @@ class FacilityStepThree extends StatelessWidget {
                                           leadingIcon: Icon(
                                             Icons.add,
                                             size: 20,
-                                            color: ColorsUtils.black,
+                                            color: Theme.of(context).colorScheme.onSurface,
                                           ),
-                                          textcolor: ColorsUtils.black,
-                                          buttonColor: ColorsUtils.selectedGridItemColor,
-                                          borderColor: ColorsUtils.selectedGridItemColor,
+                                          textcolor: Theme.of(context).colorScheme.onSurface,
+                                          buttonColor: Theme.of(context).extension<CustomColors>()!.selectedGridItemColor,
+                                          borderColor: Theme.of(context).extension<CustomColors>()!.selectedGridItemColor,
                                           textsize: 16,
                                           fontWeight: FontWeight.bold,
                                           buttonheight: 35,
@@ -610,7 +610,7 @@ class FacilityStepThree extends StatelessWidget {
                                                 return Form(
                                                   key: editSlot.formKey,
                                                   child: BaseContainer(
-                                                    bgColor: ColorsUtils.white,
+                                                    bgColor: Theme.of(context).extension<CustomColors>()!.containerBG,
                                                     child: Column(
                                                       mainAxisAlignment: MainAxisAlignment.start,
                                                       crossAxisAlignment: CrossAxisAlignment.start,
@@ -620,7 +620,7 @@ class FacilityStepThree extends StatelessWidget {
                                                           children: [
                                                             Text(
                                                               'Session',
-                                                              style: TextStyle(fontSize: 16, fontWeight: FontWeight.w600, fontFamily: 'Montserrat', color: ColorsUtils.black),
+                                                              style: TextStyle(fontSize: 16, fontWeight: FontWeight.w600, fontFamily: 'Montserrat', color: Theme.of(context).colorScheme.onSurface),
                                                             ),
                                                             GestureDetector(
                                                               onTap: () {
@@ -638,7 +638,7 @@ class FacilityStepThree extends StatelessWidget {
                                                             fontSize: 14,
                                                             fontWeight: FontWeight.w500,
                                                             fontFamily: 'Inter',
-                                                            color: ColorsUtils.chipText,
+                                                            color: Theme.of(context).extension<CustomColors>()!.chipText,
                                                           ),
                                                         ),
                                                         const SizedBox(height: 8),
@@ -664,17 +664,17 @@ class FacilityStepThree extends StatelessWidget {
                                                               child: Container(
                                                                 padding: EdgeInsets.symmetric(horizontal: 6, vertical: 4),
                                                                 decoration: BoxDecoration(
-                                                                  color: ColorsUtils.selectedGridItemColor,
+                                                                  color: Theme.of(context).extension<CustomColors>()!.selectedGridItemColor,
                                                                   borderRadius: BorderRadius.circular(6),
                                                                   border: Border.all(
-                                                                    color: ColorsUtils.lightBlueBorderColor,
+                                                                    color: Theme.of(context).extension<CustomColors>()!.lightBlueBorderColor,
                                                                   ),
                                                                 ),
                                                                 child: Text(
                                                                   time,
                                                                   style: TextStyle(
                                                                     fontSize: 14,
-                                                                    color: ColorsUtils.black,
+                                                                    color: Theme.of(context).colorScheme.onSurface,
                                                                     fontFamily: 'Inter',
                                                                     fontWeight: FontWeight.w400,
                                                                   ),
@@ -688,7 +688,7 @@ class FacilityStepThree extends StatelessWidget {
                                                           'Popular booking times. Click to select quickly.',
                                                           style: TextStyle(
                                                             fontSize: 12,
-                                                            color: ColorsUtils.textGray,
+                                                            color: Theme.of(context).extension<CustomColors>()!.textGray,
                                                             fontFamily: 'Inter',
                                                             fontWeight: FontWeight.w400,
                                                           ),
@@ -705,7 +705,7 @@ class FacilityStepThree extends StatelessWidget {
                                                                   fontSize: 14,
                                                                   fontWeight: FontWeight.w500,
                                                                   fontFamily: 'Inter',
-                                                                  color: ColorsUtils.chipText,
+                                                                  color: Theme.of(context).extension<CustomColors>()!.chipText,
                                                                 ),
                                                               ),
                                                               const SizedBox(height: 15),
@@ -713,7 +713,7 @@ class FacilityStepThree extends StatelessWidget {
                                                                 controller: editSlot.numberOfSlots,
                                                                 autovalidateMode: AutovalidateMode.onUserInteraction,
                                                                 maxLength: 2,
-                                                                fillColor: ColorsUtils.white,
+                                                                fillColor: Theme.of(context).extension<CustomColors>()!.containerBG,
                                                                 isNumber: true,
                                                                 borderRadius: 6,
                                                                 hint: "Number of Slots",
@@ -721,7 +721,7 @@ class FacilityStepThree extends StatelessWidget {
                                                                 textStyle: TextStyle(
                                                                   fontSize: 16,
                                                                   fontFamily: "Inter",
-                                                                  color: ColorsUtils.black,
+                                                                  color: Theme.of(context).colorScheme.onSurface,
                                                                   fontWeight: FontWeight.w500,
                                                                 ),
                                                                 validator: (value) {
@@ -748,7 +748,7 @@ class FacilityStepThree extends StatelessWidget {
                                                                 'Consecutive hours for venue booking',
                                                                 style: TextStyle(
                                                                   fontSize: 12,
-                                                                  color: ColorsUtils.textGray,
+                                                                  color: Theme.of(context).extension<CustomColors>()!.textGray,
                                                                   fontFamily: 'Inter',
                                                                   fontWeight: FontWeight.w400,
                                                                 ),
@@ -760,10 +760,10 @@ class FacilityStepThree extends StatelessWidget {
                                                                 strokeWidth: 1.5,
                                                                 radius: const Radius.circular(5),
                                                                 dashPattern: const [3, 3],
-                                                                color: ColorsUtils.messageRight,
+                                                                color: Theme.of(context).extension<CustomColors>()!.messageRight,
                                                                 child: Container(
                                                                   decoration: BoxDecoration(
-                                                                    color: ColorsUtils.buttonColorGrey,
+                                                                    color: Theme.of(context).extension<CustomColors>()!.buttonColorGrey,
                                                                     borderRadius: BorderRadius.all(
                                                                       Radius.circular(5),
                                                                     ),
@@ -810,7 +810,7 @@ class FacilityStepThree extends StatelessWidget {
                                       'Add multiple slots if you have separate booking periods on the same day',
                                       style: TextStyle(
                                         fontSize: 12,
-                                        color: ColorsUtils.textGray,
+                                        color: Theme.of(context).extension<CustomColors>()!.textGray,
                                         fontFamily: 'Inter',
                                         fontWeight: FontWeight.w400,
                                       ),
@@ -827,8 +827,8 @@ class FacilityStepThree extends StatelessWidget {
                               Expanded(
                                 child: CustomButton(
                                   text: "Cancel",
-                                  textcolor: ColorsUtils.black,
-                                  buttonColor: ColorsUtils.buttonBg,
+                                  textcolor: Theme.of(context).colorScheme.onSurface,
+                                  buttonColor: Theme.of(context).extension<CustomColors>()!.buttonBg,
                                   textsize: 16,
                                   fontWeight: FontWeight.bold,
                                   buttonheight: 50,
@@ -844,8 +844,8 @@ class FacilityStepThree extends StatelessWidget {
                               Expanded(
                                 child: CustomButton(
                                   text: "Add Time Slot",
-                                  textcolor: ColorsUtils.white,
-                                  buttonColor: ColorsUtils.primary,
+                                  textcolor: Theme.of(context).colorScheme.onPrimary,
+                                  buttonColor: Theme.of(context).colorScheme.primary,
                                   textsize: 16,
                                   fontWeight: FontWeight.bold,
                                   buttonheight: 50,
@@ -882,15 +882,23 @@ class FacilityStepThree extends StatelessWidget {
               width: 30,
               height: 30,
               decoration: BoxDecoration(
-                color: isSelected ? ColorsUtils.primary : ColorsUtils.greyBG,
+                color: isSelected ? Theme.of(context).colorScheme.primary : Theme.of(context).extension<CustomColors>()!.greyBG,
                 borderRadius: BorderRadius.circular(7),
               ),
-              child: isSelected ? Icon(Icons.check, size: 18, color: ColorsUtils.white) : null,
+              child: isSelected
+                  ? Icon(Icons.check, size: 18, color: Theme.of(context).extension<CustomColors>()!.onAccentText)
+                  : null,
             ),
             SizedBox(width: 8),
             Text(
               day,
-              style: TextStyle(color: isSelected ? ColorsUtils.black : ColorsUtils.hintTextColor, fontSize: 14, fontWeight: FontWeight.w600, fontFamily: 'Inter'),
+              style: TextStyle(
+                  color: isSelected
+                      ? Theme.of(context).colorScheme.onSurface
+                      : Theme.of(context).extension<CustomColors>()!.hintTextColor,
+                  fontSize: 14,
+                  fontWeight: FontWeight.w600,
+                  fontFamily: 'Inter'),
             ),
           ],
         ),

--- a/lib/screens/setup/facility_setup/view/widgets/facility_step_two.dart
+++ b/lib/screens/setup/facility_setup/view/widgets/facility_step_two.dart
@@ -7,8 +7,7 @@ import 'package:oqdo_mobile_app/screens/setup/facility_setup/view/widgets/base_c
 import 'package:oqdo_mobile_app/screens/setup/facility_setup/view/widgets/duration_input_field.dart';
 import 'package:oqdo_mobile_app/screens/setup/facility_setup/viewmodel/create_facility_view_model.dart';
 import 'package:oqdo_mobile_app/screens/setup/setups_bottom_sheets/ShowClearSlotsBottomSheet.dart';
-import 'package:oqdo_mobile_app/theme/oqdo_theme_data.dart';
-import 'package:oqdo_mobile_app/utils/colorsUtils.dart';
+import 'package:oqdo_mobile_app/theme/custom_colors.dart';
 import 'package:oqdo_mobile_app/utils/constants.dart';
 import 'package:oqdo_mobile_app/utils/custom_text_field.dart';
 import 'package:permission_handler/permission_handler.dart';
@@ -84,7 +83,7 @@ class FacilityStepTwo extends StatelessWidget {
         ),
       ),
       clipBehavior: Clip.antiAliasWithSaveLayer,
-      backgroundColor: OQDOThemeData.whiteColor,
+      backgroundColor: Theme.of(context).colorScheme.surface,
       builder: (BuildContext context) => const ShowClearSlotsBottomSheet(
         height: 230,
         fieldName: "Rental Duration",
@@ -106,6 +105,8 @@ class FacilityStepTwo extends StatelessWidget {
   }
 
   Widget _buildImageAndDescriptionView(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    final customColors = Theme.of(context).extension<CustomColors>()!;
     return Column(
       mainAxisAlignment: MainAxisAlignment.start,
       crossAxisAlignment: CrossAxisAlignment.start,
@@ -115,20 +116,20 @@ class FacilityStepTwo extends StatelessWidget {
           "Images & Description",
           style: TextStyle(
             fontFamily: 'SFPro',
-            color: ColorsUtils.primary,
+            color: colorScheme.primary,
             fontWeight: FontWeight.w600,
             fontSize: 16,
           ),
         ),
         const SizedBox(height: 15.0),
         BaseContainer(
-          bgColor: ColorsUtils.white,
+          bgColor: customColors.containerBG,
           width: double.infinity,
           child: _buildGalleryImageSelectionView(context),
         ),
         const SizedBox(height: 20.0),
         BaseContainer(
-          bgColor: ColorsUtils.white,
+          bgColor: customColors.containerBG,
           width: double.infinity,
           child: _buildCoverImageSelectionView(context),
         ),
@@ -137,7 +138,7 @@ class FacilityStepTwo extends StatelessWidget {
           "Add a cover image and up to 3 gallery photos showcasing your facility.",
           style: TextStyle(
             fontFamily: 'Inter',
-            color: ColorsUtils.hintTextColor,
+            color: customColors.hintTextColor,
             fontWeight: FontWeight.w400,
             fontSize: 12,
           ),
@@ -147,6 +148,7 @@ class FacilityStepTwo extends StatelessWidget {
   }
 
   Widget _buildGalleryImageSelectionView(BuildContext context) {
+    final customColors = Theme.of(context).extension<CustomColors>()!;
     return Column(
       mainAxisAlignment: MainAxisAlignment.start,
       crossAxisAlignment: CrossAxisAlignment.start,
@@ -155,7 +157,7 @@ class FacilityStepTwo extends StatelessWidget {
           "Gallery",
           style: TextStyle(
             fontFamily: 'Montserrat',
-            color: ColorsUtils.chipText,
+            color: customColors.chipText,
             fontWeight: FontWeight.w600,
             fontSize: 14,
           ),
@@ -179,6 +181,8 @@ class FacilityStepTwo extends StatelessWidget {
   }
 
   Widget _buildGallerySelectionTile(BuildContext context, bool forGallery) {
+    final colorScheme = Theme.of(context).colorScheme;
+    final customColors = Theme.of(context).extension<CustomColors>()!;
     return GestureDetector(
       onTap: () async {
         if (forGallery) {
@@ -199,9 +203,9 @@ class FacilityStepTwo extends StatelessWidget {
         width: 90,
         height: 90,
         decoration: BoxDecoration(
-          color: ColorsUtils.lightBlueBGColor,
+          color: customColors.lightBlueBGColor,
           borderRadius: BorderRadius.circular(5),
-          border: Border.all(color: ColorsUtils.primary, width: 1),
+          border: Border.all(color: colorScheme.primary, width: 1),
         ),
         child: Center(
           child: SizedBox(
@@ -348,7 +352,7 @@ class FacilityStepTwo extends StatelessWidget {
           "Cover Image",
           style: TextStyle(
             fontFamily: 'Montserrat',
-            color: ColorsUtils.chipText,
+            color: Theme.of(context).extension<CustomColors>()!.chipText,
             fontWeight: FontWeight.w600,
             fontSize: 14,
           ),
@@ -390,7 +394,7 @@ class FacilityStepTwo extends StatelessWidget {
                     "Tell users about your facility's features",
                     style: TextStyle(
                       fontFamily: 'Montserrat',
-                      color: ColorsUtils.chipText,
+                      color: Theme.of(context).extension<CustomColors>()!.chipText,
                       fontWeight: FontWeight.w600,
                       fontSize: 14,
                     ),
@@ -400,7 +404,7 @@ class FacilityStepTwo extends StatelessWidget {
               const SizedBox(height: 15.0),
               CommonTextField(
                 maxLength: 250,
-                fillColor: ColorsUtils.white,
+                fillColor: Theme.of(context).extension<CustomColors>()!.containerBG,
                 borderRadius: 6,
                 maxLines: 4,
                 hint: "Facility Description",
@@ -410,7 +414,7 @@ class FacilityStepTwo extends StatelessWidget {
                 textStyle: TextStyle(
                   fontSize: 16,
                   fontFamily: "Inter",
-                  color: ColorsUtils.black,
+                  color: Theme.of(context).colorScheme.onSurface,
                   fontWeight: FontWeight.w500,
                 ),
                 validator: (value) {
@@ -425,7 +429,7 @@ class FacilityStepTwo extends StatelessWidget {
                 "Describe your facility's features and amenities.",
                 style: TextStyle(
                   fontFamily: 'Inter',
-                  color: ColorsUtils.hintTextColor,
+                  color: Theme.of(context).extension<CustomColors>()!.hintTextColor,
                   fontWeight: FontWeight.w400,
                   fontSize: 12,
                 ),
@@ -444,7 +448,7 @@ class FacilityStepTwo extends StatelessWidget {
       children: [
         const SizedBox(height: 20),
         BaseContainer(
-          bgColor: ColorsUtils.white,
+          bgColor: Theme.of(context).extension<CustomColors>()!.containerBG,
           child: Column(
             mainAxisAlignment: MainAxisAlignment.start,
             crossAxisAlignment: CrossAxisAlignment.start,
@@ -454,7 +458,7 @@ class FacilityStepTwo extends StatelessWidget {
                 "Configure your facility details",
                 style: TextStyle(
                   fontFamily: 'Montserrat',
-                  color: ColorsUtils.chipText,
+                  color: Theme.of(context).extension<CustomColors>()!.chipText,
                   fontWeight: FontWeight.w600,
                   fontSize: 14,
                 ),
@@ -479,7 +483,7 @@ class FacilityStepTwo extends StatelessWidget {
                               ),
                             ),
                             clipBehavior: Clip.antiAliasWithSaveLayer,
-                            backgroundColor: OQDOThemeData.whiteColor,
+                            backgroundColor: Theme.of(context).colorScheme.surface,
                             builder: (BuildContext context) => const ShowClearSlotsBottomSheet(
                               height: 230,
                               fieldName: "Rental Duration",
@@ -555,7 +559,7 @@ class FacilityStepTwo extends StatelessWidget {
                                 ),
                               ),
                               clipBehavior: Clip.antiAliasWithSaveLayer,
-                              backgroundColor: OQDOThemeData.whiteColor,
+                              backgroundColor: Theme.of(context).colorScheme.surface,
                               builder: (BuildContext context) => const ShowClearSlotsBottomSheet(
                                 height: 230,
                                 fieldName: "Rental Duration",
@@ -587,7 +591,7 @@ class FacilityStepTwo extends StatelessWidget {
                       style: TextStyle(
                         fontSize: 14,
                         fontFamily: "Inter",
-                        color: ColorsUtils.hintTextColor,
+                        color: Theme.of(context).extension<CustomColors>()!.hintTextColor,
                         fontWeight: FontWeight.w400,
                       ),
                     ),
@@ -599,7 +603,7 @@ class FacilityStepTwo extends StatelessWidget {
                 "Minimum 1 hour -  booking duration for users",
                 style: TextStyle(
                   fontFamily: 'Inter',
-                  color: ColorsUtils.hintTextColor,
+                  color: Theme.of(context).extension<CustomColors>()!.hintTextColor,
                   fontWeight: FontWeight.w400,
                   fontSize: 12,
                 ),
@@ -617,17 +621,17 @@ class FacilityStepTwo extends StatelessWidget {
                     child: Container(
                       padding: EdgeInsets.symmetric(horizontal: 6, vertical: 4),
                       decoration: BoxDecoration(
-                        color: ColorsUtils.selectedGridItemColor,
+                        color: Theme.of(context).extension<CustomColors>()!.selectedGridItemColor,
                         borderRadius: BorderRadius.circular(6),
                         border: Border.all(
-                          color: ColorsUtils.lightBlueBorderColor,
+                          color: Theme.of(context).extension<CustomColors>()!.lightBlueBorderColor,
                         ),
                       ),
                       child: Text(
                         duration,
                         style: TextStyle(
                           fontSize: 14,
-                          color: ColorsUtils.black,
+                          color: Theme.of(context).colorScheme.onSurface,
                           fontFamily: 'Inter',
                           fontWeight: FontWeight.w400,
                         ),
@@ -641,7 +645,7 @@ class FacilityStepTwo extends StatelessWidget {
                 'Popular Duration. Click to select quickly.',
                 style: TextStyle(
                   fontSize: 12,
-                  color: ColorsUtils.textGray,
+                  color: Theme.of(context).extension<CustomColors>()!.textGray,
                   fontFamily: 'Inter',
                   fontWeight: FontWeight.w400,
                 ),
@@ -649,7 +653,7 @@ class FacilityStepTwo extends StatelessWidget {
               const SizedBox(height: 15),
               CommonTextField(
                 maxLength: 3,
-                fillColor: ColorsUtils.white,
+                fillColor: Theme.of(context).extension<CustomColors>()!.containerBG,
                 isNumber: true,
                 borderRadius: 6,
                 hint: (context.watch<CreateFacilityViewModel>().selectedBookingType?.id == 1)
@@ -663,7 +667,7 @@ class FacilityStepTwo extends StatelessWidget {
                 textStyle: TextStyle(
                   fontSize: 16,
                   fontFamily: "Inter",
-                  color: ColorsUtils.black,
+                  color: Theme.of(context).colorScheme.onSurface,
                   fontWeight: FontWeight.w500,
                 ),
                 validator: (value) {
@@ -693,7 +697,7 @@ class FacilityStepTwo extends StatelessWidget {
                 "Maximum number of people allowed to book the facility",
                 style: TextStyle(
                   fontFamily: 'Inter',
-                  color: ColorsUtils.hintTextColor,
+                  color: Theme.of(context).extension<CustomColors>()!.hintTextColor,
                   fontWeight: FontWeight.w400,
                   fontSize: 12,
                 ),

--- a/lib/screens/setup/facility_setup/view/widgets/setup_grid_view_item.dart
+++ b/lib/screens/setup/facility_setup/view/widgets/setup_grid_view_item.dart
@@ -1,6 +1,6 @@
 import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
-import 'package:oqdo_mobile_app/utils/colorsUtils.dart';
+import 'package:oqdo_mobile_app/theme/custom_colors.dart';
 
 class SetupGridViewItem extends StatelessWidget {
   const SetupGridViewItem({
@@ -24,18 +24,23 @@ class SetupGridViewItem extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    final customColors = Theme.of(context).extension<CustomColors>()!;
+    final double borderOpacity = isEnabled ? 1 : 0.25;
+    final double backgroundOpacity = isEnabled ? 1 : 0.5;
+    final Color resolvedUnselectedColor = unSelectedColor ?? customColors.containerBG;
     return GestureDetector(
       onTap: isEnabled ? onTap : null,
       child: Container(
         padding: EdgeInsets.all(10.0),
         decoration: BoxDecoration(
           border: Border.all(
-              color: isSelected ? ColorsUtils.primary.withValues(alpha: isEnabled ? 1 : 0.25) : ColorsUtils.borderColor.withValues(alpha: isEnabled ? 1 : 0.25),
+              color: (isSelected ? colorScheme.primary : customColors.borderColor).withOpacity(borderOpacity),
               width: 1),
           borderRadius: BorderRadius.circular(5.0),
           color: isSelected
-              ? ColorsUtils.selectedGridItemColor.withValues(alpha: isEnabled ? 1 : 0.5)
-              : ((unSelectedColor ?? ColorsUtils.containerBG)..withValues(alpha: isEnabled ? 1 : 0.5)),
+              ? customColors.selectedGridItemColor.withOpacity(backgroundOpacity)
+              : resolvedUnselectedColor.withOpacity(backgroundOpacity),
         ),
         child: Column(
           mainAxisAlignment: MainAxisAlignment.center,
@@ -69,7 +74,7 @@ class SetupGridViewItem extends StatelessWidget {
                 style: TextStyle(
                   fontSize: 13,
                   fontWeight: FontWeight.w500,
-                  color: ColorsUtils.black,
+                  color: colorScheme.onSurface,
                   fontFamily: 'Inter',
                 ),
               ),

--- a/lib/screens/setup/facility_setup/view/widgets/time_input_field.dart
+++ b/lib/screens/setup/facility_setup/view/widgets/time_input_field.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
-import 'package:oqdo_mobile_app/utils/colorsUtils.dart';
+import 'package:oqdo_mobile_app/theme/custom_colors.dart';
 import 'package:oqdo_mobile_app/utils/constants.dart';
 
 class TimeInputField extends StatefulWidget {
@@ -268,9 +268,9 @@ class TimeInputFieldState extends State<TimeInputField> {
           child: Theme(
             data: Theme.of(context).copyWith(
               timePickerTheme: TimePickerThemeData(
-                backgroundColor: ColorsUtils.white,
-                hourMinuteTextColor: ColorsUtils.black,
-                dayPeriodTextColor: ColorsUtils.black,
+                backgroundColor: Theme.of(context).colorScheme.surface,
+                hourMinuteTextColor: Theme.of(context).colorScheme.onSurface,
+                dayPeriodTextColor: Theme.of(context).colorScheme.onSurface,
               ),
             ),
             child: child!,
@@ -310,7 +310,7 @@ class TimeInputFieldState extends State<TimeInputField> {
           ScaffoldMessenger.of(context).showSnackBar(
             SnackBar(
               content: Text(errorMessage),
-              backgroundColor: ColorsUtils.redColor,
+              backgroundColor: Theme.of(context).extension<CustomColors>()!.redColor,
               duration: const Duration(seconds: 3),
             ),
           );
@@ -478,11 +478,13 @@ class TimeInputFieldState extends State<TimeInputField> {
           height: 48,
           decoration: BoxDecoration(
             border: Border.all(
-              color: _errorText != null ? ColorsUtils.redColor : ColorsUtils.borderColor,
+              color: _errorText != null
+                  ? Theme.of(context).extension<CustomColors>()!.redColor
+                  : Theme.of(context).extension<CustomColors>()!.borderColor,
               width: 1,
             ),
             borderRadius: BorderRadius.circular(6),
-            color: ColorsUtils.white,
+            color: Theme.of(context).extension<CustomColors>()!.containerBG,
           ),
           child: Row(
             children: [
@@ -497,14 +499,14 @@ class TimeInputFieldState extends State<TimeInputField> {
                   ],
                   style: TextStyle(
                     fontSize: 14,
-                    color: ColorsUtils.black,
+                    color: Theme.of(context).colorScheme.onSurface,
                     fontFamily: 'Inter',
                     fontWeight: FontWeight.w600,
                   ),
                   decoration: InputDecoration(
                     hintText: widget.hintText,
                     hintStyle: TextStyle(
-                      color: ColorsUtils.hintTextColor,
+                      color: Theme.of(context).extension<CustomColors>()!.hintTextColor,
                       fontSize: 14,
                       fontFamily: 'Inter',
                       fontWeight: FontWeight.w400,
@@ -549,7 +551,7 @@ class TimeInputFieldState extends State<TimeInputField> {
             _errorText!,
             style: TextStyle(
               fontSize: 12,
-              color: ColorsUtils.redColor,
+              color: Theme.of(context).extension<CustomColors>()!.redColor,
               fontFamily: 'Inter',
               fontWeight: FontWeight.w400,
             ),

--- a/lib/theme/custom_colors.dart
+++ b/lib/theme/custom_colors.dart
@@ -39,6 +39,19 @@ class CustomColors extends ThemeExtension<CustomColors> {
     required this.meetupCreatorCard,
     required this.meetupParticipantCard,
     required this.meetupEmptyCard,
+    required this.borderColor,
+    required this.selectedGridItemColor,
+    required this.lightBlueBGColor,
+    required this.lightBlueBorderColor,
+    required this.buttonBg,
+    required this.greyBG,
+    required this.buttonColorGrey,
+    required this.hintTextColor,
+    required this.textGray,
+    required this.containerBG,
+    required this.green,
+    required this.darkRed,
+    required this.onAccentText,
   });
 
   final Color greyButton;
@@ -78,6 +91,19 @@ class CustomColors extends ThemeExtension<CustomColors> {
   final Color meetupCreatorCard;
   final Color meetupParticipantCard;
   final Color meetupEmptyCard;
+  final Color borderColor;
+  final Color selectedGridItemColor;
+  final Color lightBlueBGColor;
+  final Color lightBlueBorderColor;
+  final Color buttonBg;
+  final Color greyBG;
+  final Color buttonColorGrey;
+  final Color hintTextColor;
+  final Color textGray;
+  final Color containerBG;
+  final Color green;
+  final Color darkRed;
+  final Color onAccentText;
 
   static const CustomColors light = CustomColors(
     greyButton: Color(0xFFEFEFEF),
@@ -117,6 +143,19 @@ class CustomColors extends ThemeExtension<CustomColors> {
     meetupCreatorCard: Color(0xFFFFFAEB),
     meetupParticipantCard: Color(0xFFEAF2F6),
     meetupEmptyCard: Color(0xFFEDEDED),
+    borderColor: Color(0xFFE9E9E9),
+    selectedGridItemColor: Color(0xFFEBF9FF),
+    lightBlueBGColor: Color(0xFFD6F3FF),
+    lightBlueBorderColor: Color(0xFFB4D9E9),
+    buttonBg: Color(0xFFF2F2F2),
+    greyBG: Color(0xFFDBDBDB),
+    buttonColorGrey: Color(0xFFF6F6F6),
+    hintTextColor: Color(0xFF878787),
+    textGray: Color(0xFF737373),
+    containerBG: Color(0xFFFBFBFB),
+    green: Color(0xFF067421),
+    darkRed: Color(0xFFA80000),
+    onAccentText: Color(0xFFFFFFFF),
   );
 
   static const CustomColors dark = CustomColors(
@@ -157,6 +196,19 @@ class CustomColors extends ThemeExtension<CustomColors> {
     meetupCreatorCard: Color(0xFF3B3628),
     meetupParticipantCard: Color(0xFF2A3540),
     meetupEmptyCard: Color(0xFF2A2A2A),
+    borderColor: Color(0xFF404040),
+    selectedGridItemColor: Color(0xFF1E3A45),
+    lightBlueBGColor: Color(0xFF102734),
+    lightBlueBorderColor: Color(0xFF2F5E73),
+    buttonBg: Color(0xFF2A2A2A),
+    greyBG: Color(0xFF3A3A3A),
+    buttonColorGrey: Color(0xFF333333),
+    hintTextColor: Color(0xFFB0B0B0),
+    textGray: Color(0xFFB0B0B0),
+    containerBG: Color(0xFF1E1E1E),
+    green: Color(0xFF4CAF50),
+    darkRed: Color(0xFFE57373),
+    onAccentText: Color(0xFFFFFFFF),
   );
 
   @override
@@ -198,6 +250,19 @@ class CustomColors extends ThemeExtension<CustomColors> {
     Color? meetupCreatorCard,
     Color? meetupParticipantCard,
     Color? meetupEmptyCard,
+    Color? borderColor,
+    Color? selectedGridItemColor,
+    Color? lightBlueBGColor,
+    Color? lightBlueBorderColor,
+    Color? buttonBg,
+    Color? greyBG,
+    Color? buttonColorGrey,
+    Color? hintTextColor,
+    Color? textGray,
+    Color? containerBG,
+    Color? green,
+    Color? darkRed,
+    Color? onAccentText,
   }) {
     return CustomColors(
       greyButton: greyButton ?? this.greyButton,
@@ -237,6 +302,19 @@ class CustomColors extends ThemeExtension<CustomColors> {
       meetupCreatorCard: meetupCreatorCard ?? this.meetupCreatorCard,
       meetupParticipantCard: meetupParticipantCard ?? this.meetupParticipantCard,
       meetupEmptyCard: meetupEmptyCard ?? this.meetupEmptyCard,
+      borderColor: borderColor ?? this.borderColor,
+      selectedGridItemColor: selectedGridItemColor ?? this.selectedGridItemColor,
+      lightBlueBGColor: lightBlueBGColor ?? this.lightBlueBGColor,
+      lightBlueBorderColor: lightBlueBorderColor ?? this.lightBlueBorderColor,
+      buttonBg: buttonBg ?? this.buttonBg,
+      greyBG: greyBG ?? this.greyBG,
+      buttonColorGrey: buttonColorGrey ?? this.buttonColorGrey,
+      hintTextColor: hintTextColor ?? this.hintTextColor,
+      textGray: textGray ?? this.textGray,
+      containerBG: containerBG ?? this.containerBG,
+      green: green ?? this.green,
+      darkRed: darkRed ?? this.darkRed,
+      onAccentText: onAccentText ?? this.onAccentText,
     );
   }
 
@@ -282,7 +360,20 @@ class CustomColors extends ThemeExtension<CustomColors> {
       meetupCreatorCard: Color.lerp(meetupCreatorCard, other.meetupCreatorCard, t)!,
       meetupParticipantCard: Color.lerp(meetupParticipantCard, other.meetupParticipantCard, t)!,
       meetupEmptyCard: Color.lerp(meetupEmptyCard, other.meetupEmptyCard, t)!,
+      borderColor: Color.lerp(borderColor, other.borderColor, t)!,
+      selectedGridItemColor: Color.lerp(selectedGridItemColor, other.selectedGridItemColor, t)!,
+      lightBlueBGColor: Color.lerp(lightBlueBGColor, other.lightBlueBGColor, t)!,
+      lightBlueBorderColor: Color.lerp(lightBlueBorderColor, other.lightBlueBorderColor, t)!,
+      buttonBg: Color.lerp(buttonBg, other.buttonBg, t)!,
+      greyBG: Color.lerp(greyBG, other.greyBG, t)!,
+      buttonColorGrey: Color.lerp(buttonColorGrey, other.buttonColorGrey, t)!,
+      hintTextColor: Color.lerp(hintTextColor, other.hintTextColor, t)!,
+      textGray: Color.lerp(textGray, other.textGray, t)!,
+      containerBG: Color.lerp(containerBG, other.containerBG, t)!,
+      green: Color.lerp(green, other.green, t)!,
+      darkRed: Color.lerp(darkRed, other.darkRed, t)!,
+      onAccentText: Color.lerp(onAccentText, other.onAccentText, t)!,
     );
-    }
   }
+}
 


### PR DESCRIPTION
## Summary
- extend the `CustomColors` theme extension with facility setup specific colors and helpers for accent text
- refactor facility setup flow widgets and preview page to resolve all `ColorsUtils` usages to theme-aware colors
- ensure bottom sheets, buttons and text fields respect the active color scheme for both light and dark modes

## Testing
- ⚠️ `flutter format` *(not run – flutter command unavailable in container)*
- ⚠️ `dart format` *(not run – dart command unavailable in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cd0adec84483328e9dfc4664d367e3