### PR TITLE
refactor: add theme-aware colors to coach setup screens

### DIFF
--- a/lib/screens/setup/coach_setup/view/coach_training_preview_page.dart
+++ b/lib/screens/setup/coach_setup/view/coach_training_preview_page.dart
@@ -4,7 +4,7 @@ import 'package:oqdo_mobile_app/components/custom_button.dart';
 import 'package:oqdo_mobile_app/oqdo_application.dart';
 import 'package:oqdo_mobile_app/screens/setup/coach_setup/models/coach_preview_model.dart';
 import 'package:oqdo_mobile_app/screens/setup/facility_setup/view/widgets/base_container.dart';
-import 'package:oqdo_mobile_app/utils/colorsUtils.dart';
+import 'package:oqdo_mobile_app/theme/custom_colors.dart';
 import 'package:oqdo_mobile_app/utils/constants.dart';
 
 class CoachTrainingPreviewPage extends StatelessWidget {
@@ -16,16 +16,19 @@ class CoachTrainingPreviewPage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    final customColors = Theme.of(context).extension<CustomColors>()!;
+
     return Scaffold(
-      backgroundColor: ColorsUtils.white,
+      backgroundColor: colorScheme.background,
       appBar: AppBar(
-        backgroundColor: ColorsUtils.white,
+        backgroundColor: colorScheme.surface,
         elevation: 0,
         titleSpacing: 0,
         leading: IconButton(
           icon: Icon(
             Icons.arrow_back,
-            color: ColorsUtils.black,
+            color: colorScheme.onSurface,
             size: 24,
           ),
           onPressed: () => Navigator.of(context).pop(true),
@@ -33,7 +36,7 @@ class CoachTrainingPreviewPage extends StatelessWidget {
         title: Text(
           "Training Preview",
           style: TextStyle(
-            color: ColorsUtils.chipText,
+            color: customColors.chipText,
             fontFamily: 'Montserrat',
             fontSize: 18,
             fontWeight: FontWeight.w600,
@@ -47,19 +50,19 @@ class CoachTrainingPreviewPage extends StatelessWidget {
             mainAxisAlignment: MainAxisAlignment.start,
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
-              _buildTrainingPreviewCard(),
+              _buildTrainingPreviewCard(context, customColors, colorScheme),
               const SizedBox(height: 20.0),
-              _buildUserCard(),
+              _buildUserCard(context, customColors, colorScheme),
               const SizedBox(height: 20.0),
-              _buildAvailableSessionsView(),
+              _buildAvailableSessionsView(context, customColors, colorScheme),
               const SizedBox(height: 20.0),
-              _buildTrainingVenueView(),
+              _buildTrainingVenueView(context, customColors, colorScheme),
               const SizedBox(height: 20.0),
-              _buildAboutTrainingView(),
+              _buildAboutTrainingView(context, customColors, colorScheme),
               const SizedBox(height: 20.0),
-              _buildGoToListViewButton(context),
+              _buildGoToListViewButton(context, colorScheme),
               const SizedBox(height: 20.0),
-              _buildBottomText(),
+              _buildBottomText(context, customColors),
             ],
           ),
         ),
@@ -67,10 +70,14 @@ class CoachTrainingPreviewPage extends StatelessWidget {
     );
   }
 
-  Widget _buildTrainingPreviewCard() {
+  Widget _buildTrainingPreviewCard(
+    BuildContext context,
+    CustomColors customColors,
+    ColorScheme colorScheme,
+  ) {
     return BaseContainer(
-      borderColor: ColorsUtils.primary,
-      bgColor: ColorsUtils.selectedGridItemColor,
+      borderColor: colorScheme.primary,
+      bgColor: customColors.selectedGridItemColor,
       child: Column(
         mainAxisAlignment: MainAxisAlignment.start,
         crossAxisAlignment: CrossAxisAlignment.start,
@@ -79,7 +86,7 @@ class CoachTrainingPreviewPage extends StatelessWidget {
             coachDetails.title,
             style: TextStyle(
               fontFamily: 'Inter',
-              color: ColorsUtils.primary,
+              color: colorScheme.primary,
               fontWeight: FontWeight.w600,
               fontSize: 18,
             ),
@@ -89,30 +96,32 @@ class CoachTrainingPreviewPage extends StatelessWidget {
             mainAxisAlignment: MainAxisAlignment.spaceBetween,
             crossAxisAlignment: CrossAxisAlignment.center,
             children: [
-              Text(
-                "${coachDetails.activity} > ${coachDetails.subActivity}",
-                style: TextStyle(
-                  fontFamily: 'Inter',
-                  color: ColorsUtils.chipText,
-                  fontWeight: FontWeight.w500,
-                  fontSize: 14,
+              Expanded(
+                child: Text(
+                  "${coachDetails.activity} > ${coachDetails.subActivity}",
+                  style: TextStyle(
+                    fontFamily: 'Inter',
+                    color: customColors.chipText,
+                    fontWeight: FontWeight.w500,
+                    fontSize: 14,
+                  ),
                 ),
               ),
               const SizedBox(width: 10.0),
               Container(
-                padding: EdgeInsets.symmetric(horizontal: 8.0, vertical: 4.0),
+                padding: const EdgeInsets.symmetric(horizontal: 8.0, vertical: 4.0),
                 decoration: BoxDecoration(
                   borderRadius: BorderRadius.circular(20.0),
                   color: coachDetails.isOpenClass
-                      ? ColorsUtils.green
-                      : ColorsUtils.darkRed,
+                      ? customColors.green
+                      : customColors.darkRed,
                 ),
                 child: Text(
                   coachDetails.isOpenClass ? 'Open Class' : 'Group Class',
                   style: TextStyle(
                     fontSize: 12,
                     fontWeight: FontWeight.w500,
-                    color: ColorsUtils.white,
+                    color: customColors.onAccentText,
                     fontFamily: 'Montserrat',
                   ),
                 ),
@@ -120,72 +129,41 @@ class CoachTrainingPreviewPage extends StatelessWidget {
             ],
           ),
           const SizedBox(height: 10),
-          Row(
-            mainAxisAlignment: MainAxisAlignment.start,
-            crossAxisAlignment: CrossAxisAlignment.start,
+          Wrap(
+            spacing: 10,
+            runSpacing: 10,
+            alignment: WrapAlignment.start,
+            crossAxisAlignment: WrapCrossAlignment.center,
             children: [
-              Row(
-                mainAxisAlignment: MainAxisAlignment.start,
-                crossAxisAlignment: CrossAxisAlignment.center,
-                children: [
-                  Icon(Icons.access_time,
-                      size: 20, color: ColorsUtils.chipText),
-                  SizedBox(width: 8),
-                  Text(
-                    '${coachDetails.slotDurationFormatted} sessions',
-                    style: TextStyle(
-                      fontSize: 13,
-                      fontFamily: 'Montserrat',
-                      fontWeight: FontWeight.w600,
-                      color: ColorsUtils.chipText,
-                    ),
-                  ),
-                ],
+              _buildTrainingInfoRow(
+                context,
+                icon: const Icon(Icons.access_time, size: 20),
+                label: '${coachDetails.slotDurationFormatted} sessions',
+                colorScheme: colorScheme,
+                customColors: customColors,
               ),
-              const SizedBox(width: 10.0),
-              Row(
-                mainAxisAlignment: MainAxisAlignment.start,
-                crossAxisAlignment: CrossAxisAlignment.center,
-                children: [
-                  Image.asset(
-                    "assets/images/ic_dollar_rounded.png",
+              _buildTrainingInfoRow(
+                context,
+                icon: Image.asset(
+                  "assets/images/ic_dollar_rounded.png",
+                  height: 20,
+                  width: 20,
+                ),
+                label: 'From ${parseDoubleToRoundString(coachDetails.slotRate)}/hr',
+                colorScheme: colorScheme,
+                customColors: customColors,
+              ),
+              if (coachDetails.isOpenClass)
+                _buildTrainingInfoRow(
+                  context,
+                  icon: Image.asset(
+                    "assets/images/ic_persons.png",
                     height: 20,
                     width: 20,
                   ),
-                  SizedBox(width: 8),
-                  Text(
-                    'From ${parseDoubleToRoundString(coachDetails.slotRate)}/hr',
-                    style: TextStyle(
-                      fontSize: 13,
-                      fontFamily: 'Montserrat',
-                      fontWeight: FontWeight.w600,
-                      color: ColorsUtils.chipText,
-                    ),
-                  ),
-                ],
-              ),
-              const SizedBox(width: 10.0),
-              if (coachDetails.isOpenClass)
-                Row(
-                  mainAxisAlignment: MainAxisAlignment.start,
-                  crossAxisAlignment: CrossAxisAlignment.center,
-                  children: [
-                    Image.asset(
-                      "assets/images/ic_persons.png",
-                      height: 20,
-                      width: 20,
-                    ),
-                    SizedBox(width: 8),
-                    Text(
-                      '${coachDetails.maxCapacityOrGroupSize} max capacity',
-                      style: TextStyle(
-                        fontSize: 13,
-                        fontFamily: 'Montserrat',
-                        fontWeight: FontWeight.w600,
-                        color: ColorsUtils.chipText,
-                      ),
-                    ),
-                  ],
+                  label: '${coachDetails.maxCapacityOrGroupSize} max capacity',
+                  colorScheme: colorScheme,
+                  customColors: customColors,
                 ),
             ],
           ),
@@ -194,10 +172,43 @@ class CoachTrainingPreviewPage extends StatelessWidget {
     );
   }
 
-  Widget _buildUserCard() {
+  Widget _buildTrainingInfoRow(
+    BuildContext context, {
+    required Widget icon,
+    required String label,
+    required ColorScheme colorScheme,
+    required CustomColors customColors,
+  }) {
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.center,
+      children: [
+        IconTheme(
+          data: IconThemeData(color: customColors.chipText),
+          child: icon,
+        ),
+        const SizedBox(width: 8),
+        Text(
+          label,
+          style: TextStyle(
+            fontSize: 13,
+            fontFamily: 'Montserrat',
+            fontWeight: FontWeight.w600,
+            color: customColors.chipText,
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildUserCard(
+    BuildContext context,
+    CustomColors customColors,
+    ColorScheme colorScheme,
+  ) {
     return BaseContainer(
-      borderColor: ColorsUtils.borderColor,
-      bgColor: ColorsUtils.buttonBg,
+      borderColor: customColors.borderColor,
+      bgColor: customColors.buttonBg,
       child: Row(
         mainAxisAlignment: MainAxisAlignment.start,
         crossAxisAlignment: CrossAxisAlignment.center,
@@ -236,7 +247,7 @@ class CoachTrainingPreviewPage extends StatelessWidget {
                 OQDOApplication.instance.userName ?? "",
                 style: TextStyle(
                   fontFamily: 'Inter',
-                  color: ColorsUtils.black,
+                  color: colorScheme.onSurface,
                   fontWeight: FontWeight.w600,
                   fontSize: 18,
                 ),
@@ -246,7 +257,7 @@ class CoachTrainingPreviewPage extends StatelessWidget {
                 "${OQDOApplication.instance.coachExperienceYears ?? 0} ${(OQDOApplication.instance.coachExperienceYears ?? 0) > 1 ? "years" : "year"}",
                 style: TextStyle(
                   fontFamily: 'Inter',
-                  color: ColorsUtils.textGray,
+                  color: customColors.textGray,
                   fontWeight: FontWeight.w500,
                   fontSize: 16,
                 ),
@@ -258,10 +269,14 @@ class CoachTrainingPreviewPage extends StatelessWidget {
     );
   }
 
-  Widget _buildAvailableSessionsView() {
+  Widget _buildAvailableSessionsView(
+    BuildContext context,
+    CustomColors customColors,
+    ColorScheme colorScheme,
+  ) {
     return BaseContainer(
-      borderColor: ColorsUtils.borderColor,
-      bgColor: ColorsUtils.white,
+      borderColor: customColors.borderColor,
+      bgColor: customColors.white,
       child: Row(
         mainAxisAlignment: MainAxisAlignment.start,
         crossAxisAlignment: CrossAxisAlignment.start,
@@ -275,7 +290,7 @@ class CoachTrainingPreviewPage extends StatelessWidget {
                   "Available Sessions",
                   style: TextStyle(
                     fontFamily: 'Inter',
-                    color: ColorsUtils.black,
+                    color: colorScheme.onSurface,
                     fontWeight: FontWeight.w600,
                     fontSize: 14,
                   ),
@@ -288,7 +303,7 @@ class CoachTrainingPreviewPage extends StatelessWidget {
                   itemBuilder: (context, index) {
                     final slotDetails = coachDetails.slotsList[index];
                     return BaseContainer(
-                      bgColor: ColorsUtils.buttonBg,
+                      bgColor: customColors.buttonBg,
                       child: Row(
                         mainAxisAlignment: MainAxisAlignment.spaceBetween,
                         crossAxisAlignment: CrossAxisAlignment.center,
@@ -304,22 +319,20 @@ class CoachTrainingPreviewPage extends StatelessWidget {
                                       child: Wrap(
                                         spacing: 8,
                                         runSpacing: 8,
-                                        children: slotDetails.sortedSelectedDays
-                                            .map((day) {
+                                        children: slotDetails.sortedSelectedDays.map((day) {
                                           return Container(
-                                            padding: EdgeInsets.symmetric(
-                                                horizontal: 10.0,
-                                                vertical: 4.0),
+                                            padding: const EdgeInsets.symmetric(
+                                                horizontal: 10.0, vertical: 4.0),
                                             decoration: BoxDecoration(
-                                                borderRadius:
-                                                    BorderRadius.circular(20.0),
-                                                color: ColorsUtils.white),
+                                              borderRadius: BorderRadius.circular(20.0),
+                                              color: customColors.containerBG,
+                                            ),
                                             child: Text(
                                               day.title,
                                               style: TextStyle(
                                                 fontSize: 14,
                                                 fontWeight: FontWeight.w400,
-                                                color: ColorsUtils.black,
+                                                color: colorScheme.onSurface,
                                                 fontFamily: 'Inter',
                                               ),
                                             ),
@@ -335,7 +348,7 @@ class CoachTrainingPreviewPage extends StatelessWidget {
                                       coachDetails.slotDurationInMinutes),
                                   style: TextStyle(
                                     fontFamily: 'Inter',
-                                    color: ColorsUtils.black,
+                                    color: colorScheme.onSurface,
                                     fontWeight: FontWeight.w500,
                                     fontSize: 14,
                                   ),
@@ -352,7 +365,7 @@ class CoachTrainingPreviewPage extends StatelessWidget {
                                 "S\$ ${parseDoubleToRoundString(slotDetails.ratePerHour ?? 0)}/hr",
                                 style: TextStyle(
                                   fontFamily: 'Inter',
-                                  color: ColorsUtils.primary,
+                                  color: colorScheme.primary,
                                   fontWeight: FontWeight.w500,
                                   fontSize: 16,
                                 ),
@@ -362,7 +375,7 @@ class CoachTrainingPreviewPage extends StatelessWidget {
                                 "${slotDetails.tempNumberOfSlots} ${((slotDetails.tempNumberOfSlots) > 1) ? "Slots" : "Slot"}",
                                 style: TextStyle(
                                   fontFamily: 'Inter',
-                                  color: ColorsUtils.textGray,
+                                  color: customColors.textGray,
                                   fontWeight: FontWeight.w500,
                                   fontSize: 14,
                                 ),
@@ -373,8 +386,7 @@ class CoachTrainingPreviewPage extends StatelessWidget {
                       ),
                     );
                   },
-                  separatorBuilder: (context, index) =>
-                      const SizedBox(height: 10.0),
+                  separatorBuilder: (context, index) => const SizedBox(height: 10.0),
                 ),
               ],
             ),
@@ -384,10 +396,14 @@ class CoachTrainingPreviewPage extends StatelessWidget {
     );
   }
 
-  Widget _buildTrainingVenueView() {
+  Widget _buildTrainingVenueView(
+    BuildContext context,
+    CustomColors customColors,
+    ColorScheme colorScheme,
+  ) {
     return BaseContainer(
-      borderColor: ColorsUtils.borderColor,
-      bgColor: ColorsUtils.white,
+      borderColor: customColors.borderColor,
+      bgColor: customColors.white,
       child: Row(
         mainAxisAlignment: MainAxisAlignment.start,
         crossAxisAlignment: CrossAxisAlignment.start,
@@ -401,7 +417,7 @@ class CoachTrainingPreviewPage extends StatelessWidget {
                   "Training Venue",
                   style: TextStyle(
                     fontFamily: 'Montserrat',
-                    color: ColorsUtils.black,
+                    color: colorScheme.onSurface,
                     fontWeight: FontWeight.w600,
                     fontSize: 14,
                   ),
@@ -411,7 +427,7 @@ class CoachTrainingPreviewPage extends StatelessWidget {
                   "Location Type",
                   style: TextStyle(
                     fontFamily: 'Inter',
-                    color: ColorsUtils.textGray,
+                    color: customColors.textGray,
                     fontWeight: FontWeight.w400,
                     fontSize: 14,
                   ),
@@ -423,11 +439,19 @@ class CoachTrainingPreviewPage extends StatelessWidget {
                   children: [
                     if ((coachDetails.addressTypeId == 1) ||
                         (coachDetails.addressTypeId == 3))
-                      _buildLocationType(title: "Coach's Address"),
+                      _buildLocationType(
+                        context,
+                        customColors,
+                        title: "Coach's Address",
+                      ),
                     const SizedBox(width: 10.0),
                     if ((coachDetails.addressTypeId == 2) ||
                         (coachDetails.addressTypeId == 3))
-                      _buildLocationType(title: "Home Training"),
+                      _buildLocationType(
+                        context,
+                        customColors,
+                        title: "Home Training",
+                      ),
                   ],
                 ),
                 const SizedBox(height: 10),
@@ -435,7 +459,7 @@ class CoachTrainingPreviewPage extends StatelessWidget {
                   "Address",
                   style: TextStyle(
                     fontFamily: 'Inter',
-                    color: ColorsUtils.textGray,
+                    color: customColors.textGray,
                     fontWeight: FontWeight.w400,
                     fontSize: 14,
                   ),
@@ -445,7 +469,7 @@ class CoachTrainingPreviewPage extends StatelessWidget {
                   "Venue address will be provided after booking",
                   style: TextStyle(
                     fontFamily: 'Inter',
-                    color: ColorsUtils.black,
+                    color: colorScheme.onSurface,
                     fontWeight: FontWeight.w600,
                     fontSize: 14,
                   ),
@@ -458,10 +482,14 @@ class CoachTrainingPreviewPage extends StatelessWidget {
     );
   }
 
-  Widget _buildAboutTrainingView() {
+  Widget _buildAboutTrainingView(
+    BuildContext context,
+    CustomColors customColors,
+    ColorScheme colorScheme,
+  ) {
     return BaseContainer(
-      borderColor: ColorsUtils.borderColor,
-      bgColor: ColorsUtils.white,
+      borderColor: customColors.borderColor,
+      bgColor: customColors.white,
       child: Row(
         mainAxisAlignment: MainAxisAlignment.start,
         crossAxisAlignment: CrossAxisAlignment.start,
@@ -475,7 +503,7 @@ class CoachTrainingPreviewPage extends StatelessWidget {
                   "About This Training",
                   style: TextStyle(
                     fontFamily: 'Montserrat',
-                    color: ColorsUtils.black,
+                    color: colorScheme.onSurface,
                     fontWeight: FontWeight.w600,
                     fontSize: 14,
                   ),
@@ -485,7 +513,7 @@ class CoachTrainingPreviewPage extends StatelessWidget {
                   "Join our open training sessions where you'll learn alongside other students. Perfect for building skills in a supportive group environment with professional instruction.",
                   style: TextStyle(
                     fontFamily: 'Inter',
-                    color: ColorsUtils.textGray,
+                    color: customColors.textGray,
                     fontWeight: FontWeight.w500,
                     fontSize: 12,
                   ),
@@ -501,17 +529,19 @@ class CoachTrainingPreviewPage extends StatelessWidget {
                           : "Maximum Group Size",
                       style: TextStyle(
                         fontFamily: 'Inter',
-                        color: ColorsUtils.textGray,
+                        color: customColors.textGray,
                         fontWeight: FontWeight.w500,
                         fontSize: 14,
                       ),
                     ),
                     const SizedBox(height: 5),
                     Text(
-                      coachDetails.isOpenClass ? coachDetails.minSessions : coachDetails.maxCapacityOrGroupSize,
+                      coachDetails.isOpenClass
+                          ? coachDetails.minSessions
+                          : coachDetails.maxCapacityOrGroupSize,
                       style: TextStyle(
                         fontFamily: 'Inter',
-                        color: ColorsUtils.black,
+                        color: colorScheme.onSurface,
                         fontWeight: FontWeight.w600,
                         fontSize: 14,
                       ),
@@ -526,11 +556,11 @@ class CoachTrainingPreviewPage extends StatelessWidget {
     );
   }
 
-  Widget _buildGoToListViewButton(BuildContext context) {
+  Widget _buildGoToListViewButton(BuildContext context, ColorScheme colorScheme) {
     return CustomButton(
       text: "Go to List",
-      textcolor: ColorsUtils.white,
-      buttonColor: ColorsUtils.primary,
+      textcolor: colorScheme.onPrimary,
+      buttonColor: colorScheme.primary,
       textsize: 16,
       fontWeight: FontWeight.bold,
       buttonheight: 50,
@@ -540,25 +570,29 @@ class CoachTrainingPreviewPage extends StatelessWidget {
     );
   }
 
-  Widget _buildBottomText() {
+  Widget _buildBottomText(BuildContext context, CustomColors customColors) {
     return Text(
       "Need a different time slot? Contact the instructor directly for custom scheduling.",
       textAlign: TextAlign.center,
       style: TextStyle(
         fontFamily: 'Inter',
-        color: ColorsUtils.textGray,
+        color: customColors.textGray,
         fontWeight: FontWeight.w400,
         fontSize: 12,
       ),
     );
   }
 
-  Widget _buildLocationType({required String title}) {
+  Widget _buildLocationType(
+    BuildContext context,
+    CustomColors customColors, {
+    required String title,
+  }) {
     return Container(
-      padding: EdgeInsets.symmetric(horizontal: 8.0, vertical: 4.0),
+      padding: const EdgeInsets.symmetric(horizontal: 8.0, vertical: 4.0),
       decoration: BoxDecoration(
         borderRadius: BorderRadius.circular(20.0),
-        color: ColorsUtils.green.withValues(alpha: 0.1),
+        color: customColors.green.withOpacity(0.1),
       ),
       child: Row(
         mainAxisAlignment: MainAxisAlignment.center,
@@ -567,7 +601,7 @@ class CoachTrainingPreviewPage extends StatelessWidget {
         children: [
           Icon(
             Icons.check,
-            color: ColorsUtils.green,
+            color: customColors.green,
             size: 16,
           ),
           const SizedBox(width: 3.0),
@@ -576,7 +610,7 @@ class CoachTrainingPreviewPage extends StatelessWidget {
             style: TextStyle(
               fontSize: 13,
               fontWeight: FontWeight.w600,
-              color: ColorsUtils.green,
+              color: customColors.green,
               fontFamily: 'Montserrat',
             ),
           ),

--- a/lib/screens/setup/coach_setup/view/create_coach_setup_page.dart
+++ b/lib/screens/setup/coach_setup/view/create_coach_setup_page.dart
@@ -9,7 +9,6 @@ import 'package:oqdo_mobile_app/screens/setup/facility_setup/viewmodel/stepper_m
 import 'package:oqdo_mobile_app/screens/setup/setups_bottom_sheets/Show24HrsAleartBottomSheet.dart';
 import 'package:oqdo_mobile_app/screens/setup/setups_bottom_sheets/ShowEditFacilityCoachChangesBottomSheet.dart';
 import 'package:oqdo_mobile_app/screens/setup/setups_bottom_sheets/ShowSaveDiscardBottomSheet.dart';
-import 'package:oqdo_mobile_app/theme/oqdo_theme_data.dart';
 import 'package:oqdo_mobile_app/utils/constants.dart';
 import 'package:progress_dialog_null_safe/progress_dialog_null_safe.dart';
 import 'package:provider/provider.dart';
@@ -84,7 +83,7 @@ class CreateCoachSetupPage extends StatelessWidget {
         ),
       ),
       clipBehavior: Clip.antiAliasWithSaveLayer,
-      backgroundColor: OQDOThemeData.whiteColor,
+      backgroundColor: Theme.of(context).colorScheme.surface,
       builder: (ctx) => const Show24HrsAlearBottomSheet(),
     ).then((value) {
       if (value != null) {
@@ -131,7 +130,7 @@ class CreateCoachSetupPage extends StatelessWidget {
           ),
         ),
         clipBehavior: Clip.antiAliasWithSaveLayer,
-        backgroundColor: OQDOThemeData.whiteColor,
+        backgroundColor: Theme.of(context).colorScheme.surface,
         builder: (ctx) => const Show24HrsAlearBottomSheet(),
       ).then((value) {
         if (value != null) {
@@ -170,7 +169,7 @@ class CreateCoachSetupPage extends StatelessWidget {
           ),
         ),
         clipBehavior: Clip.antiAliasWithSaveLayer,
-        backgroundColor: OQDOThemeData.whiteColor,
+        backgroundColor: Theme.of(context).colorScheme.surface,
         builder: (ctx) => ShowEditFacilityCoachChangesBottomSheet(
           type: 'C',
         ),
@@ -189,7 +188,7 @@ class CreateCoachSetupPage extends StatelessWidget {
                 ),
               ),
               clipBehavior: Clip.antiAliasWithSaveLayer,
-              backgroundColor: OQDOThemeData.whiteColor,
+              backgroundColor: Theme.of(context).colorScheme.surface,
               builder: (ctx) => const Show24HrsAlearBottomSheet(),
             ).then((value) {
               if (value != null) {
@@ -237,7 +236,7 @@ class CreateCoachSetupPage extends StatelessWidget {
                       ),
                     ),
                     clipBehavior: Clip.antiAliasWithSaveLayer,
-                    backgroundColor: OQDOThemeData.whiteColor,
+                    backgroundColor: Theme.of(context).colorScheme.surface,
                     builder: (ctx) => const Show24HrsAlearBottomSheet(),
                   ).then((value) {
                     if (value != null) {

--- a/lib/screens/setup/coach_setup/view/widgets/coach_step_one.dart
+++ b/lib/screens/setup/coach_setup/view/widgets/coach_step_one.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:oqdo_mobile_app/screens/setup/coach_setup/viewmodel/create_coach_view_model.dart';
 import 'package:oqdo_mobile_app/screens/setup/facility_setup/view/widgets/base_container.dart';
 import 'package:oqdo_mobile_app/screens/setup/facility_setup/view/widgets/setup_grid_view_item.dart';
-import 'package:oqdo_mobile_app/utils/colorsUtils.dart';
+import 'package:oqdo_mobile_app/theme/custom_colors.dart';
 import 'package:oqdo_mobile_app/utils/constants.dart';
 import 'package:oqdo_mobile_app/utils/custom_text_field.dart';
 import 'package:provider/provider.dart';
@@ -12,15 +12,17 @@ class CoachStepOne extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final customColors = Theme.of(context).extension<CustomColors>()!;
+    final colorScheme = Theme.of(context).colorScheme;
     return SingleChildScrollView(
       child: Column(
         mainAxisAlignment: MainAxisAlignment.start,
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           _buildMessageListener(),
-          _buildTitleAndSessionTitleView(context),
-          _buildChooseYourActivityView(context),
-          _buildChooseTrainingTypeView(context),
+          _buildTitleAndSessionTitleView(context, customColors, colorScheme),
+          _buildChooseYourActivityView(context, customColors),
+          _buildChooseTrainingTypeView(context, customColors),
         ],
       ),
     );
@@ -48,7 +50,11 @@ class CoachStepOne extends StatelessWidget {
     );
   }
 
-  Widget _buildTitleAndSessionTitleView(BuildContext context) {
+  Widget _buildTitleAndSessionTitleView(
+    BuildContext context,
+    CustomColors customColors,
+    ColorScheme colorScheme,
+  ) {
     return Column(
       mainAxisAlignment: MainAxisAlignment.start,
       crossAxisAlignment: CrossAxisAlignment.start,
@@ -58,7 +64,7 @@ class CoachStepOne extends StatelessWidget {
           "Activity & Type Setup",
           style: TextStyle(
             fontFamily: 'SFPro',
-            color: ColorsUtils.primary,
+            color: colorScheme.primary,
             fontWeight: FontWeight.w600,
             fontSize: 16,
           ),
@@ -75,7 +81,7 @@ class CoachStepOne extends StatelessWidget {
                   "Session Title",
                   style: TextStyle(
                     fontFamily: 'Montserrat',
-                    color: ColorsUtils.chipText,
+                    color: customColors.chipText,
                     fontWeight: FontWeight.w600,
                     fontSize: 14,
                   ),
@@ -84,7 +90,7 @@ class CoachStepOne extends StatelessWidget {
                 CommonTextField(
                   controller: context.read<CreateCoachViewModel>().titleController,
                   maxLength: 50,
-                  fillColor: ColorsUtils.white,
+                  fillColor: customColors.white,
                   borderRadius: 6,
                   autovalidateMode: AutovalidateMode.onUserInteraction,
                   hint: "Enter session title",
@@ -92,7 +98,7 @@ class CoachStepOne extends StatelessWidget {
                   textStyle: TextStyle(
                     fontSize: 16,
                     fontFamily: "Inter",
-                    color: ColorsUtils.black,
+                    color: colorScheme.onSurface,
                     fontWeight: FontWeight.w500,
                   ),
                   validator: (value) {
@@ -107,7 +113,7 @@ class CoachStepOne extends StatelessWidget {
                   "Give your training session a memorable title",
                   style: TextStyle(
                     fontFamily: 'Inter',
-                    color: ColorsUtils.hintTextColor,
+                    color: customColors.hintTextColor,
                     fontWeight: FontWeight.w400,
                     fontSize: 12,
                   ),
@@ -115,19 +121,22 @@ class CoachStepOne extends StatelessWidget {
               ],
             ),
           ),
-        )
+        ),
       ],
     );
   }
 
-  Widget _buildChooseYourActivityView(BuildContext context) {
+  Widget _buildChooseYourActivityView(
+    BuildContext context,
+    CustomColors customColors,
+  ) {
     return Column(
       mainAxisAlignment: MainAxisAlignment.start,
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         const SizedBox(height: 20),
         BaseContainer(
-          bgColor: ColorsUtils.white,
+          bgColor: customColors.white,
           child: Column(
             mainAxisAlignment: MainAxisAlignment.start,
             crossAxisAlignment: CrossAxisAlignment.start,
@@ -141,22 +150,26 @@ class CoachStepOne extends StatelessWidget {
                     "Choose Your Activity",
                     style: TextStyle(
                       fontFamily: 'Montserrat',
-                      color: ColorsUtils.chipText,
+                      color: customColors.chipText,
                       fontWeight: FontWeight.w600,
                       fontSize: 14,
                     ),
                   ),
                   const SizedBox(width: 10),
                   Container(
-                    padding: EdgeInsets.symmetric(horizontal: 10.0, vertical: 5.0),
-                    decoration: BoxDecoration(borderRadius: BorderRadius.circular(20.0), color: ColorsUtils.green.withValues(alpha: 0.15)),
+                    padding:
+                        const EdgeInsets.symmetric(horizontal: 10.0, vertical: 5.0),
+                    decoration: BoxDecoration(
+                      borderRadius: BorderRadius.circular(20.0),
+                      color: customColors.green.withOpacity(0.15),
+                    ),
                     child: Row(
                       mainAxisAlignment: MainAxisAlignment.center,
                       crossAxisAlignment: CrossAxisAlignment.center,
                       children: [
                         Icon(
                           Icons.check,
-                          color: ColorsUtils.green,
+                          color: customColors.green,
                           size: 16,
                         ),
                         const SizedBox(width: 5),
@@ -165,7 +178,7 @@ class CoachStepOne extends StatelessWidget {
                           style: TextStyle(
                             fontSize: 12,
                             fontWeight: FontWeight.w600,
-                            color: ColorsUtils.green,
+                            color: customColors.green,
                             fontFamily: 'Montserrat',
                           ),
                         ),
@@ -179,17 +192,27 @@ class CoachStepOne extends StatelessWidget {
                 shrinkWrap: true,
                 physics: const NeverScrollableScrollPhysics(),
                 itemCount: context.watch<CreateCoachViewModel>().subActivityList.length,
-                gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(mainAxisSpacing: 15.0, crossAxisSpacing: 15.0, crossAxisCount: 2, childAspectRatio: 2),
+                gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+                  mainAxisSpacing: 15.0,
+                  crossAxisSpacing: 15.0,
+                  crossAxisCount: 2,
+                  childAspectRatio: 2,
+                ),
                 itemBuilder: (context, index) {
                   final item = context.read<CreateCoachViewModel>().subActivityList[index];
-                  final isSelected = context.watch<CreateCoachViewModel>().selectedSubActivity?.SubActivityId == item.SubActivityId;
+                  final isSelected = context
+                          .watch<CreateCoachViewModel>()
+                          .selectedSubActivity
+                          ?.SubActivityId ==
+                      item.SubActivityId;
                   return SetupGridViewItem(
                     title: item.Name ?? "",
                     imagePath: item.imageUrl ?? "",
                     useLocalImage: false,
                     isSelected: isSelected,
                     isEnabled: !context.read<CreateCoachViewModel>().isEdit,
-                    onTap: () => context.read<CreateCoachViewModel>().onSelectActivity(item),
+                    onTap: () =>
+                        context.read<CreateCoachViewModel>().onSelectActivity(item),
                   );
                 },
               ),
@@ -198,7 +221,7 @@ class CoachStepOne extends StatelessWidget {
                 "Give your training session a memorable title",
                 style: TextStyle(
                   fontFamily: 'Inter',
-                  color: ColorsUtils.hintTextColor,
+                  color: customColors.hintTextColor,
                   fontWeight: FontWeight.w400,
                   fontSize: 12,
                 ),
@@ -210,7 +233,10 @@ class CoachStepOne extends StatelessWidget {
     );
   }
 
-  Widget _buildChooseTrainingTypeView(BuildContext context) {
+  Widget _buildChooseTrainingTypeView(
+    BuildContext context,
+    CustomColors customColors,
+  ) {
     return Column(
       mainAxisAlignment: MainAxisAlignment.start,
       crossAxisAlignment: CrossAxisAlignment.start,
@@ -230,7 +256,7 @@ class CoachStepOne extends StatelessWidget {
                     "Training Type",
                     style: TextStyle(
                       fontFamily: 'Montserrat',
-                      color: ColorsUtils.chipText,
+                      color: customColors.chipText,
                       fontWeight: FontWeight.w600,
                       fontSize: 14,
                     ),
@@ -242,17 +268,29 @@ class CoachStepOne extends StatelessWidget {
                 shrinkWrap: true,
                 physics: const NeverScrollableScrollPhysics(),
                 itemCount: context.read<CreateCoachViewModel>().trainingTypes.length,
-                gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(mainAxisSpacing: 15.0, crossAxisSpacing: 15.0, crossAxisCount: 2, childAspectRatio: 2),
+                gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+                  mainAxisSpacing: 15.0,
+                  crossAxisSpacing: 15.0,
+                  crossAxisCount: 2,
+                  childAspectRatio: 2,
+                ),
                 itemBuilder: (context, index) {
-                  final item = context.watch<CreateCoachViewModel>().trainingTypes[index];
-                  final isSelected = context.watch<CreateCoachViewModel>().selectedTrainingType?.id == item.id;
+                  final item =
+                      context.watch<CreateCoachViewModel>().trainingTypes[index];
+                  final isSelected = context
+                          .watch<CreateCoachViewModel>()
+                          .selectedTrainingType
+                          ?.id ==
+                      item.id;
                   return SetupGridViewItem(
                     title: item.title,
-                    unSelectedColor: ColorsUtils.white,
+                    unSelectedColor: customColors.white,
                     imagePath: item.imagePath,
                     isSelected: isSelected,
                     isEnabled: true,
-                    onTap: () => context.read<CreateCoachViewModel>().onSelectTrainingType(item),
+                    onTap: () => context
+                        .read<CreateCoachViewModel>()
+                        .onSelectTrainingType(item),
                   );
                 },
               ),
@@ -263,7 +301,7 @@ class CoachStepOne extends StatelessWidget {
                     : "Multiple individuals can book separately up to set capacity.",
                 style: TextStyle(
                   fontFamily: 'Inter',
-                  color: ColorsUtils.hintTextColor,
+                  color: customColors.hintTextColor,
                   fontWeight: FontWeight.w400,
                   fontSize: 12,
                 ),

--- a/lib/screens/setup/coach_setup/view/widgets/coach_step_three.dart
+++ b/lib/screens/setup/coach_setup/view/widgets/coach_step_three.dart
@@ -5,7 +5,7 @@ import 'package:oqdo_mobile_app/screens/setup/coach_setup/view/coach_training_pr
 import 'package:oqdo_mobile_app/screens/setup/coach_setup/viewmodel/create_coach_view_model.dart';
 import 'package:oqdo_mobile_app/screens/setup/facility_setup/view/widgets/base_container.dart';
 import 'package:oqdo_mobile_app/screens/setup/facility_setup/view/widgets/time_input_field.dart';
-import 'package:oqdo_mobile_app/utils/colorsUtils.dart';
+import 'package:oqdo_mobile_app/theme/custom_colors.dart';
 import 'package:oqdo_mobile_app/utils/constants.dart';
 import 'package:oqdo_mobile_app/utils/custom_text_field.dart';
 import 'package:provider/provider.dart';
@@ -63,6 +63,8 @@ class CoachStepThree extends StatelessWidget {
   }
 
   Widget _buildTimeSlotView(BuildContext context) {
+    final customColors = Theme.of(context).extension<CustomColors>()!;
+    final colorScheme = Theme.of(context).colorScheme;
     return Column(
       mainAxisAlignment: MainAxisAlignment.start,
       crossAxisAlignment: CrossAxisAlignment.start,
@@ -72,7 +74,7 @@ class CoachStepThree extends StatelessWidget {
           "Session Timetable",
           style: TextStyle(
             fontFamily: 'SFPro',
-            color: ColorsUtils.primary,
+            color: colorScheme.primary,
             fontWeight: FontWeight.w600,
             fontSize: 16,
           ),
@@ -86,9 +88,9 @@ class CoachStepThree extends StatelessWidget {
               CustomButton(
                 text: "Add Training Slot",
                 leadingIcon: Icon(Icons.add, size: 18),
-                textcolor: ColorsUtils.black,
-                buttonColor: ColorsUtils.buttonColorGrey,
-                borderColor: ColorsUtils.borderColor,
+                textcolor: colorScheme.onSurface,
+                buttonColor: customColors.buttonColorGrey,
+                borderColor: customColors.borderColor,
                 textsize: 16,
                 fontWeight: FontWeight.bold,
                 buttonheight: 50,
@@ -114,10 +116,10 @@ class CoachStepThree extends StatelessWidget {
                       strokeWidth: 1.5,
                       radius: const Radius.circular(5),
                       dashPattern: const [3, 3],
-                      color: ColorsUtils.messageRight,
+                      color: customColors.messageRight,
                       child: Container(
                         decoration: BoxDecoration(
-                          color: ColorsUtils.buttonColorGrey,
+                          color: customColors.buttonColorGrey,
                           borderRadius: BorderRadius.all(
                             Radius.circular(5),
                           ),
@@ -138,13 +140,14 @@ class CoachStepThree extends StatelessWidget {
                                     children: slotDetails.sortedSelectedDays.map((day) {
                                       return Container(
                                         padding: EdgeInsets.symmetric(horizontal: 10.0, vertical: 4.0),
-                                        decoration: BoxDecoration(borderRadius: BorderRadius.circular(20.0), color: ColorsUtils.primary),
+                                        decoration: BoxDecoration(
+                                            borderRadius: BorderRadius.circular(20.0), color: colorScheme.primary),
                                         child: Text(
                                           day.title,
                                           style: TextStyle(
                                             fontSize: 14,
                                             fontWeight: FontWeight.w400,
-                                            color: ColorsUtils.white,
+                                            color: customColors.onAccentText,
                                             fontFamily: 'Inter',
                                           ),
                                         ),
@@ -161,20 +164,42 @@ class CoachStepThree extends StatelessWidget {
                                     padding: EdgeInsets.all(4.0),
                                     child: Image.asset(
                                       "assets/images/ic_cancel_appointment.png",
-                                      color: ColorsUtils.black,
+                                      color: colorScheme.onSurface,
                                     ),
                                   ),
                                 )
                               ],
                             ),
                             _buildTitleDetailsRow(
-                                title: "Time", details: slotDetails.getAccurateTimeRangeDisplay(context.read<CreateCoachViewModel>().getClassDurationInMinutes())),
-                            _buildTitleDetailsRow(title: "Class", details: "$numberOfSessions ${numberOfSessions > 1 ? "Sessions" : "Session"}"),
-                            _buildTitleDetailsRow(title: "Per Session Time", details: context.read<CreateCoachViewModel>().getFormattedClassDurationForDisplay()),
+                              context,
+                              title: "Time",
+                              details: slotDetails.getAccurateTimeRangeDisplay(
+                                context.read<CreateCoachViewModel>().getClassDurationInMinutes(),
+                              ),
+                            ),
                             _buildTitleDetailsRow(
-                                title: "Total Duration", details: context.read<CreateCoachViewModel>().getFormattedTotalClassDurationForDisplay(numberOfSessions)),
+                              context,
+                              title: "Class",
+                              details: "$numberOfSessions ${numberOfSessions > 1 ? "Sessions" : "Session"}",
+                            ),
+                            _buildTitleDetailsRow(
+                              context,
+                              title: "Per Session Time",
+                              details: context.read<CreateCoachViewModel>().getFormattedClassDurationForDisplay(),
+                            ),
+                            _buildTitleDetailsRow(
+                              context,
+                              title: "Total Duration",
+                              details: context
+                                  .read<CreateCoachViewModel>()
+                                  .getFormattedTotalClassDurationForDisplay(numberOfSessions),
+                            ),
                             if (!context.watch<CreateCoachViewModel>().isSameRates)
-                              _buildTitleDetailsRow(title: "Rate", details: "S\$ ${parseDoubleToRoundString(slotDetails.ratePerHour ?? 0)}/hour"),
+                              _buildTitleDetailsRow(
+                                context,
+                                title: "Rate",
+                                details: "S\$ ${parseDoubleToRoundString(slotDetails.ratePerHour ?? 0)}/hour",
+                              ),
                           ],
                         ),
                       ),
@@ -189,7 +214,7 @@ class CoachStepThree extends StatelessWidget {
                 "Add multiple time slots for different days and times. Overlapping times will be prevented.",
                 style: TextStyle(
                   fontFamily: 'Inter',
-                  color: ColorsUtils.hintTextColor,
+                  color: customColors.hintTextColor,
                   fontWeight: FontWeight.w400,
                   fontSize: 12,
                 ),
@@ -201,7 +226,13 @@ class CoachStepThree extends StatelessWidget {
     );
   }
 
-  Widget _buildTitleDetailsRow({required String title, required String details, bool addTopPadding = true}) {
+  Widget _buildTitleDetailsRow(
+    BuildContext context, {
+    required String title,
+    required String details,
+    bool addTopPadding = true,
+  }) {
+    final colorScheme = Theme.of(context).colorScheme;
     return Column(
       mainAxisAlignment: MainAxisAlignment.start,
       crossAxisAlignment: CrossAxisAlignment.start,
@@ -216,7 +247,7 @@ class CoachStepThree extends StatelessWidget {
               style: TextStyle(
                 fontSize: 14,
                 fontWeight: FontWeight.w400,
-                color: ColorsUtils.black,
+                color: colorScheme.onSurface,
                 fontFamily: 'Inter',
               ),
             ),
@@ -226,7 +257,7 @@ class CoachStepThree extends StatelessWidget {
               style: TextStyle(
                 fontSize: 14,
                 fontWeight: FontWeight.w600,
-                color: ColorsUtils.black,
+                color: colorScheme.onSurface,
                 fontFamily: 'Inter',
               ),
             ),
@@ -237,6 +268,8 @@ class CoachStepThree extends StatelessWidget {
   }
 
   void _showAddSlotBottomSheet(BuildContext context, CreateCoachViewModel viewModel) {
+    final customColors = Theme.of(context).extension<CustomColors>()!;
+    final colorScheme = Theme.of(context).colorScheme;
     showModalBottomSheet(
       context: context,
       isScrollControlled: true,
@@ -264,7 +297,7 @@ class CoachStepThree extends StatelessWidget {
                       // Remove fixed height - let content determine height
                       padding: EdgeInsets.all(15.0),
                       decoration: BoxDecoration(
-                        color: ColorsUtils.white,
+                        color: customColors.white,
                         borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
                       ),
                       child: Column(
@@ -279,7 +312,7 @@ class CoachStepThree extends StatelessWidget {
                                 style: TextStyle(
                                   fontSize: 18,
                                   fontWeight: FontWeight.w600,
-                                  color: ColorsUtils.black,
+                                  color: colorScheme.onSurface,
                                   fontFamily: 'Montserrat',
                                 ),
                               ),
@@ -316,6 +349,7 @@ class CoachStepThree extends StatelessWidget {
                                       children: context.watch<CreateCoachViewModel>().days.map((day) {
                                         final isSelected = context.watch<CreateCoachViewModel>().selectedDays.contains(day);
                                         return _buildDayItemWrap(
+                                            context: context,
                                             day: day.title,
                                             isSelected: isSelected,
                                             onTap: () {
@@ -328,7 +362,7 @@ class CoachStepThree extends StatelessWidget {
                                       'Select multiple days when the same schedule applies',
                                       style: TextStyle(
                                         fontSize: 12,
-                                        color: ColorsUtils.textGray,
+                                        color: customColors.textGray,
                                         fontFamily: 'Inter',
                                         fontWeight: FontWeight.w400,
                                       ),
@@ -345,21 +379,21 @@ class CoachStepThree extends StatelessWidget {
                                               fontSize: 16,
                                               fontWeight: FontWeight.w600,
                                               fontFamily: 'Montserrat',
-                                              color: ColorsUtils.black,
+                                              color: colorScheme.onSurface,
                                             ),
                                           ),
                                           const SizedBox(height: 10),
                                           CommonTextField(
                                             maxLength: 6,
                                             autovalidateMode: AutovalidateMode.onUserInteraction,
-                                            fillColor: ColorsUtils.white,
+                                            fillColor: customColors.white,
                                             isDouble: true,
                                             borderRadius: 6,
                                             hint: "Enter rate",
                                             textStyle: TextStyle(
                                               fontSize: 16,
                                               fontFamily: "Inter",
-                                              color: ColorsUtils.black,
+                                              color: colorScheme.onSurface,
                                               fontWeight: FontWeight.w500,
                                             ),
                                             validator: (value) {
@@ -375,7 +409,7 @@ class CoachStepThree extends StatelessWidget {
                                             'Custom rate for this specific time slot',
                                             style: TextStyle(
                                               fontSize: 12,
-                                              color: ColorsUtils.textGray,
+                                              color: customColors.textGray,
                                               fontFamily: 'Inter',
                                               fontWeight: FontWeight.w400,
                                             ),
@@ -390,7 +424,7 @@ class CoachStepThree extends StatelessWidget {
                                       children: [
                                         Row(
                                           children: [
-                                            Icon(Icons.access_time, size: 20, color: ColorsUtils.chipText),
+                                            Icon(Icons.access_time, size: 20, color: customColors.chipText),
                                             SizedBox(width: 8),
                                             Text(
                                               'Training Sessions (6 AM - 10 PM)',
@@ -398,7 +432,7 @@ class CoachStepThree extends StatelessWidget {
                                                 fontSize: 14,
                                                 fontFamily: 'Montserrat',
                                                 fontWeight: FontWeight.w600,
-                                                color: ColorsUtils.chipText,
+                                                color: customColors.chipText,
                                               ),
                                             ),
                                           ],
@@ -409,11 +443,11 @@ class CoachStepThree extends StatelessWidget {
                                           leadingIcon: Icon(
                                             Icons.add,
                                             size: 20,
-                                            color: ColorsUtils.black,
+                                            color: colorScheme.onSurface,
                                           ),
-                                          textcolor: ColorsUtils.black,
-                                          buttonColor: ColorsUtils.selectedGridItemColor,
-                                          borderColor: ColorsUtils.selectedGridItemColor,
+                                          textcolor: colorScheme.onSurface,
+                                          buttonColor: customColors.selectedGridItemColor,
+                                          borderColor: customColors.selectedGridItemColor,
                                           textsize: 16,
                                           fontWeight: FontWeight.bold,
                                           buttonheight: 35,
@@ -434,7 +468,7 @@ class CoachStepThree extends StatelessWidget {
                                                 return Form(
                                                   key: editSlot.formKey,
                                                   child: BaseContainer(
-                                                    bgColor: ColorsUtils.white,
+                                                    bgColor: customColors.white,
                                                     child: Column(
                                                       mainAxisAlignment: MainAxisAlignment.start,
                                                       crossAxisAlignment: CrossAxisAlignment.start,
@@ -448,7 +482,7 @@ class CoachStepThree extends StatelessWidget {
                                                                 fontSize: 16,
                                                                 fontWeight: FontWeight.w600,
                                                                 fontFamily: 'Montserrat',
-                                                                color: ColorsUtils.black,
+                                                                color: colorScheme.onSurface,
                                                               ),
                                                             ),
                                                             GestureDetector(
@@ -467,7 +501,7 @@ class CoachStepThree extends StatelessWidget {
                                                             fontSize: 14,
                                                             fontWeight: FontWeight.w500,
                                                             fontFamily: 'Inter',
-                                                            color: ColorsUtils.chipText,
+                                                            color: customColors.chipText,
                                                           ),
                                                         ),
                                                         const SizedBox(height: 8),
@@ -493,21 +527,21 @@ class CoachStepThree extends StatelessWidget {
                                                               child: Container(
                                                                 padding: EdgeInsets.symmetric(horizontal: 6, vertical: 4),
                                                                 decoration: BoxDecoration(
-                                                                  color: ColorsUtils.selectedGridItemColor,
+                                                                  color: customColors.selectedGridItemColor,
                                                                   borderRadius: BorderRadius.circular(6),
                                                                   border: Border.all(
-                                                                    color: ColorsUtils.lightBlueBorderColor,
+                                                                    color: customColors.lightBlueBorderColor,
                                                                   ),
                                                                 ),
-                                                                child: Text(
-                                                                  time,
-                                                                  style: TextStyle(
-                                                                    fontSize: 14,
-                                                                    color: ColorsUtils.black,
+                                                               child: Text(
+                                                                 time,
+                                                                 style: TextStyle(
+                                                                   fontSize: 14,
+                                                                    color: colorScheme.onSurface,
                                                                     fontFamily: 'Inter',
                                                                     fontWeight: FontWeight.w400,
                                                                   ),
-                                                                ),
+                                                               ),
                                                               ),
                                                             );
                                                           }).toList(),
@@ -517,7 +551,7 @@ class CoachStepThree extends StatelessWidget {
                                                           'Popular training times. Click to select quickly.',
                                                           style: TextStyle(
                                                             fontSize: 12,
-                                                            color: ColorsUtils.textGray,
+                                                            color: customColors.textGray,
                                                             fontFamily: 'Inter',
                                                             fontWeight: FontWeight.w400,
                                                           ),
@@ -534,15 +568,15 @@ class CoachStepThree extends StatelessWidget {
                                                                   fontSize: 14,
                                                                   fontWeight: FontWeight.w500,
                                                                   fontFamily: 'Inter',
-                                                                  color: ColorsUtils.chipText,
+                                                                  color: customColors.chipText,
                                                                 ),
                                                               ),
                                                               const SizedBox(height: 15),
-                                                              CommonTextField(
-                                                                controller: editSlot.numberOfSlots,
-                                                                autovalidateMode: AutovalidateMode.onUserInteraction,
-                                                                maxLength: 2,
-                                                                fillColor: ColorsUtils.white,
+                                                             CommonTextField(
+                                                               controller: editSlot.numberOfSlots,
+                                                               autovalidateMode: AutovalidateMode.onUserInteraction,
+                                                               maxLength: 2,
+                                                                fillColor: customColors.white,
                                                                 isNumber: true,
                                                                 borderRadius: 6,
                                                                 hint: "Number of Classes",
@@ -550,7 +584,7 @@ class CoachStepThree extends StatelessWidget {
                                                                 textStyle: TextStyle(
                                                                   fontSize: 16,
                                                                   fontFamily: "Inter",
-                                                                  color: ColorsUtils.black,
+                                                                  color: colorScheme.onSurface,
                                                                   fontWeight: FontWeight.w500,
                                                                 ),
                                                                 validator: (value) {
@@ -571,7 +605,7 @@ class CoachStepThree extends StatelessWidget {
                                                                 'Consecutive classes without break',
                                                                 style: TextStyle(
                                                                   fontSize: 12,
-                                                                  color: ColorsUtils.textGray,
+                                                                  color: customColors.textGray,
                                                                   fontFamily: 'Inter',
                                                                   fontWeight: FontWeight.w400,
                                                                 ),
@@ -590,10 +624,10 @@ class CoachStepThree extends StatelessWidget {
                                                                 strokeWidth: 1.5,
                                                                 radius: const Radius.circular(5),
                                                                 dashPattern: const [3, 3],
-                                                                color: ColorsUtils.messageRight,
+                                                                color: customColors.messageRight,
                                                                 child: Container(
                                                                   decoration: BoxDecoration(
-                                                                    color: ColorsUtils.buttonColorGrey,
+                                                                    color: customColors.buttonColorGrey,
                                                                     borderRadius: BorderRadius.all(
                                                                       Radius.circular(5),
                                                                     ),
@@ -603,19 +637,25 @@ class CoachStepThree extends StatelessWidget {
                                                                     mainAxisAlignment: MainAxisAlignment.start,
                                                                     crossAxisAlignment: CrossAxisAlignment.start,
                                                                     children: [
-                                                                      _buildTitleDetailsRow(
+                                                                     _buildTitleDetailsRow(
+                                                                        context,
                                                                         title: "Start",
                                                                         details: editSlot.startTime.text,
                                                                         addTopPadding: false,
                                                                       ),
                                                                       _buildTitleDetailsRow(
+                                                                          context,
                                                                           title: "End",
-                                                                          details: editSlot.getAccurateEndTime(context.read<CreateCoachViewModel>().getClassDurationInMinutes())),
+                                                                          details: editSlot.getAccurateEndTime(context
+                                                                              .read<CreateCoachViewModel>()
+                                                                              .getClassDurationInMinutes())),
                                                                       _buildTitleDetailsRow(
+                                                                        context,
                                                                         title: "Per Session Time",
                                                                         details: context.read<CreateCoachViewModel>().getFormattedClassDurationForDisplay(),
                                                                       ),
                                                                       _buildTitleDetailsRow(
+                                                                        context,
                                                                         title: "Total Duration",
                                                                         details: context
                                                                             .read<CreateCoachViewModel>()
@@ -642,7 +682,7 @@ class CoachStepThree extends StatelessWidget {
                                       'Add multiple sessions if you have breaks between training periods on the same day',
                                       style: TextStyle(
                                         fontSize: 12,
-                                        color: ColorsUtils.textGray,
+                                        color: customColors.textGray,
                                         fontFamily: 'Inter',
                                         fontWeight: FontWeight.w400,
                                       ),
@@ -659,8 +699,8 @@ class CoachStepThree extends StatelessWidget {
                               Expanded(
                                 child: CustomButton(
                                   text: "Cancel",
-                                  textcolor: ColorsUtils.black,
-                                  buttonColor: ColorsUtils.buttonBg,
+                                  textcolor: colorScheme.onSurface,
+                                  buttonColor: customColors.buttonBg,
                                   textsize: 16,
                                   fontWeight: FontWeight.bold,
                                   buttonheight: 50,
@@ -675,8 +715,8 @@ class CoachStepThree extends StatelessWidget {
                               Expanded(
                                 child: CustomButton(
                                   text: "Add Time Slot",
-                                  textcolor: ColorsUtils.white,
-                                  buttonColor: ColorsUtils.primary,
+                                  textcolor: colorScheme.onPrimary,
+                                  buttonColor: colorScheme.primary,
                                   textsize: 16,
                                   fontWeight: FontWeight.bold,
                                   buttonheight: 50,
@@ -700,7 +740,14 @@ class CoachStepThree extends StatelessWidget {
     );
   }
 
-  Widget _buildDayItemWrap({required String day, required Function()? onTap, required bool isSelected}) {
+  Widget _buildDayItemWrap({
+    required BuildContext context,
+    required String day,
+    required Function()? onTap,
+    required bool isSelected,
+  }) {
+    final customColors = Theme.of(context).extension<CustomColors>()!;
+    final colorScheme = Theme.of(context).colorScheme;
     return GestureDetector(
       onTap: onTap,
       child: SizedBox(
@@ -713,16 +760,18 @@ class CoachStepThree extends StatelessWidget {
               width: 30,
               height: 30,
               decoration: BoxDecoration(
-                color: isSelected ? ColorsUtils.primary : ColorsUtils.greyBG,
+                color: isSelected ? colorScheme.primary : customColors.greyBG,
                 borderRadius: BorderRadius.circular(7),
               ),
-              child: isSelected ? Icon(Icons.check, size: 18, color: ColorsUtils.white) : null,
+              child: isSelected
+                  ? Icon(Icons.check, size: 18, color: customColors.onAccentText)
+                  : null,
             ),
             SizedBox(width: 8),
             Text(
               day,
               style: TextStyle(
-                color: isSelected ? ColorsUtils.black : ColorsUtils.hintTextColor,
+                color: isSelected ? colorScheme.onSurface : customColors.hintTextColor,
                 fontSize: 14,
                 fontWeight: FontWeight.w600,
                 fontFamily: 'Inter',

--- a/lib/screens/setup/coach_setup/view/widgets/coach_step_two.dart
+++ b/lib/screens/setup/coach_setup/view/widgets/coach_step_two.dart
@@ -6,8 +6,7 @@ import 'package:oqdo_mobile_app/screens/setup/coach_setup/viewmodel/create_coach
 import 'package:oqdo_mobile_app/screens/setup/facility_setup/view/widgets/base_container.dart';
 import 'package:oqdo_mobile_app/screens/setup/facility_setup/view/widgets/duration_input_field.dart';
 import 'package:oqdo_mobile_app/screens/setup/setups_bottom_sheets/ShowClearSlotsBottomSheet.dart';
-import 'package:oqdo_mobile_app/theme/oqdo_theme_data.dart';
-import 'package:oqdo_mobile_app/utils/colorsUtils.dart';
+import 'package:oqdo_mobile_app/theme/custom_colors.dart';
 import 'package:oqdo_mobile_app/utils/constants.dart';
 import 'package:oqdo_mobile_app/utils/custom_text_field.dart';
 import 'package:oqdo_mobile_app/utils/custom_text_view.dart';
@@ -83,7 +82,7 @@ class CoachStepTwo extends StatelessWidget {
         ),
       ),
       clipBehavior: Clip.antiAliasWithSaveLayer,
-      backgroundColor: OQDOThemeData.whiteColor,
+      backgroundColor: Theme.of(context).colorScheme.surface,
       builder: (BuildContext context) => const ShowClearSlotsBottomSheet(
         height: 230,
         fieldName: "Class Duration",
@@ -105,6 +104,8 @@ class CoachStepTwo extends StatelessWidget {
   }
 
   Widget _buildClassSettingsView(BuildContext context) {
+    final customColors = Theme.of(context).extension<CustomColors>()!;
+    final colorScheme = Theme.of(context).colorScheme;
     return Column(
       mainAxisAlignment: MainAxisAlignment.start,
       crossAxisAlignment: CrossAxisAlignment.start,
@@ -114,14 +115,14 @@ class CoachStepTwo extends StatelessWidget {
           "Class Configuration",
           style: TextStyle(
             fontFamily: 'SFPro',
-            color: ColorsUtils.primary,
+            color: colorScheme.primary,
             fontWeight: FontWeight.w600,
             fontSize: 16,
           ),
         ),
         const SizedBox(height: 15.0),
         BaseContainer(
-          bgColor: ColorsUtils.white,
+          bgColor: customColors.white,
           child: Column(
             mainAxisAlignment: MainAxisAlignment.start,
             crossAxisAlignment: CrossAxisAlignment.start,
@@ -131,7 +132,7 @@ class CoachStepTwo extends StatelessWidget {
                 "Class Settings",
                 style: TextStyle(
                   fontFamily: 'Montserrat',
-                  color: ColorsUtils.chipText,
+                  color: customColors.chipText,
                   fontWeight: FontWeight.w600,
                   fontSize: 14,
                 ),
@@ -139,7 +140,7 @@ class CoachStepTwo extends StatelessWidget {
               const SizedBox(height: 15),
               CommonTextField(
                 maxLength: context.read<CreateCoachViewModel>().selectedTrainingType?.id == 2 ? 3 : 4,
-                fillColor: ColorsUtils.white,
+                fillColor: customColors.white,
                 isNumber: true,
                 borderRadius: 6,
                 hint: context.read<CreateCoachViewModel>().selectedTrainingType?.id == 2 ? "Maximum Group Size" : "Class Capacity",
@@ -149,7 +150,7 @@ class CoachStepTwo extends StatelessWidget {
                 textStyle: TextStyle(
                   fontSize: 16,
                   fontFamily: "Inter",
-                  color: ColorsUtils.black,
+                  color: colorScheme.onSurface,
                   fontWeight: FontWeight.w500,
                 ),
                 validator: (value) {
@@ -172,7 +173,7 @@ class CoachStepTwo extends StatelessWidget {
                 "Maximum participants per class",
                 style: TextStyle(
                   fontFamily: 'Inter',
-                  color: ColorsUtils.hintTextColor,
+                  color: customColors.hintTextColor,
                   fontWeight: FontWeight.w400,
                   fontSize: 12,
                 ),
@@ -197,7 +198,7 @@ class CoachStepTwo extends StatelessWidget {
                               ),
                             ),
                             clipBehavior: Clip.antiAliasWithSaveLayer,
-                            backgroundColor: OQDOThemeData.whiteColor,
+                            backgroundColor: Theme.of(context).colorScheme.surface,
                             builder: (BuildContext context) => const ShowClearSlotsBottomSheet(
                               height: 230,
                               fieldName: "Class Duration",
@@ -273,7 +274,7 @@ class CoachStepTwo extends StatelessWidget {
                                 ),
                               ),
                               clipBehavior: Clip.antiAliasWithSaveLayer,
-                              backgroundColor: OQDOThemeData.whiteColor,
+                              backgroundColor: Theme.of(context).colorScheme.surface,
                               builder: (BuildContext context) => const ShowClearSlotsBottomSheet(
                                 height: 230,
                                 fieldName: "Class Duration",
@@ -305,7 +306,7 @@ class CoachStepTwo extends StatelessWidget {
                       style: TextStyle(
                         fontSize: 14,
                         fontFamily: "Inter",
-                        color: ColorsUtils.hintTextColor,
+                        color: customColors.hintTextColor,
                         fontWeight: FontWeight.w400,
                       ),
                     ),
@@ -317,7 +318,7 @@ class CoachStepTwo extends StatelessWidget {
                 "Minimum 1 hour - coaches can choose longer durations for their classes",
                 style: TextStyle(
                   fontFamily: 'Inter',
-                  color: ColorsUtils.hintTextColor,
+                  color: customColors.hintTextColor,
                   fontWeight: FontWeight.w400,
                   fontSize: 12,
                 ),
@@ -335,17 +336,17 @@ class CoachStepTwo extends StatelessWidget {
                     child: Container(
                       padding: EdgeInsets.symmetric(horizontal: 6, vertical: 4),
                       decoration: BoxDecoration(
-                        color: ColorsUtils.selectedGridItemColor,
+                        color: customColors.selectedGridItemColor,
                         borderRadius: BorderRadius.circular(6),
                         border: Border.all(
-                          color: ColorsUtils.lightBlueBorderColor,
+                          color: customColors.lightBlueBorderColor,
                         ),
                       ),
                       child: Text(
                         duration,
                         style: TextStyle(
                           fontSize: 14,
-                          color: ColorsUtils.black,
+                          color: colorScheme.onSurface,
                           fontFamily: 'Inter',
                           fontWeight: FontWeight.w400,
                         ),
@@ -359,7 +360,7 @@ class CoachStepTwo extends StatelessWidget {
                 'Popular Duration. Click to select quickly.',
                 style: TextStyle(
                   fontSize: 12,
-                  color: ColorsUtils.textGray,
+                  color: customColors.textGray,
                   fontFamily: 'Inter',
                   fontWeight: FontWeight.w400,
                 ),
@@ -377,7 +378,7 @@ class CoachStepTwo extends StatelessWidget {
                         Expanded(
                           child: CommonTextField(
                             maxLength: 2,
-                            fillColor: ColorsUtils.white,
+                            fillColor: customColors.white,
                             isNumber: true,
                             borderRadius: 6,
                             hint: "Min Sessions to Book for Coaching",
@@ -387,7 +388,7 @@ class CoachStepTwo extends StatelessWidget {
                             textStyle: TextStyle(
                               fontSize: 16,
                               fontFamily: "Inter",
-                              color: ColorsUtils.black,
+                              color: colorScheme.onSurface,
                               fontWeight: FontWeight.w500,
                             ),
                             validator: (value) {
@@ -411,15 +412,15 @@ class CoachStepTwo extends StatelessWidget {
                         const SizedBox(width: 10),
                         Padding(
                           padding: const EdgeInsets.only(top: 15.0),
-                          child: Text(
-                            "sessions",
-                            style: TextStyle(
-                              fontSize: 14,
-                              fontFamily: "Inter",
-                              color: ColorsUtils.hintTextColor,
-                              fontWeight: FontWeight.w400,
-                            ),
-                          ),
+                      child: Text(
+                        "sessions",
+                        style: TextStyle(
+                          fontSize: 14,
+                          fontFamily: "Inter",
+                          color: customColors.hintTextColor,
+                          fontWeight: FontWeight.w400,
+                        ),
+                      ),
                         )
                       ],
                     ),
@@ -428,7 +429,7 @@ class CoachStepTwo extends StatelessWidget {
                       "Minimum number of sessions students must book to get coaching",
                       style: TextStyle(
                         fontFamily: 'Inter',
-                        color: ColorsUtils.hintTextColor,
+                        color: customColors.hintTextColor,
                         fontWeight: FontWeight.w400,
                         fontSize: 12,
                       ),
@@ -443,6 +444,8 @@ class CoachStepTwo extends StatelessWidget {
   }
 
   Widget _buildTrainingVenueView(BuildContext context) {
+    final customColors = Theme.of(context).extension<CustomColors>()!;
+    final colorScheme = Theme.of(context).colorScheme;
     return Column(
       mainAxisAlignment: MainAxisAlignment.start,
       crossAxisAlignment: CrossAxisAlignment.start,
@@ -463,7 +466,7 @@ class CoachStepTwo extends StatelessWidget {
                       "Training Venue",
                       style: TextStyle(
                         fontFamily: 'Montserrat',
-                        color: ColorsUtils.chipText,
+                        color: customColors.chipText,
                         fontWeight: FontWeight.w600,
                         fontSize: 14,
                       ),
@@ -478,18 +481,20 @@ class CoachStepTwo extends StatelessWidget {
                                 "Training Location",
                                 style: TextStyle(
                                   fontFamily: 'Inter',
-                                  color: ColorsUtils.chipText,
+                                  color: customColors.chipText,
                                   fontWeight: FontWeight.w500,
                                   fontSize: 12,
                                 ),
                               ),
                               const SizedBox(height: 10.0),
                               _buildTrainingLocationCheckBoxTitleRow(
+                                context,
                                 title: "At Coach's Address",
                                 isSelected: (context.watch<CreateCoachViewModel>().trainingLocationCheckBoxValue == 1),
                                 onTap: () => context.read<CreateCoachViewModel>().onChangeTrainingLocationCheckBoxValue(1),
                               ),
                               _buildTrainingLocationCheckBoxTitleRow(
+                                context,
                                 title: "Home Training",
                                 isSelected: (context.watch<CreateCoachViewModel>().trainingLocationCheckBoxValue == 2),
                                 onTap: () {
@@ -511,6 +516,7 @@ class CoachStepTwo extends StatelessWidget {
                                 },
                               ),
                               _buildTrainingLocationCheckBoxTitleRow(
+                                context,
                                 title: "Both Options Available",
                                 isSelected: (context.watch<CreateCoachViewModel>().trainingLocationCheckBoxValue == 3),
                                 onTap: () {
@@ -536,7 +542,7 @@ class CoachStepTwo extends StatelessWidget {
                                 "Select the training location options you offer",
                                 style: TextStyle(
                                   fontFamily: 'Inter',
-                                  color: ColorsUtils.textGray,
+                                  color: customColors.textGray,
                                   fontWeight: FontWeight.w400,
                                   fontSize: 12,
                                 ),
@@ -555,22 +561,22 @@ class CoachStepTwo extends StatelessWidget {
                                         children: [
                                           Container(
                                             decoration: BoxDecoration(
-                                              border: Border.all(color: ColorsUtils.borderColor),
+                                              border: Border.all(color: customColors.borderColor),
                                               borderRadius: BorderRadius.circular(6),
-                                              color: OQDOThemeData.backgroundColor,
+                                              color: colorScheme.surface,
                                             ),
                                             child: Padding(
                                               padding: const EdgeInsets.only(left: 10, right: 10),
                                               child: DropdownButton<CoachTrainingAddress>(
                                                   isExpanded: true,
-                                                  icon: const Icon(Icons.keyboard_arrow_down_rounded, color: OQDOThemeData.blackColor),
-                                                  dropdownColor: ColorsUtils.white,
+                                                  icon: Icon(Icons.keyboard_arrow_down_rounded, color: colorScheme.onSurface),
+                                                  dropdownColor: customColors.white,
                                                   underline: const SizedBox(),
                                                   borderRadius: BorderRadius.circular(6),
                                                   hint: CustomTextView(
                                                     label: "Select Training Venue",
                                                     textStyle: TextStyle(
-                                                      color: ColorsUtils.hintTextColor,
+                                                      color: customColors.hintTextColor,
                                                       fontSize: 14,
                                                       fontWeight: FontWeight.w400,
                                                       fontFamily: 'Inter',
@@ -588,7 +594,7 @@ class CoachStepTwo extends StatelessWidget {
                                                             address.addressName ?? "",
                                                             overflow: TextOverflow.ellipsis,
                                                             style: TextStyle(
-                                                              color: ColorsUtils.black,
+                                                              color: colorScheme.onSurface,
                                                               fontSize: 14,
                                                               fontWeight: FontWeight.bold,
                                                               fontFamily: 'Inter',
@@ -600,7 +606,7 @@ class CoachStepTwo extends StatelessWidget {
                                                             overflow: TextOverflow.ellipsis,
                                                             style: TextStyle(
                                                               fontFamily: 'Inter',
-                                                              color: ColorsUtils.hintTextColor,
+                                                              color: customColors.hintTextColor,
                                                               fontWeight: FontWeight.w400,
                                                               fontSize: 12,
                                                             ),
@@ -618,9 +624,9 @@ class CoachStepTwo extends StatelessWidget {
                                     CustomButton(
                                       text: "Add New Address",
                                       leadingIcon: Icon(Icons.add, size: 18),
-                                      textcolor: ColorsUtils.black,
-                                      buttonColor: ColorsUtils.buttonColorGrey,
-                                      borderColor: ColorsUtils.borderColor,
+                                      textcolor: colorScheme.onSurface,
+                                      buttonColor: customColors.buttonColorGrey,
+                                      borderColor: customColors.borderColor,
                                       textsize: 16,
                                       fontWeight: FontWeight.bold,
                                       buttonheight: 50,
@@ -636,7 +642,7 @@ class CoachStepTwo extends StatelessWidget {
                                       "Select from available venues or add a new custom address",
                                       style: TextStyle(
                                         fontFamily: 'Inter',
-                                        color: ColorsUtils.textGray,
+                                        color: customColors.textGray,
                                         fontWeight: FontWeight.w400,
                                         fontSize: 12,
                                       ),
@@ -648,7 +654,7 @@ class CoachStepTwo extends StatelessWidget {
                                         children: [
                                           const SizedBox(height: 10.0),
                                           BaseContainer(
-                                            bgColor: ColorsUtils.buttonBg,
+                                            bgColor: customColors.buttonBg,
                                             child: Row(
                                               mainAxisAlignment: MainAxisAlignment.start,
                                               crossAxisAlignment: CrossAxisAlignment.start,
@@ -662,7 +668,7 @@ class CoachStepTwo extends StatelessWidget {
                                                         context.read<CreateCoachViewModel>().selectedAddress?.addressName ?? "",
                                                         overflow: TextOverflow.ellipsis,
                                                         style: TextStyle(
-                                                          color: ColorsUtils.black,
+                                                          color: colorScheme.onSurface,
                                                           fontSize: 14,
                                                           fontWeight: FontWeight.bold,
                                                           fontFamily: 'Inter',
@@ -673,7 +679,7 @@ class CoachStepTwo extends StatelessWidget {
                                                         "${context.read<CreateCoachViewModel>().selectedAddress?.address1 ?? ""}${(context.read<CreateCoachViewModel>().selectedAddress?.address1 ?? "").isNotEmpty ? ", " : ""}${context.read<CreateCoachViewModel>().selectedAddress?.address2 ?? ""}${(context.read<CreateCoachViewModel>().selectedAddress?.address2 ?? "").isNotEmpty ? ", " : ""}${context.read<CreateCoachViewModel>().selectedAddress?.pinCode ?? ""}",
                                                         style: TextStyle(
                                                           fontFamily: 'Inter',
-                                                          color: ColorsUtils.hintTextColor,
+                                                          color: customColors.hintTextColor,
                                                           fontWeight: FontWeight.w400,
                                                           fontSize: 12,
                                                         ),
@@ -698,7 +704,7 @@ class CoachStepTwo extends StatelessWidget {
                                 "Training Location",
                                 style: TextStyle(
                                   fontFamily: 'Inter',
-                                  color: ColorsUtils.chipText,
+                                  color: customColors.chipText,
                                   fontWeight: FontWeight.w500,
                                   fontSize: 12,
                                 ),
@@ -706,18 +712,21 @@ class CoachStepTwo extends StatelessWidget {
                               const SizedBox(height: 10.0),
                               if (context.watch<CreateCoachViewModel>().classCapacity > 0)
                                 _buildTrainingLocationCheckBoxTitleRow(
+                                  context,
                                   title: "At Coach's Address",
                                   isSelected: (context.watch<CreateCoachViewModel>().trainingLocationCheckBoxValue == 1),
                                   onTap: () => context.read<CreateCoachViewModel>().onChangeTrainingLocationCheckBoxValue(1),
                                 ),
                               if (context.watch<CreateCoachViewModel>().classCapacity == 1)
                                 _buildTrainingLocationCheckBoxTitleRow(
+                                  context,
                                   title: "Home Training",
                                   isSelected: (context.watch<CreateCoachViewModel>().trainingLocationCheckBoxValue == 2),
                                   onTap: () => context.read<CreateCoachViewModel>().onChangeTrainingLocationCheckBoxValue(2),
                                 ),
                               if (context.watch<CreateCoachViewModel>().classCapacity == 1)
                                 _buildTrainingLocationCheckBoxTitleRow(
+                                  context,
                                   title: "Both Options Available",
                                   isSelected: (context.watch<CreateCoachViewModel>().trainingLocationCheckBoxValue == 3),
                                   onTap: () => context.read<CreateCoachViewModel>().onChangeTrainingLocationCheckBoxValue(3),
@@ -727,7 +736,7 @@ class CoachStepTwo extends StatelessWidget {
                                 "Select the training location options you offer",
                                 style: TextStyle(
                                   fontFamily: 'Inter',
-                                  color: ColorsUtils.textGray,
+                                  color: customColors.textGray,
                                   fontWeight: FontWeight.w400,
                                   fontSize: 12,
                                 ),
@@ -746,22 +755,22 @@ class CoachStepTwo extends StatelessWidget {
                                         children: [
                                           Container(
                                             decoration: BoxDecoration(
-                                              border: Border.all(color: ColorsUtils.borderColor),
+                                              border: Border.all(color: customColors.borderColor),
                                               borderRadius: BorderRadius.circular(6),
-                                              color: OQDOThemeData.backgroundColor,
+                                              color: colorScheme.surface,
                                             ),
                                             child: Padding(
                                               padding: const EdgeInsets.only(left: 10, right: 10),
                                               child: DropdownButton<CoachTrainingAddress>(
                                                   isExpanded: true,
-                                                  icon: const Icon(Icons.keyboard_arrow_down_rounded, color: OQDOThemeData.blackColor),
-                                                  dropdownColor: ColorsUtils.white,
+                                                  icon: Icon(Icons.keyboard_arrow_down_rounded, color: colorScheme.onSurface),
+                                                  dropdownColor: customColors.white,
                                                   underline: const SizedBox(),
                                                   borderRadius: BorderRadius.circular(6),
                                                   hint: CustomTextView(
                                                     label: "Select Training Venue",
                                                     textStyle: TextStyle(
-                                                      color: ColorsUtils.hintTextColor,
+                                                      color: customColors.hintTextColor,
                                                       fontSize: 14,
                                                       fontWeight: FontWeight.w400,
                                                       fontFamily: 'Inter',
@@ -779,7 +788,7 @@ class CoachStepTwo extends StatelessWidget {
                                                             address.addressName ?? "",
                                                             overflow: TextOverflow.ellipsis,
                                                             style: TextStyle(
-                                                              color: ColorsUtils.black,
+                                                              color: colorScheme.onSurface,
                                                               fontSize: 14,
                                                               fontWeight: FontWeight.bold,
                                                               fontFamily: 'Inter',
@@ -791,7 +800,7 @@ class CoachStepTwo extends StatelessWidget {
                                                             overflow: TextOverflow.ellipsis,
                                                             style: TextStyle(
                                                               fontFamily: 'Inter',
-                                                              color: ColorsUtils.hintTextColor,
+                                                              color: customColors.hintTextColor,
                                                               fontWeight: FontWeight.w400,
                                                               fontSize: 12,
                                                             ),
@@ -809,22 +818,23 @@ class CoachStepTwo extends StatelessWidget {
                                     CustomButton(
                                       text: "Add New Address",
                                       leadingIcon: Icon(Icons.add, size: 18),
-                                      textcolor: ColorsUtils.black,
-                                      buttonColor: ColorsUtils.buttonColorGrey,
-                                      borderColor: ColorsUtils.borderColor,
+                                      textcolor: colorScheme.onSurface,
+                                      buttonColor: customColors.buttonColorGrey,
+                                      borderColor: customColors.borderColor,
                                       textsize: 16,
                                       fontWeight: FontWeight.bold,
                                       buttonheight: 50,
                                       radius: 5,
                                       buttonwidth: double.infinity,
-                                      onTap: () => _showAddAddressBottomSheet(context, context.read<CreateCoachViewModel>()),
+                                      onTap: () =>
+                                          _showAddAddressBottomSheet(context, context.read<CreateCoachViewModel>()),
                                     ),
                                     const SizedBox(height: 10.0),
                                     Text(
                                       "Select from available venues or add a new custom address",
                                       style: TextStyle(
                                         fontFamily: 'Inter',
-                                        color: ColorsUtils.textGray,
+                                        color: customColors.textGray,
                                         fontWeight: FontWeight.w400,
                                         fontSize: 12,
                                       ),
@@ -836,7 +846,7 @@ class CoachStepTwo extends StatelessWidget {
                                         children: [
                                           const SizedBox(height: 10.0),
                                           BaseContainer(
-                                            bgColor: ColorsUtils.buttonBg,
+                                            bgColor: customColors.buttonBg,
                                             child: Row(
                                               mainAxisAlignment: MainAxisAlignment.start,
                                               crossAxisAlignment: CrossAxisAlignment.start,
@@ -850,7 +860,7 @@ class CoachStepTwo extends StatelessWidget {
                                                         context.read<CreateCoachViewModel>().selectedAddress?.addressName ?? "",
                                                         overflow: TextOverflow.ellipsis,
                                                         style: TextStyle(
-                                                          color: ColorsUtils.black,
+                                                          color: colorScheme.onSurface,
                                                           fontSize: 14,
                                                           fontWeight: FontWeight.bold,
                                                           fontFamily: 'Inter',
@@ -861,7 +871,7 @@ class CoachStepTwo extends StatelessWidget {
                                                         "${context.read<CreateCoachViewModel>().selectedAddress?.address1 ?? ""}${(context.read<CreateCoachViewModel>().selectedAddress?.address1 ?? "").isNotEmpty ? ", " : ""}${context.read<CreateCoachViewModel>().selectedAddress?.address2 ?? ""}${(context.read<CreateCoachViewModel>().selectedAddress?.address2 ?? "").isNotEmpty ? ", " : ""}${context.read<CreateCoachViewModel>().selectedAddress?.pinCode ?? ""}",
                                                         style: TextStyle(
                                                           fontFamily: 'Inter',
-                                                          color: ColorsUtils.hintTextColor,
+                                                          color: customColors.hintTextColor,
                                                           fontWeight: FontWeight.w400,
                                                           fontSize: 12,
                                                         ),
@@ -888,6 +898,8 @@ class CoachStepTwo extends StatelessWidget {
   }
 
   void _showAddAddressBottomSheet(BuildContext aContext, CreateCoachViewModel viewModel) {
+    final customColors = Theme.of(aContext).extension<CustomColors>()!;
+    final colorScheme = Theme.of(aContext).colorScheme;
     showModalBottomSheet(
       context: aContext,
       isScrollControlled: true,
@@ -911,29 +923,29 @@ class CoachStepTwo extends StatelessWidget {
                     minHeight: 0, // Let content determine minimum height
                   ),
                   child: IntrinsicHeight(
-                    child: Container(
-                      // Remove fixed height - let content determine height
-                      padding: EdgeInsets.all(15.0),
-                      decoration: BoxDecoration(
-                        color: ColorsUtils.white,
-                        borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
-                      ),
-                      child: Column(
-                        mainAxisSize: MainAxisSize.min, // Important: use min size
-                        children: [
-                          // Header
-                          Row(
-                            mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                            children: [
-                              Text(
-                                'Add Training Address',
-                                style: TextStyle(
-                                  fontSize: 18,
-                                  fontWeight: FontWeight.bold,
-                                  color: ColorsUtils.black,
-                                  fontFamily: 'Montserrat',
-                                ),
+                  child: Container(
+                    // Remove fixed height - let content determine height
+                    padding: EdgeInsets.all(15.0),
+                    decoration: BoxDecoration(
+                      color: customColors.white,
+                      borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
+                    ),
+                    child: Column(
+                      mainAxisSize: MainAxisSize.min, // Important: use min size
+                      children: [
+                        // Header
+                        Row(
+                          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                          children: [
+                            Text(
+                              'Add Training Address',
+                              style: TextStyle(
+                                fontSize: 18,
+                                fontWeight: FontWeight.bold,
+                                color: colorScheme.onSurface,
+                                fontFamily: 'Montserrat',
                               ),
+                            ),
                               GestureDetector(
                                 onTap: () {
                                   Navigator.of(context, rootNavigator: false).pop();
@@ -960,7 +972,7 @@ class CoachStepTwo extends StatelessWidget {
                                     CommonTextField(
                                       maxLength: 50,
                                       autovalidateMode: AutovalidateMode.onUserInteraction,
-                                      fillColor: ColorsUtils.white,
+                                      fillColor: customColors.white,
                                       isAddress: true,
                                       borderRadius: 6,
                                       hint: "e.g Main Training Center",
@@ -968,7 +980,7 @@ class CoachStepTwo extends StatelessWidget {
                                       textStyle: TextStyle(
                                         fontSize: 16,
                                         fontFamily: "Inter",
-                                        color: ColorsUtils.black,
+                                        color: colorScheme.onSurface,
                                         fontWeight: FontWeight.w500,
                                       ),
                                       validator: (value) {
@@ -987,7 +999,7 @@ class CoachStepTwo extends StatelessWidget {
                                     CommonTextField(
                                       maxLength: 100,
                                       autovalidateMode: AutovalidateMode.onUserInteraction,
-                                      fillColor: ColorsUtils.white,
+                                      fillColor: customColors.white,
                                       isAddress: true,
                                       borderRadius: 6,
                                       hint: "Street address, building name",
@@ -995,7 +1007,7 @@ class CoachStepTwo extends StatelessWidget {
                                       textStyle: TextStyle(
                                         fontSize: 16,
                                         fontFamily: "Inter",
-                                        color: ColorsUtils.black,
+                                        color: colorScheme.onSurface,
                                         fontWeight: FontWeight.w500,
                                       ),
                                       validator: (value) {
@@ -1014,7 +1026,7 @@ class CoachStepTwo extends StatelessWidget {
                                     CommonTextField(
                                       maxLength: 100,
                                       autovalidateMode: AutovalidateMode.onUserInteraction,
-                                      fillColor: ColorsUtils.white,
+                                      fillColor: customColors.white,
                                       isAddress: true,
                                       borderRadius: 6,
                                       hint: "Apartment, suite, unit, etc.",
@@ -1022,7 +1034,7 @@ class CoachStepTwo extends StatelessWidget {
                                       textStyle: TextStyle(
                                         fontSize: 16,
                                         fontFamily: "Inter",
-                                        color: ColorsUtils.black,
+                                        color: colorScheme.onSurface,
                                         fontWeight: FontWeight.w500,
                                       ),
                                       validator: (value) {
@@ -1041,7 +1053,7 @@ class CoachStepTwo extends StatelessWidget {
                                     CommonTextField(
                                       maxLength: 6,
                                       autovalidateMode: AutovalidateMode.onUserInteraction,
-                                      fillColor: ColorsUtils.white,
+                                      fillColor: customColors.white,
                                       isNumber: true,
                                       borderRadius: 6,
                                       hint: "Pincode",
@@ -1049,7 +1061,7 @@ class CoachStepTwo extends StatelessWidget {
                                       textStyle: TextStyle(
                                         fontSize: 16,
                                         fontFamily: "Inter",
-                                        color: ColorsUtils.black,
+                                        color: colorScheme.onSurface,
                                         fontWeight: FontWeight.w500,
                                       ),
                                       validator: (value) {
@@ -1072,8 +1084,8 @@ class CoachStepTwo extends StatelessWidget {
                               Expanded(
                                 child: CustomButton(
                                   text: "Cancel",
-                                  textcolor: ColorsUtils.black,
-                                  buttonColor: ColorsUtils.buttonBg,
+                                  textcolor: colorScheme.onSurface,
+                                  buttonColor: customColors.buttonBg,
                                   textsize: 16,
                                   fontWeight: FontWeight.bold,
                                   buttonheight: 50,
@@ -1088,8 +1100,8 @@ class CoachStepTwo extends StatelessWidget {
                               Expanded(
                                 child: CustomButton(
                                   text: "Save Address",
-                                  textcolor: ColorsUtils.white,
-                                  buttonColor: ColorsUtils.primary,
+                                  textcolor: colorScheme.onPrimary,
+                                  buttonColor: colorScheme.primary,
                                   textsize: 16,
                                   fontWeight: FontWeight.bold,
                                   buttonheight: 50,
@@ -1119,13 +1131,15 @@ class CoachStepTwo extends StatelessWidget {
   }
 
   Widget _buildRateSettingsView(BuildContext context) {
+    final customColors = Theme.of(context).extension<CustomColors>()!;
+    final colorScheme = Theme.of(context).colorScheme;
     return Column(
       mainAxisAlignment: MainAxisAlignment.start,
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         const SizedBox(height: 20),
         BaseContainer(
-          bgColor: ColorsUtils.white,
+          bgColor: customColors.white,
           child: Column(
             mainAxisAlignment: MainAxisAlignment.start,
             crossAxisAlignment: CrossAxisAlignment.start,
@@ -1135,7 +1149,7 @@ class CoachStepTwo extends StatelessWidget {
                 "Rate Settings",
                 style: TextStyle(
                   fontFamily: 'Montserrat',
-                  color: ColorsUtils.chipText,
+                  color: customColors.chipText,
                   fontWeight: FontWeight.w600,
                   fontSize: 14,
                 ),
@@ -1153,7 +1167,7 @@ class CoachStepTwo extends StatelessWidget {
                         "Same Rate for All Sessions",
                         style: TextStyle(
                           fontFamily: 'Montserrat',
-                          color: ColorsUtils.chipText,
+                          color: customColors.chipText,
                           fontWeight: FontWeight.w600,
                           fontSize: 14,
                         ),
@@ -1163,7 +1177,7 @@ class CoachStepTwo extends StatelessWidget {
                         "Apply one rate to all time slots",
                         style: TextStyle(
                           fontFamily: 'Inter',
-                          color: ColorsUtils.hintTextColor,
+                          color: customColors.hintTextColor,
                           fontWeight: FontWeight.w400,
                           fontSize: 12,
                         ),
@@ -1215,34 +1229,34 @@ class CoachStepTwo extends StatelessWidget {
                       children: [
                         Padding(
                           padding: const EdgeInsets.only(top: 15.0),
-                          child: Text(
-                            "S \$",
-                            style: TextStyle(
-                              fontSize: 14,
-                              fontFamily: "Inter",
-                              color: ColorsUtils.darkGrey,
-                              fontWeight: FontWeight.w400,
-                            ),
+                        child: Text(
+                          "S \$",
+                          style: TextStyle(
+                            fontSize: 14,
+                            fontFamily: "Inter",
+                            color: customColors.hintTextColor,
+                            fontWeight: FontWeight.w400,
                           ),
                         ),
+                      ),
                         const SizedBox(width: 10.0),
                         Expanded(
-                          child: CommonTextField(
-                            maxLength: 6,
-                            fillColor: ColorsUtils.white,
-                            controller: context.read<CreateCoachViewModel>().hourlyRateController,
-                            isDouble: true,
-                            autovalidateMode: AutovalidateMode.onUserInteraction,
-                            normalBorderColor: ColorsUtils.borderColor,
-                            borderRadius: 6,
-                            hint: "Enter hourly rate",
-                            labelText: "Hourly Rate",
-                            textStyle: TextStyle(
-                              fontSize: 16,
-                              fontFamily: "Inter",
-                              color: ColorsUtils.black,
-                              fontWeight: FontWeight.w500,
-                            ),
+                        child: CommonTextField(
+                          maxLength: 6,
+                          fillColor: customColors.white,
+                          controller: context.read<CreateCoachViewModel>().hourlyRateController,
+                          isDouble: true,
+                          autovalidateMode: AutovalidateMode.onUserInteraction,
+                          normalBorderColor: customColors.borderColor,
+                          borderRadius: 6,
+                          hint: "Enter hourly rate",
+                          labelText: "Hourly Rate",
+                          textStyle: TextStyle(
+                            fontSize: 16,
+                            fontFamily: "Inter",
+                            color: colorScheme.onSurface,
+                            fontWeight: FontWeight.w500,
+                          ),
                             validator: (value) {
                               if (value?.isEmpty ?? true) {
                                 return "Please enter hourly rate";
@@ -1270,7 +1284,10 @@ class CoachStepTwo extends StatelessWidget {
     );
   }
 
-  Widget _buildTrainingLocationCheckBoxTitleRow({required String title, required bool isSelected, required Function()? onTap}) {
+  Widget _buildTrainingLocationCheckBoxTitleRow(BuildContext context,
+      {required String title, required bool isSelected, required Function()? onTap}) {
+    final customColors = Theme.of(context).extension<CustomColors>()!;
+    final colorScheme = Theme.of(context).colorScheme;
     return GestureDetector(
       onTap: onTap,
       child: SizedBox(
@@ -1282,16 +1299,18 @@ class CoachStepTwo extends StatelessWidget {
               width: 30,
               height: 30,
               decoration: BoxDecoration(
-                color: isSelected ? ColorsUtils.primary : ColorsUtils.greyBG,
+                color: isSelected ? colorScheme.primary : customColors.greyBG,
                 borderRadius: BorderRadius.circular(7),
               ),
-              child: isSelected ? Icon(Icons.check, size: 18, color: ColorsUtils.white) : null,
+              child: isSelected
+                  ? Icon(Icons.check, size: 18, color: customColors.onAccentText)
+                  : null,
             ),
             SizedBox(width: 8),
             Text(
               title,
               style: TextStyle(
-                color: isSelected ? ColorsUtils.black : ColorsUtils.hintTextColor,
+                color: isSelected ? colorScheme.onSurface : customColors.hintTextColor,
                 fontSize: 14,
                 fontWeight: FontWeight.w600,
                 fontFamily: 'Inter',


### PR DESCRIPTION
## Summary
- migrate the coach setup step widgets to use CustomColors and ColorScheme instead of hard-coded ColorsUtils values
- update the training preview page to resolve theme-aware colors for cards, chips, and buttons
- ensure coach setup bottom sheets adopt themed surface backgrounds for consistency in dark mode

## Testing
- not run (flutter not available in container)

------
https://chatgpt.com/codex/tasks/task_e_68d0381869ec8332a66147115179fb4e