### PR TITLE
Update progress dialog styling

### DIFF
--- a/lib/screens/appointment/EndUserFacilityAppointmentDetails.dart
+++ b/lib/screens/appointment/EndUserFacilityAppointmentDetails.dart
@@ -835,7 +835,10 @@ class _EndUserFacilityAppointmentDetailsState extends State<EndUserFacilityAppoi
 
   Future callAddRating() async {
     _progressDialog = ProgressDialog(context, type: ProgressDialogType.normal, isDismissible: false);
-    _progressDialog.style(message: "Please wait..");
+    _progressDialog.style(
+            message: "Please wait..",
+            backgroundColor: Theme.of(context).extension<CustomColors>()!.progressDialogBackgroundColor,
+            messageTextStyle: TextStyle(color: Theme.of(context).extension<CustomColors>()!.blackAndWhiteColor, fontFamily: 'Inter', fontWeight: FontWeight.bold, fontSize: 18));
     Map<String, dynamic> request = {};
     request['FacilityBookingId'] = widget.model!.bookingId!;
     request['Rating'] = ratingValue;

--- a/lib/screens/appointment/appointment_view_order_screen.dart
+++ b/lib/screens/appointment/appointment_view_order_screen.dart
@@ -819,7 +819,10 @@ class _EndUserCoachAppointmentDetailsScreenState extends State<EndUserCoachAppoi
 
   Future callAddRating() async {
     _progressDialog = ProgressDialog(context, type: ProgressDialogType.normal, isDismissible: false);
-    _progressDialog.style(message: "Please wait..");
+    _progressDialog.style(
+            message: "Please wait..",
+            backgroundColor: Theme.of(context).extension<CustomColors>()!.progressDialogBackgroundColor,
+            messageTextStyle: TextStyle(color: Theme.of(context).extension<CustomColors>()!.blackAndWhiteColor, fontFamily: 'Inter', fontWeight: FontWeight.bold, fontSize: 18));
     Map<String, dynamic> request = {};
     request['CoachBookingId'] = widget.model!.bookingId!;
     request['Rating'] = ratingValue;

--- a/lib/screens/appointment/cancel_coach_appointment_reason_screen.dart
+++ b/lib/screens/appointment/cancel_coach_appointment_reason_screen.dart
@@ -41,7 +41,10 @@ class _CancelCoachAppointmentReasonScreenState extends State<CancelCoachAppointm
     super.initState();
     WidgetsBinding.instance.addPostFrameCallback((_) async {
       _progressDialog = ProgressDialog(context, type: ProgressDialogType.normal, isDismissible: false);
-      _progressDialog.style(message: "Please wait..");
+      _progressDialog.style(
+              message: "Please wait..",
+              backgroundColor: Theme.of(context).extension<CustomColors>()!.progressDialogBackgroundColor,
+              messageTextStyle: TextStyle(color: Theme.of(context).extension<CustomColors>()!.blackAndWhiteColor, fontFamily: 'Inter', fontWeight: FontWeight.bold, fontSize: 18));
       getCancelReasons();
     });
   }
@@ -336,7 +339,10 @@ class _CancelCoachAppointmentReasonScreenState extends State<CancelCoachAppointm
 
   Future<void> facilityCancelRequest() async {
     _progressDialog = ProgressDialog(context, type: ProgressDialogType.normal, isDismissible: false);
-    _progressDialog.style(message: "Please wait..");
+    _progressDialog.style(
+            message: "Please wait..",
+            backgroundColor: Theme.of(context).extension<CustomColors>()!.progressDialogBackgroundColor,
+            messageTextStyle: TextStyle(color: Theme.of(context).extension<CustomColors>()!.blackAndWhiteColor, fontFamily: 'Inter', fontWeight: FontWeight.bold, fontSize: 18));
     try {
       await _progressDialog.show();
       Map<String, dynamic> request = {};

--- a/lib/screens/appointment/cancel_facility_appointment_reason_screen.dart
+++ b/lib/screens/appointment/cancel_facility_appointment_reason_screen.dart
@@ -39,7 +39,10 @@ class _CancelFacilityAppointmentReasonScreenState extends State<CancelFacilityAp
     super.initState();
     WidgetsBinding.instance.addPostFrameCallback((_) async {
       _progressDialog = ProgressDialog(context, type: ProgressDialogType.normal, isDismissible: false);
-      _progressDialog.style(message: "Please wait..");
+      _progressDialog.style(
+              message: "Please wait..",
+              backgroundColor: Theme.of(context).extension<CustomColors>()!.progressDialogBackgroundColor,
+              messageTextStyle: TextStyle(color: Theme.of(context).extension<CustomColors>()!.blackAndWhiteColor, fontFamily: 'Inter', fontWeight: FontWeight.bold, fontSize: 18));
       getCancelReasons();
     });
   }

--- a/lib/screens/appointment/coach_appointment_screen.dart
+++ b/lib/screens/appointment/coach_appointment_screen.dart
@@ -424,7 +424,10 @@ class _CoachAppointmentsScreenState extends State<CoachAppointmentsScreen> {
 
   Future<void> getEndUserAppointments(DateTime passingDate) async {
     _progressDialog = ProgressDialog(context, type: ProgressDialogType.normal, isDismissible: false);
-    _progressDialog.style(message: "Please wait..");
+    _progressDialog.style(
+            message: "Please wait..",
+            backgroundColor: Theme.of(context).extension<CustomColors>()!.progressDialogBackgroundColor,
+            messageTextStyle: TextStyle(color: Theme.of(context).extension<CustomColors>()!.blackAndWhiteColor, fontFamily: 'Inter', fontWeight: FontWeight.bold, fontSize: 18));
     try {
       await _progressDialog.show();
       List<CoachAppointmentsResponseModel> endUserAppointmentList = await Provider.of<AppointmentViewModel>(context, listen: false)

--- a/lib/screens/appointment/coach_details_appointment_screen.dart
+++ b/lib/screens/appointment/coach_details_appointment_screen.dart
@@ -505,7 +505,10 @@ class _CoachDetailAppointmentScreenState extends State<CoachDetailAppointmentScr
 
   Future<void> getFacilityAppointmentDetails() async {
     _progressDialog = ProgressDialog(context, type: ProgressDialogType.normal, isDismissible: false);
-    _progressDialog.style(message: "Please wait..");
+    _progressDialog.style(
+            message: "Please wait..",
+            backgroundColor: Theme.of(context).extension<CustomColors>()!.progressDialogBackgroundColor,
+            messageTextStyle: TextStyle(color: Theme.of(context).extension<CustomColors>()!.blackAndWhiteColor, fontFamily: 'Inter', fontWeight: FontWeight.bold, fontSize: 18));
     try {
       await _progressDialog.show();
       model.CoachAppointmentDetailResponseModel facilityAppointmentDetailModel =

--- a/lib/screens/appointment/coach_enduser_verification_screen.dart
+++ b/lib/screens/appointment/coach_enduser_verification_screen.dart
@@ -36,7 +36,10 @@ class _CoachEndUserVerificationScreenState extends State<CoachEndUserVerificatio
     super.initState();
     WidgetsBinding.instance.addPostFrameCallback((_) async {
       _progressDialog = ProgressDialog(context, type: ProgressDialogType.normal, isDismissible: false);
-      _progressDialog.style(message: "Please wait...");
+      _progressDialog.style(
+              message: "Please wait..",
+              backgroundColor: Theme.of(context).extension<CustomColors>()!.progressDialogBackgroundColor,
+              messageTextStyle: TextStyle(color: Theme.of(context).extension<CustomColors>()!.blackAndWhiteColor, fontFamily: 'Inter', fontWeight: FontWeight.bold, fontSize: 18));
       for (var i = 0; i < widget.cancelCoachAppointmentModel!.bookingSlotList!.length; i++) {
         if (widget.cancelCoachAppointmentModel!.bookingSlotList![i].isSlotSelected!) {
           setState(() {

--- a/lib/screens/appointment/enduser_appointment_screen.dart
+++ b/lib/screens/appointment/enduser_appointment_screen.dart
@@ -478,7 +478,10 @@ class _EndUserAppointmentsScreenState extends State<EndUserAppointmentsScreen> {
 
   Future<void> getEndUserAppointments(DateTime passingDate) async {
     _progressDialog = ProgressDialog(context, type: ProgressDialogType.normal, isDismissible: false);
-    _progressDialog.style(message: "Please wait..");
+    _progressDialog.style(
+            message: "Please wait..",
+            backgroundColor: Theme.of(context).extension<CustomColors>()!.progressDialogBackgroundColor,
+            messageTextStyle: TextStyle(color: Theme.of(context).extension<CustomColors>()!.blackAndWhiteColor, fontFamily: 'Inter', fontWeight: FontWeight.bold, fontSize: 18));
     try {
       await _progressDialog.show();
       List<EndUserAppointmentsResponseModel> endUserAppointmentList = await Provider.of<AppointmentViewModel>(context, listen: false)
@@ -1401,7 +1404,10 @@ class _EndUserAppointmentsScreenState extends State<EndUserAppointmentsScreen> {
 
   Future<void> getAppointmentDetails(int bookingId, int? setupDaySlotMapId) async {
     _progressDialog = ProgressDialog(context, type: ProgressDialogType.normal, isDismissible: false);
-    _progressDialog.style(message: "Please wait..");
+    _progressDialog.style(
+            message: "Please wait..",
+            backgroundColor: Theme.of(context).extension<CustomColors>()!.progressDialogBackgroundColor,
+            messageTextStyle: TextStyle(color: Theme.of(context).extension<CustomColors>()!.blackAndWhiteColor, fontFamily: 'Inter', fontWeight: FontWeight.bold, fontSize: 18));
     try {
       await _progressDialog.show();
       model.CoachAppointmentDetailResponseModel facilityAppointmentDetailModel =
@@ -1494,7 +1500,10 @@ class _EndUserAppointmentsScreenState extends State<EndUserAppointmentsScreen> {
 
   Future<void> getFacilityAppointmentDetails(int? bookingId, int? setupDaySlotMapId) async {
     _progressDialog = ProgressDialog(context, type: ProgressDialogType.normal, isDismissible: false);
-    _progressDialog.style(message: "Please wait..");
+    _progressDialog.style(
+            message: "Please wait..",
+            backgroundColor: Theme.of(context).extension<CustomColors>()!.progressDialogBackgroundColor,
+            messageTextStyle: TextStyle(color: Theme.of(context).extension<CustomColors>()!.blackAndWhiteColor, fontFamily: 'Inter', fontWeight: FontWeight.bold, fontSize: 18));
     try {
       await _progressDialog.show();
       FacilityAppointmentDetailModel facilityAppointmentDetailModel =
@@ -1548,7 +1557,10 @@ class _EndUserAppointmentsScreenState extends State<EndUserAppointmentsScreen> {
 
   Future<void> facilityCancelRequest(FacilityAppointmentDetailModel? facilityAppointmentDetailModel, int? setupDaySlotMapId) async {
     _progressDialog = ProgressDialog(context, type: ProgressDialogType.normal, isDismissible: false);
-    _progressDialog.style(message: "Please wait..");
+    _progressDialog.style(
+            message: "Please wait..",
+            backgroundColor: Theme.of(context).extension<CustomColors>()!.progressDialogBackgroundColor,
+            messageTextStyle: TextStyle(color: Theme.of(context).extension<CustomColors>()!.blackAndWhiteColor, fontFamily: 'Inter', fontWeight: FontWeight.bold, fontSize: 18));
     try {
       await _progressDialog.show();
       Map<String, dynamic> request = {};
@@ -1607,7 +1619,10 @@ class _EndUserAppointmentsScreenState extends State<EndUserAppointmentsScreen> {
 
   Future<void> coachCancelRequest(model.CoachAppointmentDetailResponseModel coachAppointmentDetailResponseModel, int? setupDaySlotMapId) async {
     _progressDialog = ProgressDialog(context, type: ProgressDialogType.normal, isDismissible: false);
-    _progressDialog.style(message: "Please wait..");
+    _progressDialog.style(
+            message: "Please wait..",
+            backgroundColor: Theme.of(context).extension<CustomColors>()!.progressDialogBackgroundColor,
+            messageTextStyle: TextStyle(color: Theme.of(context).extension<CustomColors>()!.blackAndWhiteColor, fontFamily: 'Inter', fontWeight: FontWeight.bold, fontSize: 18));
     try {
       await _progressDialog.show();
       Map<String, dynamic> request = {};

--- a/lib/screens/appointment/facility_appointment_details_screen.dart
+++ b/lib/screens/appointment/facility_appointment_details_screen.dart
@@ -629,7 +629,10 @@ class _FacilityAppointmentDetailsScreenState extends State<FacilityAppointmentDe
 
   Future<void> getFacilityAppointmentDetails() async {
     _progressDialog = ProgressDialog(context, type: ProgressDialogType.normal, isDismissible: false);
-    _progressDialog.style(message: "Please wait...");
+    _progressDialog.style(
+            message: "Please wait..",
+            backgroundColor: Theme.of(context).extension<CustomColors>()!.progressDialogBackgroundColor,
+            messageTextStyle: TextStyle(color: Theme.of(context).extension<CustomColors>()!.blackAndWhiteColor, fontFamily: 'Inter', fontWeight: FontWeight.bold, fontSize: 18));
     try {
       await _progressDialog.show();
       FacilityAppointmentDetailModel facilityAppointmentDetailModel =

--- a/lib/screens/appointment/facility_appointment_screen.dart
+++ b/lib/screens/appointment/facility_appointment_screen.dart
@@ -425,7 +425,10 @@ class _FacilityAppointmentsScreenState extends State<FacilityAppointmentsScreen>
 
   Future<void> getEndUserAppointments(DateTime passingDate) async {
     _progressDialog = ProgressDialog(context, type: ProgressDialogType.normal, isDismissible: false);
-    _progressDialog.style(message: "Please wait..");
+    _progressDialog.style(
+            message: "Please wait..",
+            backgroundColor: Theme.of(context).extension<CustomColors>()!.progressDialogBackgroundColor,
+            messageTextStyle: TextStyle(color: Theme.of(context).extension<CustomColors>()!.blackAndWhiteColor, fontFamily: 'Inter', fontWeight: FontWeight.bold, fontSize: 18));
     try {
       await _progressDialog.show();
       List<FacilityAppointmentsResponseModel> endUserAppointmentList = await Provider.of<AppointmentViewModel>(context, listen: false)

--- a/lib/screens/appointment/facility_enduser_verification_screen.dart
+++ b/lib/screens/appointment/facility_enduser_verification_screen.dart
@@ -42,7 +42,10 @@ class _FacilityEndUserCancelAppointmentVerificationScreenState
     WidgetsBinding.instance.addPostFrameCallback((_) async {
       _progressDialog = ProgressDialog(context,
           type: ProgressDialogType.normal, isDismissible: false);
-      _progressDialog.style(message: "Please wait..");
+      _progressDialog.style(
+              message: "Please wait..",
+              backgroundColor: Theme.of(context).extension<CustomColors>()!.progressDialogBackgroundColor,
+              messageTextStyle: TextStyle(color: Theme.of(context).extension<CustomColors>()!.blackAndWhiteColor, fontFamily: 'Inter', fontWeight: FontWeight.bold, fontSize: 18));
       for (var i = 0;
           i < widget.cancelFacilityAppointmentModel!.list!.length;
           i++) {

--- a/lib/screens/appointment/review_appointment_screen.dart
+++ b/lib/screens/appointment/review_appointment_screen.dart
@@ -743,7 +743,10 @@ class _ReviewAppointmentScreenState extends State<ReviewAppointmentScreen> {
   Future<void> facilityAppointmentBooking() async {
     _progressDialog = ProgressDialog(context,
         type: ProgressDialogType.normal, isDismissible: false);
-    _progressDialog.style(message: "Please wait..");
+    _progressDialog.style(
+            message: "Please wait..",
+            backgroundColor: Theme.of(context).extension<CustomColors>()!.progressDialogBackgroundColor,
+            messageTextStyle: TextStyle(color: Theme.of(context).extension<CustomColors>()!.blackAndWhiteColor, fontFamily: 'Inter', fontWeight: FontWeight.bold, fontSize: 18));
     try {
       await _progressDialog.show();
       Map<String, dynamic> request = {};
@@ -931,7 +934,10 @@ class _ReviewAppointmentScreenState extends State<ReviewAppointmentScreen> {
       String paymentID, int facilityBookingId) async {
     _progressDialog = ProgressDialog(context,
         type: ProgressDialogType.normal, isDismissible: false);
-    _progressDialog.style(message: "Please wait...");
+    _progressDialog.style(
+            message: "Please wait..",
+            backgroundColor: Theme.of(context).extension<CustomColors>()!.progressDialogBackgroundColor,
+            messageTextStyle: TextStyle(color: Theme.of(context).extension<CustomColors>()!.blackAndWhiteColor, fontFamily: 'Inter', fontWeight: FontWeight.bold, fontSize: 18));
     try {
       await _progressDialog.show();
       Map<String, dynamic> request = {};
@@ -980,7 +986,10 @@ class _ReviewAppointmentScreenState extends State<ReviewAppointmentScreen> {
   Future<void> successBooking(String paymentId, int facilityBookingId) async {
     _progressDialog = ProgressDialog(context,
         type: ProgressDialogType.normal, isDismissible: false);
-    _progressDialog.style(message: "Please wait...");
+    _progressDialog.style(
+            message: "Please wait..",
+            backgroundColor: Theme.of(context).extension<CustomColors>()!.progressDialogBackgroundColor,
+            messageTextStyle: TextStyle(color: Theme.of(context).extension<CustomColors>()!.blackAndWhiteColor, fontFamily: 'Inter', fontWeight: FontWeight.bold, fontSize: 18));
     try {
       await _progressDialog.show();
       Map<String, dynamic> request = {};
@@ -1095,7 +1104,10 @@ class _ReviewAppointmentScreenState extends State<ReviewAppointmentScreen> {
   Future<void> failedBooking(String paymentId, int facilityBookingId) async {
     _progressDialog = ProgressDialog(context,
         type: ProgressDialogType.normal, isDismissible: false);
-    _progressDialog.style(message: "Please wait...");
+    _progressDialog.style(
+            message: "Please wait..",
+            backgroundColor: Theme.of(context).extension<CustomColors>()!.progressDialogBackgroundColor,
+            messageTextStyle: TextStyle(color: Theme.of(context).extension<CustomColors>()!.blackAndWhiteColor, fontFamily: 'Inter', fontWeight: FontWeight.bold, fontSize: 18));
     try {
       await _progressDialog.show();
       Map<String, dynamic> request = {};

--- a/lib/screens/bazaar/ads_screen/add_ads_screen.dart
+++ b/lib/screens/bazaar/ads_screen/add_ads_screen.dart
@@ -14,6 +14,7 @@ import 'package:oqdo_mobile_app/utils/textfields_widget.dart';
 import 'package:oqdo_mobile_app/utils/utilities.dart';
 import 'package:progress_dialog_null_safe/progress_dialog_null_safe.dart';
 import 'package:provider/provider.dart';
+import 'package:oqdo_mobile_app/theme/custom_colors.dart';
 
 class AddAdsScreen extends StatefulWidget {
   const AddAdsScreen({super.key});
@@ -69,7 +70,10 @@ class _AddAdsScreenState extends State<AddAdsScreen> {
     super.initState();
     WidgetsBinding.instance.addPostFrameCallback((timeStamp) {
       _progressDialog = ProgressDialog(context, type: ProgressDialogType.normal, isDismissible: false);
-      _progressDialog.style(message: "Please wait..");
+      _progressDialog.style(
+              message: "Please wait..",
+              backgroundColor: Theme.of(context).extension<CustomColors>()!.progressDialogBackgroundColor,
+              messageTextStyle: TextStyle(color: Theme.of(context).extension<CustomColors>()!.blackAndWhiteColor, fontFamily: 'Inter', fontWeight: FontWeight.bold, fontSize: 18));
     });
   }
 

--- a/lib/screens/bazaar/buy/buy_fav_screen.dart
+++ b/lib/screens/bazaar/buy/buy_fav_screen.dart
@@ -13,6 +13,7 @@ import 'package:oqdo_mobile_app/utils/network_interceptor.dart';
 import 'package:oqdo_mobile_app/utils/string_manager.dart';
 import 'package:progress_dialog_null_safe/progress_dialog_null_safe.dart';
 import 'package:provider/provider.dart';
+import 'package:oqdo_mobile_app/theme/custom_colors.dart';
 
 class BuyFavScreen extends StatefulWidget {
   static const String routeName = '/buyFavScreen';
@@ -232,7 +233,10 @@ class _BuyFavScreenState extends State<BuyFavScreen> {
   Future<void> addRemoveFromFavorite(BuyFavoriteEquipment equipment) async {
     try {
       _progressDialog = ProgressDialog(context, type: ProgressDialogType.normal, isDismissible: false);
-      _progressDialog.style(message: "Please wait..");
+      _progressDialog.style(
+              message: "Please wait..",
+              backgroundColor: Theme.of(context).extension<CustomColors>()!.progressDialogBackgroundColor,
+              messageTextStyle: TextStyle(color: Theme.of(context).extension<CustomColors>()!.blackAndWhiteColor, fontFamily: 'Inter', fontWeight: FontWeight.bold, fontSize: 18));
       await _progressDialog.show();
 
       await Provider.of<SellViewmodel>(context, listen: false).addRemoveFromFavorite(equipment.equipmentId.toString()).then((value) async {

--- a/lib/screens/bazaar/buy/buy_product_details_screen.dart
+++ b/lib/screens/bazaar/buy/buy_product_details_screen.dart
@@ -10,6 +10,7 @@ import 'package:oqdo_mobile_app/utils/network_interceptor.dart';
 import 'package:oqdo_mobile_app/utils/string_manager.dart';
 import 'package:progress_dialog_null_safe/progress_dialog_null_safe.dart';
 import 'package:provider/provider.dart';
+import 'package:oqdo_mobile_app/theme/custom_colors.dart';
 
 /// A screen that displays product details for selling items
 /// Shows product images, details, and a post button
@@ -36,7 +37,10 @@ class _BuyProductDetailsScreenState extends State<BuyProductDetailsScreen> {
     super.initState();
     WidgetsBinding.instance.addPostFrameCallback((_) async {
       _progressDialog = ProgressDialog(context, type: ProgressDialogType.normal, isDismissible: false);
-      _progressDialog.style(message: "Please wait..");
+      _progressDialog.style(
+              message: "Please wait..",
+              backgroundColor: Theme.of(context).extension<CustomColors>()!.progressDialogBackgroundColor,
+              messageTextStyle: TextStyle(color: Theme.of(context).extension<CustomColors>()!.blackAndWhiteColor, fontFamily: 'Inter', fontWeight: FontWeight.bold, fontSize: 18));
       getSellEquipmentDetails();
     });
   }

--- a/lib/screens/bazaar/buy/buy_screen.dart
+++ b/lib/screens/bazaar/buy/buy_screen.dart
@@ -16,6 +16,7 @@ import 'package:oqdo_mobile_app/utils/string_manager.dart';
 import 'package:progress_dialog_null_safe/progress_dialog_null_safe.dart';
 import 'package:provider/provider.dart';
 import 'package:oqdo_mobile_app/screens/bazaar/sell/models/equipment_category_response_model.dart' as sell_models;
+import 'package:oqdo_mobile_app/theme/custom_colors.dart';
 
 class BuyScreen extends StatefulWidget {
   const BuyScreen({super.key});
@@ -339,7 +340,10 @@ class _BuyScreenState extends State<BuyScreen> {
   Future<void> addRemoveFromFavorite(EquipmentData equipment) async {
     try {
       _progressDialog = ProgressDialog(context, type: ProgressDialogType.normal, isDismissible: false);
-      _progressDialog.style(message: "Please wait..");
+      _progressDialog.style(
+              message: "Please wait..",
+              backgroundColor: Theme.of(context).extension<CustomColors>()!.progressDialogBackgroundColor,
+              messageTextStyle: TextStyle(color: Theme.of(context).extension<CustomColors>()!.blackAndWhiteColor, fontFamily: 'Inter', fontWeight: FontWeight.bold, fontSize: 18));
       await _progressDialog.show();
 
       await Provider.of<SellViewmodel>(context, listen: false).addRemoveFromFavorite(equipment.equipmentId.toString()).then((value) async {

--- a/lib/screens/bazaar/chats/buying/buying_chat_screen.dart
+++ b/lib/screens/bazaar/chats/buying/buying_chat_screen.dart
@@ -1044,7 +1044,10 @@ class _BuyingChatScreenState extends State<BuyingChatScreen> {
 
   Future<void> deleteChat() async {
     _progressDialog = ProgressDialog(context, type: ProgressDialogType.normal, isDismissible: false);
-    _progressDialog.style(message: "Please wait..");
+    _progressDialog.style(
+            message: "Please wait..",
+            backgroundColor: Theme.of(context).extension<CustomColors>()!.progressDialogBackgroundColor,
+            messageTextStyle: TextStyle(color: Theme.of(context).extension<CustomColors>()!.blackAndWhiteColor, fontFamily: 'Inter', fontWeight: FontWeight.bold, fontSize: 18));
     _progressDialog.show();
     try {
       Map<String, dynamic> request = {};

--- a/lib/screens/bazaar/chats/selling/selling_chat_screen.dart
+++ b/lib/screens/bazaar/chats/selling/selling_chat_screen.dart
@@ -792,7 +792,10 @@ class _SellingChatScreenState extends State<SellingChatScreen> {
 
   Future<void> deleteChat() async {
     _progressDialog = ProgressDialog(context, type: ProgressDialogType.normal, isDismissible: false);
-    _progressDialog.style(message: "Please wait..");
+    _progressDialog.style(
+            message: "Please wait..",
+            backgroundColor: Theme.of(context).extension<CustomColors>()!.progressDialogBackgroundColor,
+            messageTextStyle: TextStyle(color: Theme.of(context).extension<CustomColors>()!.blackAndWhiteColor, fontFamily: 'Inter', fontWeight: FontWeight.bold, fontSize: 18));
     _progressDialog.show();
     try {
       Map<String, dynamic> request = {};

--- a/lib/screens/bazaar/sell/product/create_product_screen.dart
+++ b/lib/screens/bazaar/sell/product/create_product_screen.dart
@@ -23,6 +23,7 @@ import 'package:oqdo_mobile_app/utils/utilities.dart';
 import 'package:permission_handler/permission_handler.dart';
 import 'package:progress_dialog_null_safe/progress_dialog_null_safe.dart';
 import 'package:provider/provider.dart';
+import 'package:oqdo_mobile_app/theme/custom_colors.dart';
 
 class CreateProductScreen extends StatefulWidget {
   const CreateProductScreen({super.key, required this.editViewEquipmentIntentModel});
@@ -74,7 +75,10 @@ class _CreateProductScreenState extends State<CreateProductScreen> {
     super.initState();
     WidgetsBinding.instance.addPostFrameCallback((_) async {
       _progressDialog = ProgressDialog(context, type: ProgressDialogType.normal, isDismissible: false);
-      _progressDialog.style(message: "Please wait..");
+      _progressDialog.style(
+              message: "Please wait..",
+              backgroundColor: Theme.of(context).extension<CustomColors>()!.progressDialogBackgroundColor,
+              messageTextStyle: TextStyle(color: Theme.of(context).extension<CustomColors>()!.blackAndWhiteColor, fontFamily: 'Inter', fontWeight: FontWeight.bold, fontSize: 18));
       getAllEquipmentConditionList();
 
       if (widget.editViewEquipmentIntentModel.isEdit) {

--- a/lib/screens/bazaar/sell/product/edit_sell_product_detail_screen.dart
+++ b/lib/screens/bazaar/sell/product/edit_sell_product_detail_screen.dart
@@ -13,6 +13,7 @@ import 'package:oqdo_mobile_app/utils/network_interceptor.dart';
 import 'package:oqdo_mobile_app/utils/string_manager.dart';
 import 'package:progress_dialog_null_safe/progress_dialog_null_safe.dart';
 import 'package:provider/provider.dart';
+import 'package:oqdo_mobile_app/theme/custom_colors.dart';
 
 class EditSellProductDetailScreen extends StatefulWidget {
   static const routeName = '/edit-sell-equipment-detail';
@@ -38,7 +39,10 @@ class _SellProductDetailScreenState extends State<EditSellProductDetailScreen> {
     super.initState();
     WidgetsBinding.instance.addPostFrameCallback((_) async {
       _progressDialog = ProgressDialog(context, type: ProgressDialogType.normal, isDismissible: false);
-      _progressDialog.style(message: "Please wait..");
+      _progressDialog.style(
+              message: "Please wait..",
+              backgroundColor: Theme.of(context).extension<CustomColors>()!.progressDialogBackgroundColor,
+              messageTextStyle: TextStyle(color: Theme.of(context).extension<CustomColors>()!.blackAndWhiteColor, fontFamily: 'Inter', fontWeight: FontWeight.bold, fontSize: 18));
       getSellEquipmentDetails();
     });
   }

--- a/lib/screens/bazaar/sell/product/sell_product_detail_screen.dart
+++ b/lib/screens/bazaar/sell/product/sell_product_detail_screen.dart
@@ -35,7 +35,10 @@ class _SellProductDetailScreenState extends State<SellProductDetailScreen> {
     super.initState();
     WidgetsBinding.instance.addPostFrameCallback((_) async {
       _progressDialog = ProgressDialog(context, type: ProgressDialogType.normal, isDismissible: false);
-      _progressDialog.style(message: "Please wait..");
+      _progressDialog.style(
+              message: "Please wait..",
+              backgroundColor: Theme.of(context).extension<CustomColors>()!.progressDialogBackgroundColor,
+              messageTextStyle: TextStyle(color: Theme.of(context).extension<CustomColors>()!.blackAndWhiteColor, fontFamily: 'Inter', fontWeight: FontWeight.bold, fontSize: 18));
       if (!widget.editViewEquipmentIntentModel.isEdit) {
         int expiryDays = int.parse(OQDOApplication.instance.configResponseModel!.equipmentDefualtExpiryDays);
         postExpiryDate = DateTime.now().add(Duration(days: expiryDays)).toString();

--- a/lib/screens/bazaar/sell/sell_screen.dart
+++ b/lib/screens/bazaar/sell/sell_screen.dart
@@ -14,6 +14,7 @@ import 'package:oqdo_mobile_app/utils/network_interceptor.dart';
 import 'package:oqdo_mobile_app/utils/string_manager.dart';
 import 'package:progress_dialog_null_safe/progress_dialog_null_safe.dart';
 import 'package:provider/provider.dart';
+import 'package:oqdo_mobile_app/theme/custom_colors.dart';
 
 class SellScreen extends StatefulWidget {
   const SellScreen({super.key});
@@ -41,7 +42,10 @@ class _SellScreenState extends State<SellScreen> {
     WidgetsBinding.instance.addPostFrameCallback((timeStamp) {
       _progressDialog = ProgressDialog(context,
           type: ProgressDialogType.normal, isDismissible: false);
-      _progressDialog.style(message: "Please wait..");
+      _progressDialog.style(
+              message: "Please wait..",
+              backgroundColor: Theme.of(context).extension<CustomColors>()!.progressDialogBackgroundColor,
+              messageTextStyle: TextStyle(color: Theme.of(context).extension<CustomColors>()!.blackAndWhiteColor, fontFamily: 'Inter', fontWeight: FontWeight.bold, fontSize: 18));
       getSellEquipments(isInitial: true);
     });
   }

--- a/lib/screens/buddies/features/buddies/presentaion/buddies_profile.dart
+++ b/lib/screens/buddies/features/buddies/presentaion/buddies_profile.dart
@@ -635,7 +635,10 @@ class _BuddiesProfilePageState extends State<BuddiesProfilePage> {
 
   Future<void> sendFriendRequest(AllBuddiesModel allBuddiesModel) async {
     _progressDialog = ProgressDialog(context, type: ProgressDialogType.normal, isDismissible: false);
-    _progressDialog.style(message: "Please wait..");
+    _progressDialog.style(
+            message: "Please wait..",
+            backgroundColor: Theme.of(context).extension<CustomColors>()!.progressDialogBackgroundColor,
+            messageTextStyle: TextStyle(color: Theme.of(context).extension<CustomColors>()!.blackAndWhiteColor, fontFamily: 'Inter', fontWeight: FontWeight.bold, fontSize: 18));
     try {
       await _progressDialog.show();
       Map<String, dynamic> request = {};
@@ -685,7 +688,10 @@ class _BuddiesProfilePageState extends State<BuddiesProfilePage> {
 
   Future<void> callAcceptReject(String acceptReject, String type) async {
     _progressDialog = ProgressDialog(context, type: ProgressDialogType.normal, isDismissible: false);
-    _progressDialog.style(message: "Please wait..");
+    _progressDialog.style(
+            message: "Please wait..",
+            backgroundColor: Theme.of(context).extension<CustomColors>()!.progressDialogBackgroundColor,
+            messageTextStyle: TextStyle(color: Theme.of(context).extension<CustomColors>()!.blackAndWhiteColor, fontFamily: 'Inter', fontWeight: FontWeight.bold, fontSize: 18));
     try {
       await _progressDialog.show();
       Map<String, dynamic> request = {};
@@ -747,7 +753,10 @@ class _BuddiesProfilePageState extends State<BuddiesProfilePage> {
   Future<void> callCancelRequest(AllBuddiesModel allBuddiesModel, String type) async {
     debugPrint('c');
     _progressDialog = ProgressDialog(context, type: ProgressDialogType.normal, isDismissible: false);
-    _progressDialog.style(message: "Please wait...");
+    _progressDialog.style(
+            message: "Please wait..",
+            backgroundColor: Theme.of(context).extension<CustomColors>()!.progressDialogBackgroundColor,
+            messageTextStyle: TextStyle(color: Theme.of(context).extension<CustomColors>()!.blackAndWhiteColor, fontFamily: 'Inter', fontWeight: FontWeight.bold, fontSize: 18));
     try {
       await _progressDialog.show();
       Map<String, dynamic> request = {};

--- a/lib/screens/buddies/features/buddies/presentaion/buddies_screen.dart
+++ b/lib/screens/buddies/features/buddies/presentaion/buddies_screen.dart
@@ -630,7 +630,10 @@ class _BuddiesScreenState extends State<BuddiesScreen> {
 
   Future<void> sendFriendRequest(AllBuddiesModel allBuddiesModel) async {
     _progressDialog = ProgressDialog(context, type: ProgressDialogType.normal, isDismissible: false);
-    _progressDialog.style(message: "Please wait..");
+    _progressDialog.style(
+            message: "Please wait..",
+            backgroundColor: Theme.of(context).extension<CustomColors>()!.progressDialogBackgroundColor,
+            messageTextStyle: TextStyle(color: Theme.of(context).extension<CustomColors>()!.blackAndWhiteColor, fontFamily: 'Inter', fontWeight: FontWeight.bold, fontSize: 18));
     try {
       await _progressDialog.show();
       Map<String, dynamic> request = {};
@@ -689,7 +692,10 @@ class _BuddiesScreenState extends State<BuddiesScreen> {
 
   Future<void> callAcceptReject(AllBuddiesModel allBuddiesModel) async {
     _progressDialog = ProgressDialog(context, type: ProgressDialogType.normal, isDismissible: false);
-    _progressDialog.style(message: "Please wait..");
+    _progressDialog.style(
+            message: "Please wait..",
+            backgroundColor: Theme.of(context).extension<CustomColors>()!.progressDialogBackgroundColor,
+            messageTextStyle: TextStyle(color: Theme.of(context).extension<CustomColors>()!.blackAndWhiteColor, fontFamily: 'Inter', fontWeight: FontWeight.bold, fontSize: 18));
     try {
       await _progressDialog.show();
       Map<String, dynamic> request = {};

--- a/lib/screens/buddies/features/buddies/presentaion/create_group_screen.dart
+++ b/lib/screens/buddies/features/buddies/presentaion/create_group_screen.dart
@@ -496,7 +496,10 @@ class _CreateGroupScreenState extends State<CreateGroupScreen> {
 
   Future<void> createGroup(Map data) async {
     _progressDialog = ProgressDialog(context, type: ProgressDialogType.normal, isDismissible: false);
-    _progressDialog.style(message: "Please wait...");
+    _progressDialog.style(
+            message: "Please wait..",
+            backgroundColor: Theme.of(context).extension<CustomColors>()!.progressDialogBackgroundColor,
+            messageTextStyle: TextStyle(color: Theme.of(context).extension<CustomColors>()!.blackAndWhiteColor, fontFamily: 'Inter', fontWeight: FontWeight.bold, fontSize: 18));
     try {
       await _progressDialog.show();
       CreateGroupResponse? response = await Provider.of<GetAllBuddiesReposotory>(context, listen: false).createGroup(data);

--- a/lib/screens/buddies/features/buddies/presentaion/group_detail_screen.dart
+++ b/lib/screens/buddies/features/buddies/presentaion/group_detail_screen.dart
@@ -427,7 +427,10 @@ class _GroupDetailScreenState extends State<GroupDetailScreen> {
 
   Future<void> editGroup(Map data) async {
     _progressDialog = ProgressDialog(context, type: ProgressDialogType.normal, isDismissible: false);
-    _progressDialog.style(message: "Please wait...");
+    _progressDialog.style(
+            message: "Please wait..",
+            backgroundColor: Theme.of(context).extension<CustomColors>()!.progressDialogBackgroundColor,
+            messageTextStyle: TextStyle(color: Theme.of(context).extension<CustomColors>()!.blackAndWhiteColor, fontFamily: 'Inter', fontWeight: FontWeight.bold, fontSize: 18));
     try {
       await _progressDialog.show();
       var response = await Provider.of<GetAllBuddiesReposotory>(context, listen: false).editGroup(data);

--- a/lib/screens/buddies/features/buddies/presentaion/group_info_screen.dart
+++ b/lib/screens/buddies/features/buddies/presentaion/group_info_screen.dart
@@ -275,7 +275,10 @@ class _GroupInfoScreenState extends State<GroupInfoScreen> {
 
   Future<void> getGroupInfo() async {
     _progressDialog = ProgressDialog(context, type: ProgressDialogType.normal, isDismissible: false);
-    _progressDialog.style(message: "Please wait...");
+    _progressDialog.style(
+            message: "Please wait..",
+            backgroundColor: Theme.of(context).extension<CustomColors>()!.progressDialogBackgroundColor,
+            messageTextStyle: TextStyle(color: Theme.of(context).extension<CustomColors>()!.blackAndWhiteColor, fontFamily: 'Inter', fontWeight: FontWeight.bold, fontSize: 18));
     _progressDialog.show();
 
     try {

--- a/lib/screens/buddies/features/buddies/presentaion/my_friends_screen.dart
+++ b/lib/screens/buddies/features/buddies/presentaion/my_friends_screen.dart
@@ -523,7 +523,10 @@ class _MyFriendsScreenState extends State<MyFriendsScreen> {
 
   Future<void> callCancelRequest(AllBuddiesModel friendsList, int index) async {
     _progressDialog = ProgressDialog(context, type: ProgressDialogType.normal, isDismissible: false);
-    _progressDialog.style(message: "Please wait...");
+    _progressDialog.style(
+            message: "Please wait..",
+            backgroundColor: Theme.of(context).extension<CustomColors>()!.progressDialogBackgroundColor,
+            messageTextStyle: TextStyle(color: Theme.of(context).extension<CustomColors>()!.blackAndWhiteColor, fontFamily: 'Inter', fontWeight: FontWeight.bold, fontSize: 18));
     try {
       await _progressDialog.show();
       Map<String, dynamic> request = {};
@@ -609,7 +612,10 @@ class _MyFriendsScreenState extends State<MyFriendsScreen> {
 
   Future<void> callAcceptReject(String acceptReject, AllBuddiesModel allBuddiesModel, int index) async {
     _progressDialog = ProgressDialog(context, type: ProgressDialogType.normal, isDismissible: false);
-    _progressDialog.style(message: "Please wait...");
+    _progressDialog.style(
+            message: "Please wait..",
+            backgroundColor: Theme.of(context).extension<CustomColors>()!.progressDialogBackgroundColor,
+            messageTextStyle: TextStyle(color: Theme.of(context).extension<CustomColors>()!.blackAndWhiteColor, fontFamily: 'Inter', fontWeight: FontWeight.bold, fontSize: 18));
     try {
       await _progressDialog.show();
       Map<String, dynamic> request = {};

--- a/lib/screens/buddies/features/meetups/presentation/add_meetup_screen.dart
+++ b/lib/screens/buddies/features/meetups/presentation/add_meetup_screen.dart
@@ -646,7 +646,10 @@ class _AddMeetupScreenState extends State<AddMeetupScreen> {
 
   Future<void> getFriendList() async {
     _progressDialog = ProgressDialog(context, type: ProgressDialogType.normal, isDismissible: false);
-    _progressDialog.style(message: "Please wait..");
+    _progressDialog.style(
+            message: "Please wait..",
+            backgroundColor: Theme.of(context).extension<CustomColors>()!.progressDialogBackgroundColor,
+            messageTextStyle: TextStyle(color: Theme.of(context).extension<CustomColors>()!.blackAndWhiteColor, fontFamily: 'Inter', fontWeight: FontWeight.bold, fontSize: 18));
     try {
       await _progressDialog.show();
       var response = await Provider.of<MeetupRepository>(context, listen: false).getFriendList();
@@ -692,7 +695,10 @@ class _AddMeetupScreenState extends State<AddMeetupScreen> {
 
   Future<void> addMeetup() async {
     _progressDialog = ProgressDialog(context, type: ProgressDialogType.normal, isDismissible: false);
-    _progressDialog.style(message: "Please wait..");
+    _progressDialog.style(
+            message: "Please wait..",
+            backgroundColor: Theme.of(context).extension<CustomColors>()!.progressDialogBackgroundColor,
+            messageTextStyle: TextStyle(color: Theme.of(context).extension<CustomColors>()!.blackAndWhiteColor, fontFamily: 'Inter', fontWeight: FontWeight.bold, fontSize: 18));
     try {
       await _progressDialog.show();
       Map<String, dynamic> request = {};

--- a/lib/screens/buddies/features/meetups/presentation/meetup_details_screen.dart
+++ b/lib/screens/buddies/features/meetups/presentation/meetup_details_screen.dart
@@ -560,7 +560,10 @@ class _MeetupDetailsScreenState extends State<MeetupDetailsScreen> {
 
   Future<void> acceptRejectMeetup(String type, String remarks) async {
     _progressDialog = ProgressDialog(context, type: ProgressDialogType.normal, isDismissible: false);
-    _progressDialog.style(message: "Please wait..");
+    _progressDialog.style(
+            message: "Please wait..",
+            backgroundColor: Theme.of(context).extension<CustomColors>()!.progressDialogBackgroundColor,
+            messageTextStyle: TextStyle(color: Theme.of(context).extension<CustomColors>()!.blackAndWhiteColor, fontFamily: 'Inter', fontWeight: FontWeight.bold, fontSize: 18));
     try {
       await _progressDialog.show();
       Map<String, dynamic> request = {};
@@ -611,7 +614,10 @@ class _MeetupDetailsScreenState extends State<MeetupDetailsScreen> {
 
   Future<void> deleteMeetup(String remarks) async {
     _progressDialog = ProgressDialog(context, type: ProgressDialogType.normal, isDismissible: false);
-    _progressDialog.style(message: "Please wait..");
+    _progressDialog.style(
+            message: "Please wait..",
+            backgroundColor: Theme.of(context).extension<CustomColors>()!.progressDialogBackgroundColor,
+            messageTextStyle: TextStyle(color: Theme.of(context).extension<CustomColors>()!.blackAndWhiteColor, fontFamily: 'Inter', fontWeight: FontWeight.bold, fontSize: 18));
     try {
       await _progressDialog.show();
       Map<String, dynamic> request = {};

--- a/lib/screens/cancellation request/coach_cancellation_request_page.dart
+++ b/lib/screens/cancellation request/coach_cancellation_request_page.dart
@@ -48,7 +48,10 @@ class _CoachCancellationRequestPageState extends State<CoachCancellationRequestP
     super.initState();
     WidgetsBinding.instance.addPostFrameCallback((_) async {
       _progressDialog = ProgressDialog(context, type: ProgressDialogType.normal, isDismissible: false);
-      _progressDialog.style(message: "Please wait..");
+      _progressDialog.style(
+              message: "Please wait..",
+              backgroundColor: Theme.of(context).extension<CustomColors>()!.progressDialogBackgroundColor,
+              messageTextStyle: TextStyle(color: Theme.of(context).extension<CustomColors>()!.blackAndWhiteColor, fontFamily: 'Inter', fontWeight: FontWeight.bold, fontSize: 18));
       getTransaction(OQDOApplication.instance.coachID!, false);
       _scrollController.addListener(() {
         if (_scrollController.position.pixels == _scrollController.position.maxScrollExtent) {

--- a/lib/screens/cancellation request/facility_cancellation_request_page.dart
+++ b/lib/screens/cancellation request/facility_cancellation_request_page.dart
@@ -48,7 +48,10 @@ class _FacilityCancellationRequestPageState extends State<FacilityCancellationRe
     super.initState();
     WidgetsBinding.instance.addPostFrameCallback((_) async {
       _progressDialog = ProgressDialog(context, type: ProgressDialogType.normal, isDismissible: false);
-      _progressDialog.style(message: "Please wait..");
+      _progressDialog.style(
+              message: "Please wait..",
+              backgroundColor: Theme.of(context).extension<CustomColors>()!.progressDialogBackgroundColor,
+              messageTextStyle: TextStyle(color: Theme.of(context).extension<CustomColors>()!.blackAndWhiteColor, fontFamily: 'Inter', fontWeight: FontWeight.bold, fontSize: 18));
       getTransaction(OQDOApplication.instance.facilityID!, false);
       _scrollController.addListener(() {
         if (_scrollController.position.pixels == _scrollController.position.maxScrollExtent) {

--- a/lib/screens/coach/coach_list_page.dart
+++ b/lib/screens/coach/coach_list_page.dart
@@ -644,7 +644,10 @@ class _CoachListPageState extends State<CoachListPage> {
   Future<void> addRemoveFromFavorite(Data coachesModel) async {
     try {
       _progressDialog = ProgressDialog(context, type: ProgressDialogType.normal, isDismissible: false);
-      _progressDialog.style(message: "Please wait..");
+      _progressDialog.style(
+              message: "Please wait..",
+              backgroundColor: Theme.of(context).extension<CustomColors>()!.progressDialogBackgroundColor,
+              messageTextStyle: TextStyle(color: Theme.of(context).extension<CustomColors>()!.blackAndWhiteColor, fontFamily: 'Inter', fontWeight: FontWeight.bold, fontSize: 18));
       await _progressDialog.show();
 
       Map<String, dynamic> request = {"SetupId": coachesModel.coachBatchSetupId.toString(), "Flag": 'C'};
@@ -716,7 +719,10 @@ class _CoachListPageState extends State<CoachListPage> {
   Future<void> getCoachDetailsById(int coachBatchId) async {
     try {
       _progressDialog = ProgressDialog(context, type: ProgressDialogType.normal, isDismissible: false);
-      _progressDialog.style(message: "Please wait..");
+      _progressDialog.style(
+              message: "Please wait..",
+              backgroundColor: Theme.of(context).extension<CustomColors>()!.progressDialogBackgroundColor,
+              messageTextStyle: TextStyle(color: Theme.of(context).extension<CustomColors>()!.blackAndWhiteColor, fontFamily: 'Inter', fontWeight: FontWeight.bold, fontSize: 18));
       await _progressDialog.show();
       await Provider.of<BookingViewModel>(context, listen: false).getCoachDetailsById(coachBatchId).then((value) async {
         Response res = value;

--- a/lib/screens/dashboard/dashboard_page.dart
+++ b/lib/screens/dashboard/dashboard_page.dart
@@ -118,7 +118,10 @@ class DashboardPagesState extends State<DashboardPages> with SingleTickerProvide
       coachProfileResponseModel = CoachProfileResponseModel();
       PackageInfo packageInfo = await PackageInfo.fromPlatform();
       _progressDialog = ProgressDialog(context, type: ProgressDialogType.normal, isDismissible: false);
-      _progressDialog.style(message: "Please wait..");
+      _progressDialog.style(
+              message: "Please wait..",
+              backgroundColor: Theme.of(context).extension<CustomColors>()!.progressDialogBackgroundColor,
+              messageTextStyle: TextStyle(color: Theme.of(context).extension<CustomColors>()!.blackAndWhiteColor, fontFamily: 'Inter', fontWeight: FontWeight.bold, fontSize: 18));
       getNotificationData();
     });
     getData();

--- a/lib/screens/favorites/coach_favorites_list_page.dart
+++ b/lib/screens/favorites/coach_favorites_list_page.dart
@@ -465,7 +465,10 @@ class _CoachFavoritesListPageState extends State<CoachFavoritesListPage> {
   Future<void> getCoachDetailsById(int coachBatchId) async {
     try {
       _progressDialog = ProgressDialog(context, type: ProgressDialogType.normal, isDismissible: false);
-      _progressDialog.style(message: "Please wait..");
+      _progressDialog.style(
+              message: "Please wait..",
+              backgroundColor: Theme.of(context).extension<CustomColors>()!.progressDialogBackgroundColor,
+              messageTextStyle: TextStyle(color: Theme.of(context).extension<CustomColors>()!.blackAndWhiteColor, fontFamily: 'Inter', fontWeight: FontWeight.bold, fontSize: 18));
       await _progressDialog.show();
       await Provider.of<BookingViewModel>(context, listen: false).getCoachDetailsById(coachBatchId).then((value) async {
         Response res = value;
@@ -529,7 +532,10 @@ class _CoachFavoritesListPageState extends State<CoachFavoritesListPage> {
   Future<void> addRemoveFromFavorite(CoachBatchData coachesModel) async {
     try {
       _progressDialog = ProgressDialog(context, type: ProgressDialogType.normal, isDismissible: false);
-      _progressDialog.style(message: "Please wait..");
+      _progressDialog.style(
+              message: "Please wait..",
+              backgroundColor: Theme.of(context).extension<CustomColors>()!.progressDialogBackgroundColor,
+              messageTextStyle: TextStyle(color: Theme.of(context).extension<CustomColors>()!.blackAndWhiteColor, fontFamily: 'Inter', fontWeight: FontWeight.bold, fontSize: 18));
       await _progressDialog.show();
 
       Map<String, dynamic> request = {"SetupId": coachesModel.coachBatchSetupId.toString(), "Flag": 'C'};

--- a/lib/screens/forgot_password/create_password_page.dart
+++ b/lib/screens/forgot_password/create_password_page.dart
@@ -20,6 +20,7 @@ import 'package:progress_dialog_null_safe/progress_dialog_null_safe.dart';
 import 'package:provider/provider.dart';
 
 import '../../helper/helpers.dart';
+import 'package:oqdo_mobile_app/theme/custom_colors.dart';
 
 class CreatePasswordPage extends StatefulWidget {
   CreatePasswordPage({super.key, required this.userDetails});
@@ -55,7 +56,10 @@ class CreatePasswordPageState extends State<CreatePasswordPage> {
     hp = Helper.of(context);
     WidgetsBinding.instance.addPostFrameCallback((_) async {
       _progressDialog = ProgressDialog(context, type: ProgressDialogType.normal, isDismissible: false);
-      _progressDialog.style(message: "Please wait..");
+      _progressDialog.style(
+              message: "Please wait..",
+              backgroundColor: Theme.of(context).extension<CustomColors>()!.progressDialogBackgroundColor,
+              messageTextStyle: TextStyle(color: Theme.of(context).extension<CustomColors>()!.blackAndWhiteColor, fontFamily: 'Inter', fontWeight: FontWeight.bold, fontSize: 18));
     });
   }
 

--- a/lib/screens/forgot_password/forgot_otp_verification_page.dart
+++ b/lib/screens/forgot_password/forgot_otp_verification_page.dart
@@ -16,6 +16,7 @@ import 'package:oqdo_mobile_app/viewmodels/login_view_model.dart';
 import 'package:pin_code_text_field/pin_code_text_field.dart';
 import 'package:progress_dialog_null_safe/progress_dialog_null_safe.dart';
 import 'package:provider/provider.dart';
+import 'package:oqdo_mobile_app/theme/custom_colors.dart';
 
 class ForgotOTPVerificationPage extends StatefulWidget {
   ForgotOTPVerificationPage({super.key, required this.email});
@@ -47,7 +48,10 @@ class ForgotOTPVerificationPageState extends State<ForgotOTPVerificationPage> {
     WidgetsBinding.instance.addPostFrameCallback((_) async {
       _progressDialog = ProgressDialog(context,
           type: ProgressDialogType.normal, isDismissible: false);
-      _progressDialog.style(message: "Please wait..");
+      _progressDialog.style(
+              message: "Please wait..",
+              backgroundColor: Theme.of(context).extension<CustomColors>()!.progressDialogBackgroundColor,
+              messageTextStyle: TextStyle(color: Theme.of(context).extension<CustomColors>()!.blackAndWhiteColor, fontFamily: 'Inter', fontWeight: FontWeight.bold, fontSize: 18));
     });
   }
 

--- a/lib/screens/forgot_password/forgot_password_page.dart
+++ b/lib/screens/forgot_password/forgot_password_page.dart
@@ -18,6 +18,7 @@ import 'package:oqdo_mobile_app/utils/validator.dart';
 import 'package:oqdo_mobile_app/viewmodels/login_view_model.dart';
 import 'package:progress_dialog_null_safe/progress_dialog_null_safe.dart';
 import 'package:provider/provider.dart';
+import 'package:oqdo_mobile_app/theme/custom_colors.dart';
 
 class ForgotPasswordPage extends StatefulWidget {
   const ForgotPasswordPage({super.key});
@@ -46,7 +47,10 @@ class ForgotPasswordPageState extends State<ForgotPasswordPage> {
     super.initState();
     WidgetsBinding.instance.addPostFrameCallback((_) async {
       _progressDialog = ProgressDialog(context, type: ProgressDialogType.normal, isDismissible: false);
-      _progressDialog.style(message: "Please wait..");
+      _progressDialog.style(
+              message: "Please wait..",
+              backgroundColor: Theme.of(context).extension<CustomColors>()!.progressDialogBackgroundColor,
+              messageTextStyle: TextStyle(color: Theme.of(context).extension<CustomColors>()!.blackAndWhiteColor, fontFamily: 'Inter', fontWeight: FontWeight.bold, fontSize: 18));
     });
   }
 

--- a/lib/screens/home/change_password_page.dart
+++ b/lib/screens/home/change_password_page.dart
@@ -21,6 +21,7 @@ import 'package:progress_dialog_null_safe/progress_dialog_null_safe.dart';
 import 'package:provider/provider.dart';
 
 import '../../helper/helpers.dart';
+import 'package:oqdo_mobile_app/theme/custom_colors.dart';
 
 class ChangePasswordPage extends StatefulWidget {
   const ChangePasswordPage({Key? key}) : super(key: key);
@@ -57,7 +58,10 @@ class _ChangePasswordPageState extends State<ChangePasswordPage> {
     hp = Helper.of(context);
     WidgetsBinding.instance.addPostFrameCallback((_) async {
       _progressDialog = ProgressDialog(context, type: ProgressDialogType.normal, isDismissible: false);
-      _progressDialog.style(message: "Please wait...");
+      _progressDialog.style(
+              message: "Please wait..",
+              backgroundColor: Theme.of(context).extension<CustomColors>()!.progressDialogBackgroundColor,
+              messageTextStyle: TextStyle(color: Theme.of(context).extension<CustomColors>()!.blackAndWhiteColor, fontFamily: 'Inter', fontWeight: FontWeight.bold, fontSize: 18));
     });
   }
 

--- a/lib/screens/home/end_user_calendar_screen.dart
+++ b/lib/screens/home/end_user_calendar_screen.dart
@@ -344,9 +344,9 @@ class _EndUserCalendarViewScreenState extends State<EndUserCalendarViewScreen> {
   Future<void> getEndUserAppointments(DateTime passingDate) async {
     _progressDialog = ProgressDialog(context, type: ProgressDialogType.normal, isDismissible: false);
     _progressDialog.style(
-        message: "Please wait..",
-        backgroundColor: Theme.of(context).extension<CustomColors>()!.progressDialogBackgroundColor,
-        messageTextStyle: TextStyle(color: Theme.of(context).extension<CustomColors>()!.blackAndWhiteColor, fontFamily: 'Inter', fontWeight: FontWeight.bold, fontSize: 18));
+            message: "Please wait..",
+            backgroundColor: Theme.of(context).extension<CustomColors>()!.progressDialogBackgroundColor,
+            messageTextStyle: TextStyle(color: Theme.of(context).extension<CustomColors>()!.blackAndWhiteColor, fontFamily: 'Inter', fontWeight: FontWeight.bold, fontSize: 18));
     try {
       await _progressDialog.show();
       List<EndUserAppointmentsResponseModel> endUserAppointmentList = await Provider.of<AppointmentViewModel>(context, listen: false)

--- a/lib/screens/home/notifications_page.dart
+++ b/lib/screens/home/notifications_page.dart
@@ -485,7 +485,10 @@ class _NotificationsPageState extends State<NotificationsPage> {
       String notificationId, int index) async {
     _progressDialog = ProgressDialog(context,
         type: ProgressDialogType.normal, isDismissible: false);
-    _progressDialog.style(message: "Please wait..");
+    _progressDialog.style(
+            message: "Please wait..",
+            backgroundColor: Theme.of(context).extension<CustomColors>()!.progressDialogBackgroundColor,
+            messageTextStyle: TextStyle(color: Theme.of(context).extension<CustomColors>()!.blackAndWhiteColor, fontFamily: 'Inter', fontWeight: FontWeight.bold, fontSize: 18));
 
     try {
       await _progressDialog.show();
@@ -554,7 +557,10 @@ class _NotificationsPageState extends State<NotificationsPage> {
   Future<void> deleteAllNotification() async {
     _progressDialog = ProgressDialog(context,
         type: ProgressDialogType.normal, isDismissible: false);
-    _progressDialog.style(message: "Please wait..");
+    _progressDialog.style(
+            message: "Please wait..",
+            backgroundColor: Theme.of(context).extension<CustomColors>()!.progressDialogBackgroundColor,
+            messageTextStyle: TextStyle(color: Theme.of(context).extension<CustomColors>()!.blackAndWhiteColor, fontFamily: 'Inter', fontWeight: FontWeight.bold, fontSize: 18));
 
     try {
       await _progressDialog.show();

--- a/lib/screens/home/service_provider_calendar_screen.dart
+++ b/lib/screens/home/service_provider_calendar_screen.dart
@@ -14,6 +14,7 @@ import 'package:oqdo_mobile_app/viewmodels/appointment_view_model.dart';
 import 'package:progress_dialog_null_safe/progress_dialog_null_safe.dart';
 import 'package:provider/provider.dart';
 import 'package:table_calendar/table_calendar.dart';
+import 'package:oqdo_mobile_app/theme/custom_colors.dart';
 
 class ServiceProviderCalendarScreen extends StatefulWidget {
   const ServiceProviderCalendarScreen({Key? key}) : super(key: key);
@@ -242,7 +243,10 @@ class _ServiceProviderCalendarScreenState extends State<ServiceProviderCalendarS
 
   Future<void> getFacilityAppointments(DateTime passingDate) async {
     _progressDialog = ProgressDialog(context, type: ProgressDialogType.normal, isDismissible: false);
-    _progressDialog.style(message: "Please wait..");
+    _progressDialog.style(
+            message: "Please wait..",
+            backgroundColor: Theme.of(context).extension<CustomColors>()!.progressDialogBackgroundColor,
+            messageTextStyle: TextStyle(color: Theme.of(context).extension<CustomColors>()!.blackAndWhiteColor, fontFamily: 'Inter', fontWeight: FontWeight.bold, fontSize: 18));
     try {
       await _progressDialog.show();
       List<FacilityAppointmentsResponseModel> endUserAppointmentList = await Provider.of<AppointmentViewModel>(context, listen: false)
@@ -295,7 +299,10 @@ class _ServiceProviderCalendarScreenState extends State<ServiceProviderCalendarS
 
   Future<void> getCoachAppointments(DateTime passingDate) async {
     _progressDialog = ProgressDialog(context, type: ProgressDialogType.normal, isDismissible: false);
-    _progressDialog.style(message: "Please wait..");
+    _progressDialog.style(
+            message: "Please wait..",
+            backgroundColor: Theme.of(context).extension<CustomColors>()!.progressDialogBackgroundColor,
+            messageTextStyle: TextStyle(color: Theme.of(context).extension<CustomColors>()!.blackAndWhiteColor, fontFamily: 'Inter', fontWeight: FontWeight.bold, fontSize: 18));
     try {
       await _progressDialog.show();
       List<CoachAppointmentsResponseModel> endUserAppointmentList = await Provider.of<AppointmentViewModel>(context, listen: false)

--- a/lib/screens/login/login_page.dart
+++ b/lib/screens/login/login_page.dart
@@ -59,9 +59,9 @@ class _LoginPageState extends State<LoginPage> {
         isDismissible: false,
       );
       _progressDialog.style(
-        message: "Please wait..",
-        backgroundColor: Theme.of(context).extension<CustomColors>()!.progressDialogBackgroundColor,
-      );
+              message: "Please wait..",
+              backgroundColor: Theme.of(context).extension<CustomColors>()!.progressDialogBackgroundColor,
+              messageTextStyle: TextStyle(color: Theme.of(context).extension<CustomColors>()!.blackAndWhiteColor, fontFamily: 'Inter', fontWeight: FontWeight.bold, fontSize: 18));
     });
     getToken();
   }

--- a/lib/screens/profile/coach_profile.dart
+++ b/lib/screens/profile/coach_profile.dart
@@ -158,7 +158,10 @@ class CoachProfilePageState extends State<CoachProfilePage> {
     maxAllowedCancellationTime = convertMinutesToDuration(maxCancellationMin);
     WidgetsBinding.instance.addPostFrameCallback((_) async {
       _progressDialog = ProgressDialog(context, type: ProgressDialogType.normal, isDismissible: false);
-      _progressDialog.style(message: "Please wait...");
+      _progressDialog.style(
+              message: "Please wait..",
+              backgroundColor: Theme.of(context).extension<CustomColors>()!.progressDialogBackgroundColor,
+              messageTextStyle: TextStyle(color: Theme.of(context).extension<CustomColors>()!.blackAndWhiteColor, fontFamily: 'Inter', fontWeight: FontWeight.bold, fontSize: 18));
       cityId = OQDOApplication.instance.storage.getStringValue(AppStrings.selectedCountryID);
       // debugPrint('CityId ->' + cityId.toString());
       getCoachDetails();
@@ -3030,7 +3033,10 @@ class CoachProfilePageState extends State<CoachProfilePage> {
 
   Future<void> deleteTrainingAddressCall(CoachTrainingAddress model) async {
     _progressDialog = ProgressDialog(context, type: ProgressDialogType.normal, isDismissible: false);
-    _progressDialog.style(message: "Please wait..");
+    _progressDialog.style(
+            message: "Please wait..",
+            backgroundColor: Theme.of(context).extension<CustomColors>()!.progressDialogBackgroundColor,
+            messageTextStyle: TextStyle(color: Theme.of(context).extension<CustomColors>()!.blackAndWhiteColor, fontFamily: 'Inter', fontWeight: FontWeight.bold, fontSize: 18));
 
     try {
       await _progressDialog.show();

--- a/lib/screens/profile/facility_profile.dart
+++ b/lib/screens/profile/facility_profile.dart
@@ -152,7 +152,10 @@ class FacilityProfilePageState extends State<FacilityProfilePage> {
     maxAllowedCancellationTime = convertMinutesToDuration(maxCancellationMin);
     WidgetsBinding.instance.addPostFrameCallback((_) async {
       _progressDialog = ProgressDialog(context, type: ProgressDialogType.normal, isDismissible: false);
-      _progressDialog.style(message: "Please wait..");
+      _progressDialog.style(
+              message: "Please wait..",
+              backgroundColor: Theme.of(context).extension<CustomColors>()!.progressDialogBackgroundColor,
+              messageTextStyle: TextStyle(color: Theme.of(context).extension<CustomColors>()!.blackAndWhiteColor, fontFamily: 'Inter', fontWeight: FontWeight.bold, fontSize: 18));
       getFacilityProviderProfile();
       // mobileNoLengthStr = OQDOApplication.instance.storage.getStringValue(AppStrings.mobileNoLength);
       // mobileNoLength = int.parse(mobileNoLengthStr!);

--- a/lib/screens/register/register_page.dart
+++ b/lib/screens/register/register_page.dart
@@ -35,6 +35,7 @@ import 'package:provider/provider.dart';
 import '../../helper/helpers.dart';
 import '../../oqdo_application.dart';
 import '../../utils/validator.dart';
+import 'package:oqdo_mobile_app/theme/custom_colors.dart';
 
 class RegisterPage extends StatefulWidget {
   const RegisterPage({super.key});
@@ -114,7 +115,10 @@ class RegisterPageState extends State<RegisterPage> {
     hp = Helper.of(context);
     WidgetsBinding.instance.addPostFrameCallback((_) async {
       _progressDialog = ProgressDialog(context, type: ProgressDialogType.normal, isDismissible: false);
-      _progressDialog.style(message: "Please wait..");
+      _progressDialog.style(
+              message: "Please wait..",
+              backgroundColor: Theme.of(context).extension<CustomColors>()!.progressDialogBackgroundColor,
+              messageTextStyle: TextStyle(color: Theme.of(context).extension<CustomColors>()!.blackAndWhiteColor, fontFamily: 'Inter', fontWeight: FontWeight.bold, fontSize: 18));
       // getAllCity();
       getShredPrefValues();
       getAllActivity();

--- a/lib/screens/service_provider/coach/coach_add_page.dart
+++ b/lib/screens/service_provider/coach/coach_add_page.dart
@@ -25,6 +25,7 @@ import '../../../theme/oqdo_theme_data.dart';
 import '../../../utils/string_manager.dart';
 import '../../../utils/validator.dart';
 import '../../../viewmodels/end_user_resgistration_view_model.dart';
+import 'package:oqdo_mobile_app/theme/custom_colors.dart';
 
 class CoachAddPage extends StatefulWidget {
   const CoachAddPage({Key? key}) : super(key: key);
@@ -78,7 +79,10 @@ class CoachAddPageState extends State<CoachAddPage> {
     hp = Helper.of(context);
     WidgetsBinding.instance.addPostFrameCallback((_) async {
       _progressDialog = ProgressDialog(context, type: ProgressDialogType.normal, isDismissible: false);
-      _progressDialog.style(message: "Please wait..");
+      _progressDialog.style(
+              message: "Please wait..",
+              backgroundColor: Theme.of(context).extension<CustomColors>()!.progressDialogBackgroundColor,
+              messageTextStyle: TextStyle(color: Theme.of(context).extension<CustomColors>()!.blackAndWhiteColor, fontFamily: 'Inter', fontWeight: FontWeight.bold, fontSize: 18));
       // getAllCity();
       getPrefValue();
     });

--- a/lib/screens/service_provider/coach/coach_add_page_one.dart
+++ b/lib/screens/service_provider/coach/coach_add_page_one.dart
@@ -30,6 +30,7 @@ import '../../../theme/oqdo_theme_data.dart';
 import '../../../utils/string_manager.dart';
 import '../../../utils/validator.dart';
 import '../../../viewmodels/end_user_resgistration_view_model.dart';
+import 'package:oqdo_mobile_app/theme/custom_colors.dart';
 
 class CoachAddPageOne extends StatefulWidget {
   final CommonPassingArgs commonPassingArgs;
@@ -78,7 +79,10 @@ class CoachAddPageOneState extends State<CoachAddPageOne> {
     hp = Helper.of(context);
     WidgetsBinding.instance.addPostFrameCallback((_) async {
       _progressDialog = ProgressDialog(context, type: ProgressDialogType.normal, isDismissible: false);
-      _progressDialog.style(message: "Please wait..");
+      _progressDialog.style(
+              message: "Please wait..",
+              backgroundColor: Theme.of(context).extension<CustomColors>()!.progressDialogBackgroundColor,
+              messageTextStyle: TextStyle(color: Theme.of(context).extension<CustomColors>()!.blackAndWhiteColor, fontFamily: 'Inter', fontWeight: FontWeight.bold, fontSize: 18));
       // getAllCity();
       getPrefValue();
     });
@@ -637,7 +641,10 @@ class CoachAddPageOneState extends State<CoachAddPageOne> {
           showSnackBar('4 digit IC Number is required', context);
         } else {
           _progressDialog = ProgressDialog(context, type: ProgressDialogType.normal, isDismissible: false);
-          _progressDialog.style(message: "Please wait..");
+          _progressDialog.style(
+                  message: "Please wait..",
+                  backgroundColor: Theme.of(context).extension<CustomColors>()!.progressDialogBackgroundColor,
+                  messageTextStyle: TextStyle(color: Theme.of(context).extension<CustomColors>()!.blackAndWhiteColor, fontFamily: 'Inter', fontWeight: FontWeight.bold, fontSize: 18));
           // final bytes = File(croppedFile!.path).readAsBytesSync();
           // String convertedBytes = base64Encode(bytes);
           // debugPrint(convertedBytes);

--- a/lib/screens/service_provider/coach/coach_add_page_two.dart
+++ b/lib/screens/service_provider/coach/coach_add_page_two.dart
@@ -31,6 +31,7 @@ import '../../../oqdo_application.dart';
 import '../../../theme/oqdo_theme_data.dart';
 import '../../../utils/string_manager.dart';
 import '../../../viewmodels/end_user_resgistration_view_model.dart';
+import 'package:oqdo_mobile_app/theme/custom_colors.dart';
 
 class CoachAddPageTwo extends StatefulWidget {
   final CommonPassingArgs commonPassingArgs;
@@ -103,7 +104,10 @@ class CoachAddPageTwoState extends State<CoachAddPageTwo> {
     comment.add(TextEditingController());
     WidgetsBinding.instance.addPostFrameCallback((_) async {
       _progressDialog = ProgressDialog(context, type: ProgressDialogType.normal, isDismissible: false);
-      _progressDialog.style(message: "Please wait...");
+      _progressDialog.style(
+              message: "Please wait..",
+              backgroundColor: Theme.of(context).extension<CustomColors>()!.progressDialogBackgroundColor,
+              messageTextStyle: TextStyle(color: Theme.of(context).extension<CustomColors>()!.blackAndWhiteColor, fontFamily: 'Inter', fontWeight: FontWeight.bold, fontSize: 18));
       getAllActivity();
       getPrefData();
       _focusNode.addListener(_onFocusChange);

--- a/lib/screens/service_provider/coach/coach_otp_page.dart
+++ b/lib/screens/service_provider/coach/coach_otp_page.dart
@@ -19,6 +19,7 @@ import '../../../helper/helpers.dart';
 import '../../../model/common_passing_args.dart';
 import '../../../theme/oqdo_theme_data.dart';
 import '../../../viewmodels/end_user_resgistration_view_model.dart';
+import 'package:oqdo_mobile_app/theme/custom_colors.dart';
 
 class CoachOTPPage extends StatefulWidget {
   final CommonPassingArgs commonPassingArgs;
@@ -52,7 +53,10 @@ class _CoachOTPPageState extends State<CoachOTPPage> {
     hp = Helper.of(context);
     WidgetsBinding.instance.addPostFrameCallback((_) async {
       _progressDialog = ProgressDialog(context, type: ProgressDialogType.normal, isDismissible: false);
-      _progressDialog.style(message: "Please wait..");
+      _progressDialog.style(
+              message: "Please wait..",
+              backgroundColor: Theme.of(context).extension<CustomColors>()!.progressDialogBackgroundColor,
+              messageTextStyle: TextStyle(color: Theme.of(context).extension<CustomColors>()!.blackAndWhiteColor, fontFamily: 'Inter', fontWeight: FontWeight.bold, fontSize: 18));
       // print("Coach OTP Screen");
     });
   }

--- a/lib/screens/service_provider/facility/facility_add_page.dart
+++ b/lib/screens/service_provider/facility/facility_add_page.dart
@@ -24,6 +24,7 @@ import '../../../request_models/end_user_registration_temp_req_model.dart';
 import '../../../utils/string_manager.dart';
 import '../../../utils/validator.dart';
 import '../../../viewmodels/end_user_resgistration_view_model.dart';
+import 'package:oqdo_mobile_app/theme/custom_colors.dart';
 
 class FacilityAddPage extends StatefulWidget {
   const FacilityAddPage({super.key});
@@ -75,7 +76,10 @@ class FacilityAddPageState extends State<FacilityAddPage> {
     hp = Helper.of(context);
     WidgetsBinding.instance.addPostFrameCallback((_) async {
       _progressDialog = ProgressDialog(context, type: ProgressDialogType.normal, isDismissible: false);
-      _progressDialog.style(message: "Please wait..");
+      _progressDialog.style(
+              message: "Please wait..",
+              backgroundColor: Theme.of(context).extension<CustomColors>()!.progressDialogBackgroundColor,
+              messageTextStyle: TextStyle(color: Theme.of(context).extension<CustomColors>()!.blackAndWhiteColor, fontFamily: 'Inter', fontWeight: FontWeight.bold, fontSize: 18));
       // getAllCity();
       getShredPrefValues();
     });

--- a/lib/screens/service_provider/facility/facility_add_page_one.dart
+++ b/lib/screens/service_provider/facility/facility_add_page_one.dart
@@ -29,6 +29,7 @@ import '../../../oqdo_application.dart';
 import '../../../utils/string_manager.dart';
 import '../../../utils/validator.dart';
 import '../../../viewmodels/end_user_resgistration_view_model.dart';
+import 'package:oqdo_mobile_app/theme/custom_colors.dart';
 
 class FacilityAddPageOne extends StatefulWidget {
   final CommonPassingArgs commonPassingArgs;
@@ -88,7 +89,10 @@ class _FacilityAddPageOneState extends State<FacilityAddPageOne> {
     mobile.add(TextEditingController());
     WidgetsBinding.instance.addPostFrameCallback((_) async {
       _progressDialog = ProgressDialog(context, type: ProgressDialogType.normal, isDismissible: false);
-      _progressDialog.style(message: "Please wait..");
+      _progressDialog.style(
+              message: "Please wait..",
+              backgroundColor: Theme.of(context).extension<CustomColors>()!.progressDialogBackgroundColor,
+              messageTextStyle: TextStyle(color: Theme.of(context).extension<CustomColors>()!.blackAndWhiteColor, fontFamily: 'Inter', fontWeight: FontWeight.bold, fontSize: 18));
       // getAllCity();
       // facilityName.text = _commonPassingArgs.facilityName!;
       getShredPrefValues();
@@ -873,7 +877,10 @@ class _FacilityAddPageOneState extends State<FacilityAddPageOne> {
         showSnackBar('6 digit postal code is required', context);
       } else {
         _progressDialog = ProgressDialog(context, type: ProgressDialogType.normal, isDismissible: false);
-        _progressDialog.style(message: "Please wait..");
+        _progressDialog.style(
+                message: "Please wait..",
+                backgroundColor: Theme.of(context).extension<CustomColors>()!.progressDialogBackgroundColor,
+                messageTextStyle: TextStyle(color: Theme.of(context).extension<CustomColors>()!.blackAndWhiteColor, fontFamily: 'Inter', fontWeight: FontWeight.bold, fontSize: 18));
         await _progressDialog.show();
         // final bytes = File(croppedFile!.path).readAsBytesSync();
         // String convertedBytes = base64Encode(bytes);

--- a/lib/screens/service_provider/facility/facility_add_page_two.dart
+++ b/lib/screens/service_provider/facility/facility_add_page_two.dart
@@ -31,6 +31,7 @@ import '../../../model/common_passing_args.dart';
 import '../../../model/get_all_activity_and_sub_activity_response.dart';
 import '../../../model/upload_file_response.dart';
 import '../../../viewmodels/end_user_resgistration_view_model.dart';
+import 'package:oqdo_mobile_app/theme/custom_colors.dart';
 
 class FacilityAddPageTwo extends StatefulWidget {
   final CommonPassingArgs commonPassingArgs;
@@ -110,7 +111,10 @@ class _FacilityAddPageTwoState extends State<FacilityAddPageTwo> {
     // comment.add(TextEditingController());
     WidgetsBinding.instance.addPostFrameCallback((_) async {
       _progressDialog = ProgressDialog(context, type: ProgressDialogType.normal, isDismissible: false);
-      _progressDialog.style(message: "Please wait...");
+      _progressDialog.style(
+              message: "Please wait..",
+              backgroundColor: Theme.of(context).extension<CustomColors>()!.progressDialogBackgroundColor,
+              messageTextStyle: TextStyle(color: Theme.of(context).extension<CustomColors>()!.blackAndWhiteColor, fontFamily: 'Inter', fontWeight: FontWeight.bold, fontSize: 18));
       getAllActivity();
       getPrefData();
       _focusNode.addListener(_onFocusChange);

--- a/lib/screens/service_provider/facility/facility_otp_page.dart
+++ b/lib/screens/service_provider/facility/facility_otp_page.dart
@@ -18,6 +18,7 @@ import 'package:provider/provider.dart';
 import '../../../helper/helpers.dart';
 import '../../../model/common_passing_args.dart';
 import '../../../viewmodels/end_user_resgistration_view_model.dart';
+import 'package:oqdo_mobile_app/theme/custom_colors.dart';
 
 class FacilityOTPPage extends StatefulWidget {
   final CommonPassingArgs commonPassingArgs;
@@ -54,7 +55,10 @@ class _FacilityOTPPageState extends State<FacilityOTPPage> {
     hp = Helper.of(context);
     WidgetsBinding.instance.addPostFrameCallback((_) async {
       _progressDialog = ProgressDialog(context, type: ProgressDialogType.normal, isDismissible: false);
-      _progressDialog.style(message: "Please wait..");
+      _progressDialog.style(
+              message: "Please wait..",
+              backgroundColor: Theme.of(context).extension<CustomColors>()!.progressDialogBackgroundColor,
+              messageTextStyle: TextStyle(color: Theme.of(context).extension<CustomColors>()!.blackAndWhiteColor, fontFamily: 'Inter', fontWeight: FontWeight.bold, fontSize: 18));
     });
   }
 

--- a/lib/screens/setup/add_batch_setup_page.dart
+++ b/lib/screens/setup/add_batch_setup_page.dart
@@ -119,7 +119,10 @@ class AddBatchSetupPageState extends State<AddBatchSetupPage> {
     addressType = '';
     WidgetsBinding.instance.addPostFrameCallback((_) async {
       _progressDialog = ProgressDialog(context, type: ProgressDialogType.normal, isDismissible: false);
-      _progressDialog.style(message: "Please wait..");
+      _progressDialog.style(
+              message: "Please wait..",
+              backgroundColor: Theme.of(context).extension<CustomColors>()!.progressDialogBackgroundColor,
+              messageTextStyle: TextStyle(color: Theme.of(context).extension<CustomColors>()!.blackAndWhiteColor, fontFamily: 'Inter', fontWeight: FontWeight.bold, fontSize: 18));
       getAllActivity();
       setSlotInintTime();
       // cityID = OQDOApplication.instance.storage.getStringValue(AppStrings.selectedCountryID);

--- a/lib/screens/setup/add_facility_page.dart
+++ b/lib/screens/setup/add_facility_page.dart
@@ -104,7 +104,10 @@ class AddFacilityPageState extends State<AddFacilityPage> {
     bookingType = "I";
     WidgetsBinding.instance.addPostFrameCallback((_) async {
       _progressDialog = ProgressDialog(context, type: ProgressDialogType.normal, isDismissible: false);
-      _progressDialog.style(message: "Please wait..");
+      _progressDialog.style(
+              message: "Please wait..",
+              backgroundColor: Theme.of(context).extension<CustomColors>()!.progressDialogBackgroundColor,
+              messageTextStyle: TextStyle(color: Theme.of(context).extension<CustomColors>()!.blackAndWhiteColor, fontFamily: 'Inter', fontWeight: FontWeight.bold, fontSize: 18));
       getAllActivity();
       setSlotInintTime();
     });

--- a/lib/screens/setup/add_facility_vacation_page.dart
+++ b/lib/screens/setup/add_facility_vacation_page.dart
@@ -16,6 +16,7 @@ import 'package:oqdo_mobile_app/utils/validator.dart';
 import 'package:oqdo_mobile_app/viewmodels/service_provider_setup_viewmodel.dart';
 import 'package:progress_dialog_null_safe/progress_dialog_null_safe.dart';
 import 'package:provider/provider.dart';
+import 'package:oqdo_mobile_app/theme/custom_colors.dart';
 
 class AddFacilityVacationPage extends StatefulWidget {
   const AddFacilityVacationPage({Key? key}) : super(key: key);
@@ -420,7 +421,10 @@ class _AddFacilityVacationPageState extends State<AddFacilityVacationPage> {
 
   Future<void> getFacilitySetupList() async {
     _progressDialog = ProgressDialog(context, type: ProgressDialogType.normal, isDismissible: false);
-    _progressDialog.style(message: "Please wait..");
+    _progressDialog.style(
+            message: "Please wait..",
+            backgroundColor: Theme.of(context).extension<CustomColors>()!.progressDialogBackgroundColor,
+            messageTextStyle: TextStyle(color: Theme.of(context).extension<CustomColors>()!.blackAndWhiteColor, fontFamily: 'Inter', fontWeight: FontWeight.bold, fontSize: 18));
     try {
       _progressDialog.show();
       FacilityListResponseModel facilityListResponseModel =

--- a/lib/screens/setup/batch_setup_list_page.dart
+++ b/lib/screens/setup/batch_setup_list_page.dart
@@ -248,7 +248,10 @@ class BatchSetupListPageState extends State<BatchSetupListPage> {
 
   void getCoachBatchList() async {
     _progressDialog = ProgressDialog(context, type: ProgressDialogType.normal, isDismissible: false);
-    _progressDialog.style(message: "Please wait..");
+    _progressDialog.style(
+            message: "Please wait..",
+            backgroundColor: Theme.of(context).extension<CustomColors>()!.progressDialogBackgroundColor,
+            messageTextStyle: TextStyle(color: Theme.of(context).extension<CustomColors>()!.blackAndWhiteColor, fontFamily: 'Inter', fontWeight: FontWeight.bold, fontSize: 18));
     if (_progressDialog.isShowing()) {
       await _progressDialog.hide();
     }
@@ -290,7 +293,10 @@ class BatchSetupListPageState extends State<BatchSetupListPage> {
   Future<void> getCoachBatchBySetupId(int batchID) async {
     try {
       _progressDialog = ProgressDialog(context, type: ProgressDialogType.normal, isDismissible: false);
-      _progressDialog.style(message: "Please wait..");
+      _progressDialog.style(
+              message: "Please wait..",
+              backgroundColor: Theme.of(context).extension<CustomColors>()!.progressDialogBackgroundColor,
+              messageTextStyle: TextStyle(color: Theme.of(context).extension<CustomColors>()!.blackAndWhiteColor, fontFamily: 'Inter', fontWeight: FontWeight.bold, fontSize: 18));
       await _progressDialog.show();
       GetCoachBySetupIdModel getCoachBySetupIdModel = await Provider.of<ServiceProviderSetupViewModel>(context, listen: false).getBatchByID(batchID);
       await _progressDialog.hide();
@@ -358,7 +364,10 @@ class BatchSetupListPageState extends State<BatchSetupListPage> {
 
   Future<void> deleteBatchSetup(Datum selectedBatchModel) async {
     _progressDialog = ProgressDialog(context, type: ProgressDialogType.normal, isDismissible: false);
-    _progressDialog.style(message: "Please wait..");
+    _progressDialog.style(
+            message: "Please wait..",
+            backgroundColor: Theme.of(context).extension<CustomColors>()!.progressDialogBackgroundColor,
+            messageTextStyle: TextStyle(color: Theme.of(context).extension<CustomColors>()!.blackAndWhiteColor, fontFamily: 'Inter', fontWeight: FontWeight.bold, fontSize: 18));
     Map deleteSetupMap = {};
     deleteSetupMap['CoachBatchSetupId'] = selectedBatchModel.coachBatchSetupId;
     deleteSetupMap['CoachId'] = OQDOApplication.instance.coachID;
@@ -408,7 +417,10 @@ class BatchSetupListPageState extends State<BatchSetupListPage> {
   Future<void> getCoachBatchDetailsById(int? coachBatchSetupId) async {
     try {
       _progressDialog = ProgressDialog(context, type: ProgressDialogType.normal, isDismissible: false);
-      _progressDialog.style(message: "Please wait..");
+      _progressDialog.style(
+              message: "Please wait..",
+              backgroundColor: Theme.of(context).extension<CustomColors>()!.progressDialogBackgroundColor,
+              messageTextStyle: TextStyle(color: Theme.of(context).extension<CustomColors>()!.blackAndWhiteColor, fontFamily: 'Inter', fontWeight: FontWeight.bold, fontSize: 18));
       await _progressDialog.show();
       CoachDetailsResponseModel coachDetailsResponseModel = await Provider.of<ServiceProviderSetupViewModel>(context, listen: false).getCoachDetailsById(coachBatchSetupId!);
       await _progressDialog.hide();

--- a/lib/screens/setup/coach_vacation_setup_screen.dart
+++ b/lib/screens/setup/coach_vacation_setup_screen.dart
@@ -18,6 +18,7 @@ import 'package:oqdo_mobile_app/utils/validator.dart';
 import 'package:oqdo_mobile_app/viewmodels/service_provider_setup_viewmodel.dart';
 import 'package:progress_dialog_null_safe/progress_dialog_null_safe.dart';
 import 'package:provider/provider.dart';
+import 'package:oqdo_mobile_app/theme/custom_colors.dart';
 
 class CoachVacationScreen extends StatefulWidget {
   const CoachVacationScreen({Key? key}) : super(key: key);
@@ -488,7 +489,10 @@ class _CoachVacationScreenState extends State<CoachVacationScreen> {
 
   Future<void> getCancelReasons() async {
     _progressDialog = ProgressDialog(context, type: ProgressDialogType.normal, isDismissible: false);
-    _progressDialog.style(message: "Please wait..");
+    _progressDialog.style(
+            message: "Please wait..",
+            backgroundColor: Theme.of(context).extension<CustomColors>()!.progressDialogBackgroundColor,
+            messageTextStyle: TextStyle(color: Theme.of(context).extension<CustomColors>()!.blackAndWhiteColor, fontFamily: 'Inter', fontWeight: FontWeight.bold, fontSize: 18));
     try {
       await _progressDialog.show();
       List<CancelReasonListResponseModel> list = await Provider.of<ServiceProviderSetupViewModel>(context, listen: false).getCancelReasonList();
@@ -534,7 +538,10 @@ class _CoachVacationScreenState extends State<CoachVacationScreen> {
   void getCoachBatchList() async {
     try {
       _progressDialog = ProgressDialog(context, type: ProgressDialogType.normal, isDismissible: false);
-      _progressDialog.style(message: "Please wait..");
+      _progressDialog.style(
+              message: "Please wait..",
+              backgroundColor: Theme.of(context).extension<CustomColors>()!.progressDialogBackgroundColor,
+              messageTextStyle: TextStyle(color: Theme.of(context).extension<CustomColors>()!.blackAndWhiteColor, fontFamily: 'Inter', fontWeight: FontWeight.bold, fontSize: 18));
       await _progressDialog.show();
       GetCoachBatchModel facilityListResponseModel =
           await Provider.of<ServiceProviderSetupViewModel>(context, listen: false).getCoachBatchList(OQDOApplication.instance.coachID!);

--- a/lib/screens/setup/coach_vacationlist_screen.dart
+++ b/lib/screens/setup/coach_vacationlist_screen.dart
@@ -239,7 +239,10 @@ class _CoachVacationListScreenState extends State<CoachVacationListScreen> {
 
   Future<void> getFacilityVacationCall() async {
     _progressDialog = ProgressDialog(context, type: ProgressDialogType.normal, isDismissible: false);
-    _progressDialog.style(message: "Please wait..");
+    _progressDialog.style(
+            message: "Please wait..",
+            backgroundColor: Theme.of(context).extension<CustomColors>()!.progressDialogBackgroundColor,
+            messageTextStyle: TextStyle(color: Theme.of(context).extension<CustomColors>()!.blackAndWhiteColor, fontFamily: 'Inter', fontWeight: FontWeight.bold, fontSize: 18));
     try {
       await _progressDialog.show();
       List<CoachVacationResponseModel> response =
@@ -293,7 +296,10 @@ class _CoachVacationListScreenState extends State<CoachVacationListScreen> {
 
   Future<void> deleteVacation(int? vacationId) async {
     _progressDialog = ProgressDialog(context, type: ProgressDialogType.normal, isDismissible: false);
-    _progressDialog.style(message: "Please wait..");
+    _progressDialog.style(
+            message: "Please wait..",
+            backgroundColor: Theme.of(context).extension<CustomColors>()!.progressDialogBackgroundColor,
+            messageTextStyle: TextStyle(color: Theme.of(context).extension<CustomColors>()!.blackAndWhiteColor, fontFamily: 'Inter', fontWeight: FontWeight.bold, fontSize: 18));
     try {
       await _progressDialog.show();
       Map<String, dynamic> request = {};

--- a/lib/screens/setup/edit_batch_setup.dart
+++ b/lib/screens/setup/edit_batch_setup.dart
@@ -117,7 +117,10 @@ class _EditBatchSetupScreenState extends State<EditBatchSetupScreen> {
     addressType = '';
     WidgetsBinding.instance.addPostFrameCallback((_) async {
       _progressDialog = ProgressDialog(context, type: ProgressDialogType.normal, isDismissible: false);
-      _progressDialog.style(message: "Please wait..");
+      _progressDialog.style(
+              message: "Please wait..",
+              backgroundColor: Theme.of(context).extension<CustomColors>()!.progressDialogBackgroundColor,
+              messageTextStyle: TextStyle(color: Theme.of(context).extension<CustomColors>()!.blackAndWhiteColor, fontFamily: 'Inter', fontWeight: FontWeight.bold, fontSize: 18));
       // getAllActivity();
       setBatchData();
       getCoachTrainingCenterAddress();

--- a/lib/screens/setup/edit_facility_setup.dart
+++ b/lib/screens/setup/edit_facility_setup.dart
@@ -114,7 +114,10 @@ class _EditFacilitySetupScreenState extends State<EditFacilitySetupScreen> {
     bookingType = "I";
     WidgetsBinding.instance.addPostFrameCallback((_) async {
       _progressDialog = ProgressDialog(context, type: ProgressDialogType.normal, isDismissible: false);
-      _progressDialog.style(message: "Please wait..");
+      _progressDialog.style(
+              message: "Please wait..",
+              backgroundColor: Theme.of(context).extension<CustomColors>()!.progressDialogBackgroundColor,
+              messageTextStyle: TextStyle(color: Theme.of(context).extension<CustomColors>()!.blackAndWhiteColor, fontFamily: 'Inter', fontWeight: FontWeight.bold, fontSize: 18));
       // getAllActivity();
       setFacilityData();
     });

--- a/lib/screens/setup/facility_setup_page.dart
+++ b/lib/screens/setup/facility_setup_page.dart
@@ -260,7 +260,10 @@ class FacilitySetupPageState extends State<FacilitySetupPage> {
     try {
       if (showLoader) {
         _progressDialog = ProgressDialog(context, type: ProgressDialogType.normal, isDismissible: false);
-        _progressDialog.style(message: "Please wait..");
+        _progressDialog.style(
+                message: "Please wait..",
+                backgroundColor: Theme.of(context).extension<CustomColors>()!.progressDialogBackgroundColor,
+                messageTextStyle: TextStyle(color: Theme.of(context).extension<CustomColors>()!.blackAndWhiteColor, fontFamily: 'Inter', fontWeight: FontWeight.bold, fontSize: 18));
         _progressDialog.show();
       }
       FacilityListResponseModel facilityListResponseModel =
@@ -315,7 +318,10 @@ class FacilitySetupPageState extends State<FacilitySetupPage> {
   Future<void> deleteFacilitySetupCall(Data facilitySetupList) async {
     try {
       _progressDialog = ProgressDialog(context, type: ProgressDialogType.normal, isDismissible: false);
-      _progressDialog.style(message: "Please wait..");
+      _progressDialog.style(
+              message: "Please wait..",
+              backgroundColor: Theme.of(context).extension<CustomColors>()!.progressDialogBackgroundColor,
+              messageTextStyle: TextStyle(color: Theme.of(context).extension<CustomColors>()!.blackAndWhiteColor, fontFamily: 'Inter', fontWeight: FontWeight.bold, fontSize: 18));
       await _progressDialog.show();
       Map deleteFacilitySetupRequestMap = {};
       deleteFacilitySetupRequestMap['FacilitySetupId'] = facilitySetupList.facilitySetupId!.toString();
@@ -362,7 +368,10 @@ class FacilitySetupPageState extends State<FacilitySetupPage> {
   Future<void> callGetSetupById(int? facilitySetupId) async {
     try {
       _progressDialog = ProgressDialog(context, type: ProgressDialogType.normal, isDismissible: false);
-      _progressDialog.style(message: "Please wait..");
+      _progressDialog.style(
+              message: "Please wait..",
+              backgroundColor: Theme.of(context).extension<CustomColors>()!.progressDialogBackgroundColor,
+              messageTextStyle: TextStyle(color: Theme.of(context).extension<CustomColors>()!.blackAndWhiteColor, fontFamily: 'Inter', fontWeight: FontWeight.bold, fontSize: 18));
       await _progressDialog.show();
       GetFacilityByIdModel getFacilityByIdModel = await Provider.of<ServiceProviderSetupViewModel>(context, listen: false).getFacilityById(facilitySetupId!);
       await _progressDialog.hide();
@@ -406,7 +415,10 @@ class FacilitySetupPageState extends State<FacilitySetupPage> {
   Future<void> getFacilityDetailsById(int? facilityId) async {
     try {
       _progressDialog = ProgressDialog(context, type: ProgressDialogType.normal, isDismissible: false);
-      _progressDialog.style(message: "Please wait..");
+      _progressDialog.style(
+              message: "Please wait..",
+              backgroundColor: Theme.of(context).extension<CustomColors>()!.progressDialogBackgroundColor,
+              messageTextStyle: TextStyle(color: Theme.of(context).extension<CustomColors>()!.blackAndWhiteColor, fontFamily: 'Inter', fontWeight: FontWeight.bold, fontSize: 18));
       await _progressDialog.show();
       GetFacilityByIdModel getFacilityByIdModel = await Provider.of<ServiceProviderSetupViewModel>(context, listen: false).getFacilityById(facilityId!);
       await _progressDialog.hide();

--- a/lib/screens/setup/facility_vacation_setup_screen.dart
+++ b/lib/screens/setup/facility_vacation_setup_screen.dart
@@ -19,6 +19,7 @@ import 'package:oqdo_mobile_app/utils/validator.dart';
 import 'package:oqdo_mobile_app/viewmodels/service_provider_setup_viewmodel.dart';
 import 'package:progress_dialog_null_safe/progress_dialog_null_safe.dart';
 import 'package:provider/provider.dart';
+import 'package:oqdo_mobile_app/theme/custom_colors.dart';
 
 class AddFacilityVacationScreen extends StatefulWidget {
   const AddFacilityVacationScreen({Key? key}) : super(key: key);
@@ -440,7 +441,10 @@ class _AddFacilityVacationScreenState extends State<AddFacilityVacationScreen> {
 
   Future<void> getFacilitySetupList() async {
     _progressDialog = ProgressDialog(context, type: ProgressDialogType.normal, isDismissible: false);
-    _progressDialog.style(message: "Please wait..");
+    _progressDialog.style(
+            message: "Please wait..",
+            backgroundColor: Theme.of(context).extension<CustomColors>()!.progressDialogBackgroundColor,
+            messageTextStyle: TextStyle(color: Theme.of(context).extension<CustomColors>()!.blackAndWhiteColor, fontFamily: 'Inter', fontWeight: FontWeight.bold, fontSize: 18));
     try {
       await _progressDialog.show();
       FacilityListResponseModel facilityListResponseModel =
@@ -484,7 +488,10 @@ class _AddFacilityVacationScreenState extends State<AddFacilityVacationScreen> {
 
   Future<void> getCancelReasons() async {
     _progressDialog = ProgressDialog(context, type: ProgressDialogType.normal, isDismissible: false);
-    _progressDialog.style(message: "Please wait..");
+    _progressDialog.style(
+            message: "Please wait..",
+            backgroundColor: Theme.of(context).extension<CustomColors>()!.progressDialogBackgroundColor,
+            messageTextStyle: TextStyle(color: Theme.of(context).extension<CustomColors>()!.blackAndWhiteColor, fontFamily: 'Inter', fontWeight: FontWeight.bold, fontSize: 18));
     try {
       await _progressDialog.show();
       List<CancelReasonListResponseModel> list = await Provider.of<ServiceProviderSetupViewModel>(context, listen: false).getCancelReasonList();
@@ -602,7 +609,10 @@ class _AddFacilityVacationScreenState extends State<AddFacilityVacationScreen> {
 
   Future<void> callVacationApiCall() async {
     _progressDialog = ProgressDialog(context, type: ProgressDialogType.normal, isDismissible: false);
-    _progressDialog.style(message: "Please wait..");
+    _progressDialog.style(
+            message: "Please wait..",
+            backgroundColor: Theme.of(context).extension<CustomColors>()!.progressDialogBackgroundColor,
+            messageTextStyle: TextStyle(color: Theme.of(context).extension<CustomColors>()!.blackAndWhiteColor, fontFamily: 'Inter', fontWeight: FontWeight.bold, fontSize: 18));
     try {
       await _progressDialog.show();
       Map<String, dynamic> request = {};

--- a/lib/screens/setup/vacationlist_screen.dart
+++ b/lib/screens/setup/vacationlist_screen.dart
@@ -236,7 +236,10 @@ class _VacationListScreenState extends State<VacationListScreen> {
 
   Future<void> getFacilityVacationCall() async {
     _progressDialog = ProgressDialog(context, type: ProgressDialogType.normal, isDismissible: false);
-    _progressDialog.style(message: "Please wait..");
+    _progressDialog.style(
+            message: "Please wait..",
+            backgroundColor: Theme.of(context).extension<CustomColors>()!.progressDialogBackgroundColor,
+            messageTextStyle: TextStyle(color: Theme.of(context).extension<CustomColors>()!.blackAndWhiteColor, fontFamily: 'Inter', fontWeight: FontWeight.bold, fontSize: 18));
     try {
       await _progressDialog.show();
       List<FacilityVacationResponseModel> response =
@@ -294,7 +297,10 @@ class _VacationListScreenState extends State<VacationListScreen> {
 
   Future<void> deleteVacation(int? vacationId) async {
     _progressDialog = ProgressDialog(context, type: ProgressDialogType.normal, isDismissible: false);
-    _progressDialog.style(message: "Please wait..");
+    _progressDialog.style(
+            message: "Please wait..",
+            backgroundColor: Theme.of(context).extension<CustomColors>()!.progressDialogBackgroundColor,
+            messageTextStyle: TextStyle(color: Theme.of(context).extension<CustomColors>()!.blackAndWhiteColor, fontFamily: 'Inter', fontWeight: FontWeight.bold, fontSize: 18));
     try {
       await _progressDialog.show();
       Map<String, dynamic> request = {};

--- a/lib/screens/slot_management/cancel_slot_reson_screen.dart
+++ b/lib/screens/slot_management/cancel_slot_reson_screen.dart
@@ -154,7 +154,10 @@ class _CancelReasonScreenState extends State<CancelReasonScreen> {
 
   Future<void> getCancelReasons() async {
     _progressDialog = ProgressDialog(context, type: ProgressDialogType.normal, isDismissible: false);
-    _progressDialog.style(message: "Please wait..");
+    _progressDialog.style(
+            message: "Please wait..",
+            backgroundColor: Theme.of(context).extension<CustomColors>()!.progressDialogBackgroundColor,
+            messageTextStyle: TextStyle(color: Theme.of(context).extension<CustomColors>()!.blackAndWhiteColor, fontFamily: 'Inter', fontWeight: FontWeight.bold, fontSize: 18));
     try {
       await _progressDialog.show();
       List<CancelReasonListResponseModel> list = await Provider.of<AppointmentViewModel>(context, listen: false).getCancelReasonList();
@@ -198,7 +201,10 @@ class _CancelReasonScreenState extends State<CancelReasonScreen> {
 
   Future<void> callFacilityCancelSlot() async {
     _progressDialog = ProgressDialog(context, type: ProgressDialogType.normal, isDismissible: false);
-    _progressDialog.style(message: "Please wait..");
+    _progressDialog.style(
+            message: "Please wait..",
+            backgroundColor: Theme.of(context).extension<CustomColors>()!.progressDialogBackgroundColor,
+            messageTextStyle: TextStyle(color: Theme.of(context).extension<CustomColors>()!.blackAndWhiteColor, fontFamily: 'Inter', fontWeight: FontWeight.bold, fontSize: 18));
     try {
       await _progressDialog.show();
 
@@ -257,7 +263,10 @@ class _CancelReasonScreenState extends State<CancelReasonScreen> {
 
   Future<void> callCoachCancelSlot() async {
     _progressDialog = ProgressDialog(context, type: ProgressDialogType.normal, isDismissible: false);
-    _progressDialog.style(message: "Please wait..");
+    _progressDialog.style(
+            message: "Please wait..",
+            backgroundColor: Theme.of(context).extension<CustomColors>()!.progressDialogBackgroundColor,
+            messageTextStyle: TextStyle(color: Theme.of(context).extension<CustomColors>()!.blackAndWhiteColor, fontFamily: 'Inter', fontWeight: FontWeight.bold, fontSize: 18));
     try {
       await _progressDialog.show();
       Map<String, dynamic> request = {};

--- a/lib/screens/slot_management/coach_cancel_slot_management_screen.dart
+++ b/lib/screens/slot_management/coach_cancel_slot_management_screen.dart
@@ -646,7 +646,10 @@ class _CoachCancelSlotScreenState extends State<CoachCancelSlotScreen> {
 
   Future<void> get21DaysFacilitySlots(int? facilitySetupId, String convertDateTimeToString, String passingLastDate) async {
     _progressDialog = ProgressDialog(context, type: ProgressDialogType.normal, isDismissible: false);
-    _progressDialog.style(message: "Please wait..");
+    _progressDialog.style(
+            message: "Please wait..",
+            backgroundColor: Theme.of(context).extension<CustomColors>()!.progressDialogBackgroundColor,
+            messageTextStyle: TextStyle(color: Theme.of(context).extension<CustomColors>()!.blackAndWhiteColor, fontFamily: 'Inter', fontWeight: FontWeight.bold, fontSize: 18));
     try {
       _progressDialog.show();
       if (!mounted) return;

--- a/lib/screens/slot_management/coach_slot_selection_screen.dart
+++ b/lib/screens/slot_management/coach_slot_selection_screen.dart
@@ -801,7 +801,10 @@ class _CoachSlotSelectionScreenState extends State<CoachSlotSelectionScreen> {
 
   Future<void> get21DaysFacilitySlots(int? facilitySetupId, String convertDateTimeToString, String passingLastDate) async {
     _progressDialog = ProgressDialog(context, type: ProgressDialogType.normal, isDismissible: false);
-    _progressDialog.style(message: "Please wait..");
+    _progressDialog.style(
+            message: "Please wait..",
+            backgroundColor: Theme.of(context).extension<CustomColors>()!.progressDialogBackgroundColor,
+            messageTextStyle: TextStyle(color: Theme.of(context).extension<CustomColors>()!.blackAndWhiteColor, fontFamily: 'Inter', fontWeight: FontWeight.bold, fontSize: 18));
     try {
       await _progressDialog.show();
       List<CoachGet21DaysSlotResponseModel> list = await Provider.of<SlotManagementViewModel>(context, listen: false)

--- a/lib/screens/slot_management/facility_cancel_slot_management_screen.dart
+++ b/lib/screens/slot_management/facility_cancel_slot_management_screen.dart
@@ -595,7 +595,10 @@ class _FacilityCancelSlotManagementScreenState extends State<FacilityCancelSlotM
 
   Future<void> get21DaysFacilitySlots(int? facilitySetupId, String convertDateTimeToString, String passingLastDate) async {
     _progressDialog = ProgressDialog(context, type: ProgressDialogType.normal, isDismissible: false);
-    _progressDialog.style(message: "Please wait..");
+    _progressDialog.style(
+            message: "Please wait..",
+            backgroundColor: Theme.of(context).extension<CustomColors>()!.progressDialogBackgroundColor,
+            messageTextStyle: TextStyle(color: Theme.of(context).extension<CustomColors>()!.blackAndWhiteColor, fontFamily: 'Inter', fontWeight: FontWeight.bold, fontSize: 18));
     try {
       await _progressDialog.show();
       List<Get21DaysSlotResponseModel> list =

--- a/lib/screens/slot_management/review_coach_booking_screen.dart
+++ b/lib/screens/slot_management/review_coach_booking_screen.dart
@@ -574,7 +574,10 @@ class _ReviewCoachBookingScreenState extends State<ReviewCoachBookingScreen> {
 
   Future<void> coachAppointmentBooking() async {
     _progressDialog = ProgressDialog(context, type: ProgressDialogType.normal, isDismissible: false);
-    _progressDialog.style(message: "Please wait...");
+    _progressDialog.style(
+            message: "Please wait..",
+            backgroundColor: Theme.of(context).extension<CustomColors>()!.progressDialogBackgroundColor,
+            messageTextStyle: TextStyle(color: Theme.of(context).extension<CustomColors>()!.blackAndWhiteColor, fontFamily: 'Inter', fontWeight: FontWeight.bold, fontSize: 18));
     try {
       await _progressDialog.show();
       Map<String, dynamic> request = {};
@@ -747,7 +750,10 @@ class _ReviewCoachBookingScreenState extends State<ReviewCoachBookingScreen> {
 
   Future<void> validateFacilityPaymentActivity(String paymentID, int coachBookingId) async {
     _progressDialog = ProgressDialog(context, type: ProgressDialogType.normal, isDismissible: false);
-    _progressDialog.style(message: "Please wait...");
+    _progressDialog.style(
+            message: "Please wait..",
+            backgroundColor: Theme.of(context).extension<CustomColors>()!.progressDialogBackgroundColor,
+            messageTextStyle: TextStyle(color: Theme.of(context).extension<CustomColors>()!.blackAndWhiteColor, fontFamily: 'Inter', fontWeight: FontWeight.bold, fontSize: 18));
     try {
       await _progressDialog.show();
       Map<String, dynamic> request = {};
@@ -790,7 +796,10 @@ class _ReviewCoachBookingScreenState extends State<ReviewCoachBookingScreen> {
 
   Future<void> successBooking(String paymentId, int coachBookingId) async {
     _progressDialog = ProgressDialog(context, type: ProgressDialogType.normal, isDismissible: false);
-    _progressDialog.style(message: "Please wait...");
+    _progressDialog.style(
+            message: "Please wait..",
+            backgroundColor: Theme.of(context).extension<CustomColors>()!.progressDialogBackgroundColor,
+            messageTextStyle: TextStyle(color: Theme.of(context).extension<CustomColors>()!.blackAndWhiteColor, fontFamily: 'Inter', fontWeight: FontWeight.bold, fontSize: 18));
     try {
       await _progressDialog.show();
       Map<String, dynamic> request = {};
@@ -879,7 +888,10 @@ class _ReviewCoachBookingScreenState extends State<ReviewCoachBookingScreen> {
 
   Future<void> failedBooking(String paymentId, int coachBookingId) async {
     _progressDialog = ProgressDialog(context, type: ProgressDialogType.normal, isDismissible: false);
-    _progressDialog.style(message: "Please wait...");
+    _progressDialog.style(
+            message: "Please wait..",
+            backgroundColor: Theme.of(context).extension<CustomColors>()!.progressDialogBackgroundColor,
+            messageTextStyle: TextStyle(color: Theme.of(context).extension<CustomColors>()!.blackAndWhiteColor, fontFamily: 'Inter', fontWeight: FontWeight.bold, fontSize: 18));
     try {
       await _progressDialog.show();
       Map<String, dynamic> request = {};

--- a/lib/screens/slot_management/slot_selection_screen.dart
+++ b/lib/screens/slot_management/slot_selection_screen.dart
@@ -768,7 +768,10 @@ class _SlotSelectionScreenState extends State<SlotSelectionScreen> {
 
   Future<void> get21DaysFacilitySlots(int? facilitySetupId, String convertDateTimeToString, String passingLastDate) async {
     _progressDialog = ProgressDialog(context, type: ProgressDialogType.normal, isDismissible: false);
-    _progressDialog.style(message: "Please wait..");
+    _progressDialog.style(
+            message: "Please wait..",
+            backgroundColor: Theme.of(context).extension<CustomColors>()!.progressDialogBackgroundColor,
+            messageTextStyle: TextStyle(color: Theme.of(context).extension<CustomColors>()!.blackAndWhiteColor, fontFamily: 'Inter', fontWeight: FontWeight.bold, fontSize: 18));
     try {
       await _progressDialog.show();
       List<Get21DaysSlotResponseModel> list =
@@ -881,7 +884,10 @@ class _SlotSelectionScreenState extends State<SlotSelectionScreen> {
 
   Future<void> freezeFacilityBookingCall(SlotListModel slotList) async {
     _progressDialog = ProgressDialog(context, type: ProgressDialogType.normal, isDismissible: false);
-    _progressDialog.style(message: "Please wait..");
+    _progressDialog.style(
+            message: "Please wait..",
+            backgroundColor: Theme.of(context).extension<CustomColors>()!.progressDialogBackgroundColor,
+            messageTextStyle: TextStyle(color: Theme.of(context).extension<CustomColors>()!.blackAndWhiteColor, fontFamily: 'Inter', fontWeight: FontWeight.bold, fontSize: 18));
     Map<String, dynamic> request = {};
     request['EndUserId'] = OQDOApplication.instance.endUserID.toString();
     request['FacilitySetupDetailId'] = _calendarViewModel.getFacilityByIdModel!.facilitySetupDetailId.toString();
@@ -1256,7 +1262,10 @@ class _SlotSelectionScreenState extends State<SlotSelectionScreen> {
   /// and returns a Future that completes when all slots have been unfrozen.
   Future<void> unFreezeAllSelectedSlot() async {
     _progressDialog = ProgressDialog(context, type: ProgressDialogType.normal, isDismissible: false);
-    _progressDialog.style(message: "Please wait..");
+    _progressDialog.style(
+            message: "Please wait..",
+            backgroundColor: Theme.of(context).extension<CustomColors>()!.progressDialogBackgroundColor,
+            messageTextStyle: TextStyle(color: Theme.of(context).extension<CustomColors>()!.blackAndWhiteColor, fontFamily: 'Inter', fontWeight: FontWeight.bold, fontSize: 18));
     try {
       if (unFreezeCountList.isNotEmpty) {
         await _progressDialog.show();


### PR DESCRIPTION
## Summary
- replace all `_progressDialog.style` calls with a theme-aware configuration across the lib directory
- import the `CustomColors` theme extension wherever the progress dialog styling is applied so the new colors resolve

## Testing
- not run (flutter tooling is not available in the container)


------
https://chatgpt.com/codex/tasks/task_e_68d383c5c8148332b3291a315773f6c4